### PR TITLE
Change Bundle-Version to 2.1.0.qualifier

### DIFF
--- a/plugins/eclipse/ui/META-INF/MANIFEST.MF
+++ b/plugins/eclipse/ui/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.junit,
  org.eclipse.jdt.junit.runtime,
  org.eclipse.jdt.junit4.runtime
-Bundle-Version: 2.0.0.201605071457
+Bundle-Version: 2.1.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Activator: org.robovm.eclipse.RoboVMPlugin
 Bundle-SymbolicName: org.robovm.eclipse.ui;singleton:=true


### PR DESCRIPTION
Otherwise I wasn't able to compile the eclipse plugins, see: http://stackoverflow.com/questions/21256478/what-is-an-osgi-version-qualifier

Sorry if this is the wrong way to do it, I'm not a OSGI/Maven expert - so feel free to ignore those pulls.