### PR TITLE
Update the new iOS 10 UIKit classes.

### DIFF
--- a/compiler/cocoatouch/src/main/bro-gen/coreanimation.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/coreanimation.yaml
@@ -1,5 +1,5 @@
 package: org.robovm.apple.coreanimation
-include: [foundation.yaml, coregraphics.yaml, coreimage.yaml, coretext.yaml, opengles.yaml, metal.yaml]
+include: [foundation, coregraphics, coreimage, coretext, opengles, metal]
 library: QuartzCore
 framework: QuartzCore
 clang_args: ['-x', 'objective-c']
@@ -346,6 +346,8 @@ protocols:
                 trim_after_first_colon: true
             '-drawLayer:inContext:':
                 trim_after_first_colon: true
+            '-layerWillDraw:':
+                name: willDrawLayer
             '-layoutSublayersOfLayer:':
                 name: layoutSublayers
             '-actionForLayer:forKey:':

--- a/compiler/cocoatouch/src/main/bro-gen/foundation.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/foundation.yaml
@@ -519,7 +519,8 @@ classes:
             'calendarIdentifier':
                 type: NSCalendarIdentifier
             '.*Symbols':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
         methods:
             '+currentCalendar':
                 property: true
@@ -585,7 +586,8 @@ classes:
     NSCoder: # DONE
         properties:
             'allowedClasses':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<ObjCClass>'
+                type: List<ObjCClass>
+                marshaler: NSArray.AsListMarshaler
         methods:
             '-decodeArrayOfObjCType:count:at:': {exclude: true}
             '-decodeValueOfObjCType:at:': {exclude: true}
@@ -616,7 +618,8 @@ classes:
                 visibility: protected # reordering parameters
                 parameters:
                     classes:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<ObjCClass>'
+                        type: List<ObjCClass>
+                        marshaler: NSArray.AsListMarshaler
             '-decodeTopLevelObject.*rror:':
                 name: decodeTopLevelObject
                 throws: NSErrorException
@@ -866,7 +869,8 @@ classes:
     NSDateFormatter: # DONE
         properties:
             '.*Symbols':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
         methods:
             '-getObjectValue:forString:range:error:': {exclude: true}
             '+defaultFormatterBehavior':
@@ -1202,22 +1206,26 @@ classes:
                 name: readInBackgroundAndNotify
                 parameters:
                     modes:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                        type: List<String>
+                        marshaler: NSArray.AsStringListMarshaler
             '-readToEndOfFileInBackgroundAndNotifyForModes:':
                 name: readToEndOfFileInBackgroundAndNotify
                 parameters:
                     modes:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                        type: List<String>
+                        marshaler: NSArray.AsStringListMarshaler
             '-acceptConnectionInBackgroundAndNotifyForModes:':
                 name: acceptConnectionInBackgroundAndNotify
                 parameters:
                     modes:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                        type: List<String>
+                        marshaler: NSArray.AsStringListMarshaler
             '-waitForDataInBackgroundAndNotifyForModes:':
                 name: waitForDataInBackgroundAndNotify
                 parameters:
                     modes:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                        type: List<String>
+                        marshaler: NSArray.AsStringListMarshaler
     NSFileManager: # DONE
         properties:
             'delegate':
@@ -1231,14 +1239,16 @@ classes:
                 visibility: protected
                 parameters:
                     propertyKeys:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSURLFileSystemProperty.AsListMarshaler.class) List<NSURLFileSystemProperty>'
+                        type: List<NSURLFileSystemProperty>
+                        marshaler: NSURLFileSystemProperty.AsListMarshaler
             '-contentsOfDirectoryAtURL:includingPropertiesForKeys:options:error:':
                 name: getContentsOfDirectoryAtURL
                 return_type: NSArray<NSURL>
                 throws: NSErrorException
                 parameters:
                     keys:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSURLFileSystemProperty.AsListMarshaler.class) List<NSURLFileSystemProperty>'
+                        type: List<NSURLFileSystemProperty>
+                        marshaler: NSURLFileSystemProperty.AsListMarshaler
             '-URLsForDirectory:inDomains:':
                 name: getURLsForDirectory
                 return_type: NSArray<NSURL>
@@ -1272,7 +1282,8 @@ classes:
                 throws: NSErrorException
             '-subpathsOfDirectoryAtPath:error:':
                 name: getSubpathsOfDirectoryAtPath
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                return_type: List<String>
+                return_marshaler: NSArray.AsStringListMarshaler
                 throws: NSErrorException
             '-attributesOfItemAtPath:error:':
                 name: getAttributesOfItemAtPath
@@ -1347,7 +1358,8 @@ classes:
                 name: getDisplayNameAtPath
             '-componentsToDisplayForPath:':
                 name: getComponentsToDisplayForPath
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                return_type: List<String>
+                return_marshaler: NSArray.AsStringListMarshaler
             '-enumeratorAtPath:':
                 name: getEnumeratorAtPath
             '-enumeratorAtURL:includingPropertiesForKeys:options:errorHandler:':
@@ -1356,10 +1368,12 @@ classes:
                 return_type: NSDirectoryEnumerator # no generics atm
                 parameters:
                     keys:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSURLFileSystemProperty.AsListMarshaler.class) List<NSURLFileSystemProperty>'
+                        type: List<NSURLFileSystemProperty>
+                        marshaler: NSURLFileSystemProperty.AsListMarshaler
             '-subpathsAtPath:':
                 name: getSubpathsAtPath
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                return_type: List<String>
+                return_marshaler: NSArray.AsStringListMarshaler
             '-contentsAtPath:':
                 name: getContentsAtPath
             '-createFileAtPath:contents:attributes:':
@@ -1369,7 +1383,8 @@ classes:
                         type: NSFileAttributes
             '-fileSystemRepresentationWithPath:':
                 name: getFileSystemRepresentationForPath
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(StringMarshalers.AsDefaultCharsetZMarshaler.class) String'
+                return_type: String
+                return_marshaler: StringMarshalers.AsDefaultCharsetZMarshaler
             '-stringWithFileSystemRepresentation:length:':
                 name: getPathForFileSystemRepresentation
             '-replaceItemAtURL:withItemAtURL:backupItemName:options:resultingItemURL:error:':
@@ -1434,7 +1449,8 @@ classes:
             'fileAttributes':
                 type: NSFileAttributes
             'fileWrappers':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringMapMarshaler.class) Map<String, NSFileWrapper>'
+                type: 'Map<String, NSFileWrapper>'
+                marshaler: NSDictionary.AsStringMapMarshaler
         methods:
             '-initWithURL:options:error:':
                 name: init
@@ -1443,7 +1459,8 @@ classes:
                 name: init
                 parameters:
                     childrenByPreferredName:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringMapMarshaler.class) Map<String, NSFileWrapper>'
+                        type: 'Map<String, NSFileWrapper>'
+                        marshaler: NSDictionary.AsStringMapMarshaler
             '-initWithSerializedRepresentation:':
                 name: initSerialized
                 constructor: false
@@ -1554,7 +1571,8 @@ classes:
             'properties':
                 type: NSHTTPCookieAttributes
             'portList':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsIntegerListMarshaler.class) List<Integer>'
+                type: List<Integer>
+                marshaler: NSArray.AsIntegerListMarshaler
         methods:
             '-initWithProperties:':
                 name: init
@@ -1565,7 +1583,8 @@ classes:
                 exclude: true
             '+requestHeaderFieldsWithCookies:':
                 name: getRequestHeaderFieldsWithCookies
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringStringMapMarshaler.class) Map<String, String>'
+                return_type: 'Map<String, String>'
+                return_marshaler: NSDictionary.AsStringStringMapMarshaler
                 parameters:
                     cookies:
                         type: NSArray<NSHTTPCookie>
@@ -1574,7 +1593,8 @@ classes:
                 return_type: NSArray<NSHTTPCookie>
                 parameters:
                     headerFields:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringStringMapMarshaler.class) Map<String, String>'
+                        type: 'Map<String, String>'
+                        marshaler: NSDictionary.AsStringStringMapMarshaler
                     URL:
                         name: url
     NSHTTPCookieStorage: # DONE
@@ -1617,13 +1637,15 @@ classes:
     NSHTTPURLResponse: # DONE
         properties:
             'allHeaderFields':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringStringMapMarshaler.class) Map<String, String>'
+                type: 'Map<String, String>'
+                marshaler: NSDictionary.AsStringStringMapMarshaler
         methods:
             '-initWithURL:statusCode:HTTPVersion:headerFields:':
                 name: init
                 parameters:
                     headerFields:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringStringMapMarshaler.class) Map<String, String>'
+                        type: 'Map<String, String>'
+                        marshaler: NSDictionary.AsStringStringMapMarshaler
             '+localizedStringForStatusCode:':
                 name: getLocalizedStatusCode
     NSIndexPath: # DONE
@@ -1774,7 +1796,8 @@ classes:
     NSItemProvider: # DONE
         properties:
             'registeredTypeIdentifiers':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
             'previewImageHandler':
                 type: '@Block("(@Block,,)") VoidBlock3<VoidBlock2<NSObject, NSError>, ObjCClass, NSDictionary<?, ?>>' # todo dictionary marshaling
         methods:
@@ -1895,13 +1918,15 @@ classes:
     NSLinguisticTagger: # DONE
         properties:
             'tagSchemes':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<NSLinguisticTagScheme>'
+                type: List<NSLinguisticTagScheme>
+                marshaler: NSArray.AsListMarshaler
         methods:
             '-initWithTagSchemes:options:':
                 name: init
                 parameters:
                     tagSchemes:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<NSLinguisticTagScheme>'
+                        type: List<NSLinguisticTagScheme>
+                        marshaler: NSArray.AsListMarshaler
                     opts:
                         type: NSLinguisticTaggerOptions
             '-setOrthography:range:':
@@ -1928,20 +1953,23 @@ classes:
             '-tagsInRange:scheme:options:tokenRanges:':
                 name: getTags
                 visibility: protected
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<NSLinguisticTag>'
+                return_type: List<NSLinguisticTag>
+                return_marshaler: NSArray.AsListMarshaler
                 parameters:
                     tagScheme:
                         type: NSLinguisticTagScheme
             '-possibleTagsAtIndex:scheme:tokenRange:sentenceRange:scores:':
                 name: getPossibleTags
                 visibility: protected
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<NSLinguisticTag>'
+                return_type: List<NSLinguisticTag>
+                return_marshaler: NSArray.AsListMarshaler
                 parameters:
                     tagScheme:
                         type: NSLinguisticTagScheme
             '+availableTagSchemesForLanguage:':
                 name: getAvailableTagSchemes
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<NSLinguisticTagScheme>'
+                return_type: List<NSLinguisticTagScheme>
+                return_marshaler: NSArray.AsListMarshaler
     NSLocale: # DONE
         skip_def_constructor: true
         properties:
@@ -2085,7 +2113,8 @@ classes:
     NSMetadataItem: # DONE
         properties:
             'attributes':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSMetadataItemAttribute.AsListMarshaler.class) List<NSMetadataItemAttribute>'
+                type: List<NSMetadataItemAttribute>
+                marshaler: NSMetadataItemAttribute.AsListMarshaler
         methods:
             '-valueForAttribute:':
                 name: getValue
@@ -2097,13 +2126,15 @@ classes:
                 return_type: NSMetadataItemAttributes
                 parameters:
                     keys:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSMetadataItemAttribute.AsListMarshaler.class) List<NSMetadataItemAttribute>'
+                        type: List<NSMetadataItemAttribute>
+                        marshaler: NSMetadataItemAttribute.AsListMarshaler
     NSMetadataQuery: # DONE
         properties:
             'sortDescriptors':
                 type: NSArray<NSSortDescriptor>
             '(valueListAttributes|groupingAttributes)':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSMetadataItemAttribute.AsListMarshaler.class) List<NSMetadataItemAttribute>'
+                type: List<NSMetadataItemAttribute>
+                marshaler: NSMetadataItemAttribute.AsListMarshaler
             'searchScopes':
                 name: searchScopes0
                 visibility: protected
@@ -2157,17 +2188,20 @@ classes:
     NSMethodSignature: # DONE
         properties:
             'methodReturnType':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(StringMarshalers.AsDefaultCharsetZMarshaler.class) String'
+                type: String
+                marshaler: StringMarshalers.AsDefaultCharsetZMarshaler
         methods:
             '-getArgumentTypeAtIndex:':
                 name: getArgumentType
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(StringMarshalers.AsDefaultCharsetZMarshaler.class) String'
+                return_type: String
+                return_marshaler: StringMarshalers.AsDefaultCharsetZMarshaler
             '+signatureWithObjCTypes:':
                 name: create
                 constructor: true
                 parameters:
                     types:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(StringMarshalers.AsDefaultCharsetZMarshaler.class) String'
+                        type: String
+                        marshaler: StringMarshalers.AsDefaultCharsetZMarshaler
     NSMutableArray: # DONE
         methods:
             '-initWithCapacity:':
@@ -2372,7 +2406,8 @@ classes:
             'HTTPShouldUsePipelining':
                 name: shouldUseHTTPPipelining
             'allHTTPHeaderFields':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringStringMapMarshaler.class) Map<String, String>'
+                type: 'Map<String, String>'
+                marshaler: NSDictionary.AsStringStringMapMarshaler
         methods:
             '-setValue:forHTTPHeaderField:':
                 name: setHTTPHeaderField0 # We change the order of arguments as in Java it's natural to specify the key as the first and the value as the second parameter.
@@ -2499,7 +2534,8 @@ classes:
                     coalesceMask:
                         type: NSNotificationCoalescing
                     modes:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                        type: List<String>
+                        marshaler: NSArray.AsStringListMarshaler
     NSNull: # DONE
         skip_def_constructor: true
         methods:
@@ -2742,22 +2778,27 @@ classes:
     NSOrthography: # DONE
         properties:
             'languageMap':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSOrthography.LanguageMapMarshaler.class) Map<String, List<String>>'
+                type: 'Map<String, List<String>>'
+                marshaler: NSOrthography.LanguageMapMarshaler
             'allScripts':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
             'allLanguages':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
         methods:
             '-languagesForScript:':
                 name: getLanguagesForScript
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                return_type: List<String>
+                return_marshaler: NSArray.AsStringListMarshaler
             '-dominantLanguageForScript:':
                 name: getDominantLanguageForScript
             '-initWithDominantScript:languageMap:':
                 name: init
                 parameters:
                     map:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSOrthography.LanguageMapMarshaler.class) Map<String, List<String>>'
+                        type: 'Map<String, List<String>>'
+                        marshaler: NSOrthography.LanguageMapMarshaler
             '-init.*':
                 name: init
             '+orthographyWithDominantScript:languageMap:':
@@ -2847,9 +2888,11 @@ classes:
         skip_def_constructor: true
         properties:
             'environment':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringMapMarshaler.class) Map<String, NSObject>'
+                type: 'Map<String, NSObject>'
+                marshaler: NSDictionary.AsStringMapMarshaler
             'arguments':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
             'processInfo':
                 name: sharedProcessInfo
         methods:
@@ -2874,10 +2917,6 @@ classes:
                 type: NSProgressKind
             'userInfo':
                 type: NSProgressUserInfo
-            'cancellable':
-                getter: isCancellable
-            'cancelled':
-                name: isCancelled
         methods:
             '-initWithParent:userInfo:':
                 name: init
@@ -3193,11 +3232,13 @@ classes:
     NSTextCheckingResult: # DONE
         properties:
             'grammarDetails':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
             'components':
                 type: NSTextCheckingTransitComponents
             'alternativeStrings':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
             'addressComponents':
                 type: NSTextCheckingAddressComponents
         methods:
@@ -3213,7 +3254,8 @@ classes:
                 name: getGrammarCheckingResult
                 parameters:
                     details:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                        type: List<String>
+                        marshaler: NSArray.AsStringListMarshaler
             '+dateCheckingResultWithRange:date:':
                 name: getDateCheckingResult
             '+dateCheckingResultWithRange:date:timeZone:duration:':
@@ -3237,7 +3279,8 @@ classes:
                 name: getCorrectionCheckingResult
                 parameters:
                     alternativeStrings:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                        type: List<String>
+                        marshaler: NSArray.AsStringListMarshaler
             '+regularExpressionCheckingResultWithRanges:count:regularExpression:':
                 name: getRegularExpressionCheckingResult
                 visibility: protected
@@ -3431,7 +3474,8 @@ classes:
     NSUndoManager: # DONE
         properties:
             'runLoopModes':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
             'undoActionIsDiscardable':
                 name: undoActionDiscardable
             'redoActionIsDiscardable':
@@ -3536,7 +3580,8 @@ classes:
                 return_type: NSURLProperties
                 parameters:
                     keys:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSURLProperty.AsListMarshaler.class) List<NSURLProperty>'
+                        type: List<NSURLProperty>
+                        marshaler: NSURLProperty.AsListMarshaler
             '-setResourceValue:forKey:error:':
                 trim_after_first_colon: true
                 throws: NSErrorException
@@ -3574,7 +3619,8 @@ classes:
                 throws: NSErrorException
                 parameters:
                     keys:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSURLProperty.AsListMarshaler.class) List<NSURLProperty>'
+                        type: List<NSURLProperty>
+                        marshaler: NSURLProperty.AsListMarshaler
             '+fileURL.*': {exclude: true}
             '+URL.*': {exclude: true}
             '+absoluteURLWithDataRepresentation:relativeToURL:':
@@ -3596,7 +3642,8 @@ classes:
                 throws: NSErrorException
                 parameters:
                     keys:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSURLProperty.AsListMarshaler.class) List<NSURLProperty>'
+                        type: List<NSURLProperty>
+                        marshaler: NSURLProperty.AsListMarshaler
             '-checkPromisedItemIsReachableAndReturnError:':
                 name: isPromisedItemReachable
                 throws: NSErrorException
@@ -3653,7 +3700,8 @@ classes:
     NSURLCredential: # DONE
         properties:
             'certificates':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<SecCertificate>'
+                type: List<SecCertificate>
+                marshaler: NSArray.AsListMarshaler
             'identity':
                 annotations: ['@WeaklyLinked']
         methods:
@@ -3664,18 +3712,21 @@ classes:
                 annotations: ['@WeaklyLinked']
                 parameters:
                     certArray:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<SecCertificate>'
+                        type: List<SecCertificate>
+                        marshaler: NSArray.AsListMarshaler
             '-init.*':
                 name: init
                 annotations: ['@WeaklyLinked']
     NSURLCredentialStorage: # DONE
         properties:
             'allCredentials':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringMapMarshaler.class) Map<String, NSURLCredential>'
+                type: 'Map<String, NSURLCredential>'
+                marshaler: NSDictionary.AsStringMapMarshaler
         methods:
             '-credentialsForProtectionSpace:':
                 name: getCredentials
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringMapMarshaler.class) Map<String, NSURLCredential>'
+                return_type: 'Map<String, NSURLCredential>'
+                return_marshaler: NSDictionary.AsStringMapMarshaler
             '-setCredential:forProtectionSpace:':
                 trim_after_first_colon: true
             '-removeCredential:forProtectionSpace:':
@@ -3696,7 +3747,6 @@ classes:
                 parameters:
                     completionHandler:
                         type: '@Block VoidBlock1<NSDictionary<NSString, NSURLCredential>>'
-                      #  type: '@Block("(@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringMapMarshaler.class))") VoidBlock1<Map<String, NSURLCredential>>' TODO
             '-setCredential:forProtectionSpace:task:':
                 trim_after_first_colon: true
             '-removeCredential:forProtectionSpace:options:task:':
@@ -3715,7 +3765,8 @@ classes:
             'authenticationMethod':
                 type: NSURLAuthenticationMethod
             'distinguishedNames':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
             'protocol':
                 type: NSURLProtectionSpaceProtocol
             'proxyType':
@@ -3771,7 +3822,8 @@ classes:
     NSURLRequest: # DONE
         properties:
             'allHTTPHeaderFields':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringStringMapMarshaler.class) Map<String, String>'
+                type: 'Map<String, String>'
+                marshaler: NSDictionary.AsStringStringMapMarshaler
             'HTTPShouldHandleCookies':
                 name: shouldHandleHTTPCookies
                 omit_prefix: true
@@ -3867,9 +3919,11 @@ classes:
                 type: CFProxy
             'HTTPAdditionalHeaders':
                 name: getAdditionalHTTPHeaders
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringStringMapMarshaler.class) Map<String, String>'
+                type: 'Map<String, String>'
+                marshaler: NSDictionary.AsStringStringMapMarshaler
             'protocolClasses':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<ObjCClass>'
+                type: List<ObjCClass>
+                marshaler: NSArray.AsListMarshaler
         methods:
             '+(defaultSessionConfiguration|ephemeralSessionConfiguration)':
                 property: true
@@ -4084,12 +4138,14 @@ protocols:
         methods:
             '-initWithCoder:':
                 name: init
+                parameters:
+                    aDecoder:
+                        name: decoder
             '-encodeWithCoder:':
                 name: encode
                 parameters:
                     aCoder:
                         name: coder
-#    NSCopying: {}
     NSDecimalNumberBehaviors: # DONE
         methods:
             '-roundingMode':
@@ -4202,7 +4258,8 @@ protocols:
                 return_type: 'Class<? extends NSObject>'
                 parameters:
                     classNames:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                        type: List<String>
+                        marshaler: NSArray.AsStringListMarshaler
             '-unarchiver:didDecodeObject:':
                 name: didDecodeObject
             '-unarchiver:willReplaceObject:withObject:':
@@ -4441,7 +4498,8 @@ protocols:
                 name: didStartElement
                 parameters:
                     attributeDict:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringMapMarshaler.class) Map<String, NSObject>'
+                        type: 'Map<String, NSObject>'
+                        marshaler: NSDictionary.AsStringMapMarshaler
             '-parser:didEndElement:namespaceURI:qualifiedName:':
                 name: didEndElement
             '-parser:didStartMappingPrefix:toURI:':
@@ -4514,7 +4572,8 @@ functions:
     NS(SearchPathForDirectoriesInDomains):
         class: NSPathUtilities
         name: 'get#{g[0]}'
-        return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+        return_type: List<String>
+        return_marshaler: NSArray.AsStringListMarshaler
 
     NS(Intersection|Union)Range:
         class: NSRange

--- a/compiler/cocoatouch/src/main/bro-gen/social.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/social.yaml
@@ -1,5 +1,5 @@
 package: org.robovm.apple.social
-include: [foundation.yaml, uikit.yaml, coregraphics.yaml, accounts.yaml]
+include: [foundation, uikit, coregraphics, accounts]
 library: Social
 framework: Social
 clang_args: ['-x', 'objective-c']

--- a/compiler/cocoatouch/src/main/bro-gen/systemconfiguration.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/systemconfiguration.yaml
@@ -1,5 +1,5 @@
 package: org.robovm.apple.systemconfiguration
-include: [foundation.yaml, corefoundation.yaml, dispatch.yaml]
+include: [foundation, corefoundation, dispatch]
 library: SystemConfiguration
 framework: SystemConfiguration
 clang_args: ['-x', 'objective-c']
@@ -41,7 +41,7 @@ functions:
         class: SCNetworkReachability
         name: '#{g[0]}'
         visibility: private
-        return_marshaler: CFType.NoRetainMarshaler
+        return_type: '@Pointer long'
         parameters:
             address:
                 type: Struct<?>

--- a/compiler/cocoatouch/src/main/bro-gen/uikit.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/uikit.yaml
@@ -1,5 +1,5 @@
 package: org.robovm.apple.uikit
-include: [foundation.yaml, coreanimation.yaml, coregraphics.yaml, coredata.yaml, coreimage.yaml, coretext.yaml, corelocation.yaml]
+include: [foundation, coreanimation, coregraphics, coredata, coreimage, coretext, corelocation]
 library: UIKit
 framework: UIKit
 clang_args: ['-x', 'objective-c']
@@ -8,15 +8,20 @@ headers:
 typedefs:
     NSCopying: NSObject
     'void (^)(UIBackgroundFetchResult)': '@Block VoidBlock1<UIBackgroundFetchResult>'
-    'void (^)(id<UIViewControllerTransitionCoordinatorContext>)': '@Block VoidBlock1<UIViewControllerTransitionCoordinatorContext>'
-    'void (^)(CGRect, CGRect, NSTextContainer *, NSRange, BOOL *)': '@Block("(@ByVal, @ByVal, , @ByVal, )") VoidBlock5<CGRect, CGRect, NSTextContainer, NSRange, BytePtr>'
-    'void (^)(CGRect, BOOL *)': '@Block("(@ByVal, )") VoidBlock2<CGRect, BytePtr>'
+    'void (^)(id<UIViewControllerTransitionCoordinatorContext> _Nonnull)': '@Block VoidBlock1<UIViewControllerTransitionCoordinatorContext>'
+    'void (^)(CGRect, CGRect, NSTextContainer * _Nonnull, NSRange, BOOL * _Nonnull)': '@Block("(@ByVal, @ByVal, , @ByVal, )") VoidBlock5<CGRect, CGRect, NSTextContainer, NSRange, BooleanPtr>'
+    'void (^)(CGRect, BOOL * _Nonnull)': '@Block("(@ByVal, )") VoidBlock2<CGRect, BooleanPtr>'
     'void (^)(void (^)(void))': '@Block("(@Block)") VoidBlock1<Runnable>'
     'void (^)(NSError *)': '@Block VoidBlock1<NSError>'
-    'void (^)(UILexicon *)': '@Block VoidBlock1<UILexicon>'
-    'void (^)(UIAlertAction *)': '@Block VoidBlock1<UIAlertAction>'
-    'void (^)(UITextField *)': '@Block VoidBlock1<UITextField>'
-    'void (^)(UITableViewRowAction *, NSIndexPath *)': '@Block VoidBlock2<UITableViewRowAction, NSIndexPath>'
+    'void (^)(UILexicon * _Nonnull)': '@Block VoidBlock1<UILexicon>'
+    'void (^)(UIAlertAction * _Nonnull)': '@Block VoidBlock1<UIAlertAction>'
+    'void (^)(UITextField * _Nonnull)': '@Block VoidBlock1<UITextField>'
+    'void (^)(UITableViewRowAction * _Nonnull, NSIndexPath * _Nonnull)': '@Block VoidBlock2<UITableViewRowAction, NSIndexPath>'
+    'void (^)(UIViewAnimatingPosition)': '@Block VoidBlock1<UIViewAnimatingPosition>'
+    'void (^)(UICloudSharingController * _Nonnull, void (^ _Nonnull)(CKShare * _Nullable, CKContainer * _Nullable, NSError * _Nullable))': '@Block(",(@Block)") VoidBlock2<UICloudSharingController, VoidBlock3<CKShare, CKContainer, NSError>>'
+    UIGraphicsImageDrawingActions: '@Block VoidBlock1<UIGraphicsImageRendererContext>'
+    UIGraphicsPDFDrawingActions: '@Block VoidBlock1<UIGraphicsPDFRendererContext>'
+    UITextContentType: UITextContentType
 private_typedefs:
     AnchorType: NSObject
 
@@ -34,6 +39,8 @@ enums:
     NSTextWritingDirection: {}
     NSUnderlineStyle: {}
     NSWritingDirection: {}
+    UIAccessibilityCustomRotorDirection: {}
+    UIAccessibilityHearingDeviceEar: {}
     UIAccessibilityNavigationStyle: {}
     UIAccessibilityScrollDirection: {}
     UIAccessibilityZoomType: {prefix: UIAccessibilityZoomType}
@@ -43,6 +50,7 @@ enums:
     UIAlertActionStyle: {}
     UIAlertControllerStyle: {prefix: UIAlertControllerStyle}
     UIAlertViewStyle: {}
+    UIApplicationShortcutIconType: {}
     UIApplicationState: {}
     UIAttachmentBehaviorType: {}
     UIBackgroundFetchResult: {}
@@ -55,6 +63,7 @@ enums:
     UIBaselineAdjustment: {}
     UIBlurEffectStyle: {}
     UIButtonType: {}
+    UICloudSharingPermissionOptions: {}
     UICollectionElementCategory: {}
     UICollectionUpdateAction: {}
     UICollectionViewScrollDirection: {}
@@ -68,6 +77,7 @@ enums:
     UIDatePickerMode: {}
     UIDeviceBatteryState: {}
     UIDeviceOrientation: {}
+    UIDisplayGamut: {}
     UIDocumentChangeKind: {}
     UIDocumentMenuOrder: {}
     UIDocumentPickerMode: {}
@@ -76,7 +86,9 @@ enums:
     UIDynamicItemCollisionBoundsType: {}
     UIEventSubtype: {}
     UIEventType: {}
+    UIFocusHeading: {}
     UIFontDescriptorSymbolicTraits: {}
+    UIForceTouchCapability: {}
     UIGestureRecognizerState: {}
     UIGuidedAccessRestrictionState: {}
     UIImageOrientation: {}
@@ -105,6 +117,9 @@ enums:
     UIPageViewControllerSpineLocation: {}
     UIPageViewControllerTransitionStyle: {}
     UIPopoverArrowDirection: {}
+    UIPressPhase: {}
+    UIPressType: {}
+    UIPreviewActionStyle: {}
     UIPrintErrorCode: {first: UIPrintingNotAvailableError, suffix: Error, UIPrintingNotAvailableError: PrintingNotAvailableError}
     UIPrinterCutterBehavior: {}
     UIPrinterJobTypes: {skip_none: true}
@@ -136,6 +151,7 @@ enums:
     UITabBarSystemItem: {}
     UITableViewCellAccessoryType: {}
     UITableViewCellEditingStyle: {}
+    UITableViewCellFocusStyle: {}
     UITableViewCellSelectionStyle: {}
     UITableViewCellSeparatorStyle: {}
     UITableViewCellStateMask: {suffix: mask}
@@ -148,21 +164,30 @@ enums:
     UITextAutocapitalizationType: {}
     UITextAutocorrectionType: {}
     UITextBorderStyle: {}
+    UITextFieldDidEndEditingReason: {prefix: UITextFieldDidEndEditingReason}
     UITextFieldViewMode: {}
     UITextGranularity: {}
+    UITextItemInteraction: {}
     UITextLayoutDirection: {}
     UITextSpellCheckingType: {}
     UITextStorageDirection: {}
     UITextWritingDirection: {}
+    UITimingCurveType: {}
     UIToolbarPosition: {}
     UITouchPhase: {}
+    UITouchProperties: {}
+    UITouchType: {}
+    UITraitEnvironmentLayoutDirection: {}
     UIUserInterfaceIdiom: {prefix: UIUserInterfaceIdiom}
     UIUserInterfaceLayoutDirection: {}
     UIUserInterfaceSizeClass: {}
+    UIUserInterfaceStyle: {}
     UIUserNotificationActionBehavior: {}
     UIUserNotificationActionContext: {}
     UIUserNotificationActivationMode: {}
     UIUserNotificationType: {}
+    UIViewAnimatingPosition: {}
+    UIViewAnimatingState: {}
     UIViewAnimationCurve: {}
     UIViewAnimationOptions: {}
     UIViewAnimationTransition: {}
@@ -309,16 +334,18 @@ categories:
                 name: getSize
     NSValue: # DONE
         annotations: ['@WeaklyLinked']
+        properties:
+            'CG(.*Value)':
+                name: '#{g[0]}'
+            'UI(.*Value)':
+                name: '#{g[0]}'
         methods:
-            '-CG(.*Value)':
-                name: 'get#{g[0]}'
-            '-UI(.*Value)':
-                name: 'get#{g[0]}'
             '+valueWith.*':
                 name: create
     UIAccessibility@NSObject: {protocol: true}
     UIAccessibilityAction@NSObject: {protocol: true}
     UIAccessibilityContainer@NSObject: {protocol: true}
+    UIAccessibilityCustomRotor@NSObject: {protocol: true}
     UIAccessibilityFocus@NSObject: {protocol: true}
     UINibLoadingAdditions@NSObject: {protocol: true}
     UIResponderStandardEditActions@NSObject: {protocol: true}
@@ -351,8 +378,6 @@ classes:
                 name: init
     NSFileProviderExtension: # DONE
         methods:
-            '-(providerIdentifier|documentStorageURL)':
-                property: true
             '-URLForItemWithPersistentIdentifier:':
                 name: getURLForItem
             '-persistentIdentifierForItemAtURL:':
@@ -440,9 +465,11 @@ classes:
                 return_type: NSArray<NSLayoutConstraint>
                 parameters:
                     metrics:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringNumberMapMarshaler.class) Map<String, Number>'
+                        type: 'Map<String, Number>'
+                        marshaler: NSDictionary.AsStringNumberMapMarshaler
                     views:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringMapMarshaler.class) Map<String, NSObjectProtocol>'
+                        type: 'Map<String, NSObjectProtocol>'
+                        marshaler: NSDictionary.AsStringMapMarshaler
             '+activateConstraints:':
                 trim_after_first_colon: true
                 parameters:
@@ -524,10 +551,6 @@ classes:
                 trim_after_first_colon: true
             '-getFirstUnlaidCharacterIndex:glyphIndex:':
                 trim_after_first_colon: true
-            '-firstUnlaidCharacterIndex':
-                name: getFirstUnlaidCharacterIndex
-            '-firstUnlaidGlyphIndex':
-                name: getFirstUnlaidGlyphIndex
             '-textContainerForGlyphAtIndex:effectiveRange:':
                 name: getTextContainer
             '-usedRectForTextContainer:':
@@ -624,8 +647,6 @@ classes:
             'tabStops':
                 type: NSArray<NSTextTab>
         methods:
-            '+defaultParagraphStyle':
-                property: true
             '+defaultWritingDirectionForLanguage:':
                 name: getDefaultWritingDirection
 
@@ -687,6 +708,15 @@ classes:
         methods:
             '-init.*':
                 name: init
+    UIAccessibilityCustomRotor: # DONE
+        methods:
+            '-init.*':
+                name: init
+    UIAccessibilityCustomRotorItemResult: # DONE
+        methods:
+            '-init.*':
+                name: init
+    UIAccessibilityCustomRotorSearchPredicate: {} # DONE
     UIAccessibilityElement: # DONE
         properties:
             'isAccessibilityElement':
@@ -720,19 +750,12 @@ classes:
             '-showInView:':
                 name: showIn
     UIActivity: # DONE
+        properties:
+            'activity(.*)':
+                name: '#{g[0]}'
         methods:
-            '+activityCategory':
-                name: getActivityCategory
             '-activityDidFinish:':
                 name: didFinish
-            '-activityImage':
-                name: getImage
-            '-activityTitle':
-                name: getTitle
-            '-activityType':
-                name: getType
-            '-activityViewController':
-                name: getViewController
             '-performActivity':
                 name: perform
             '-canPerformWithActivityItems:':
@@ -747,14 +770,13 @@ classes:
         methods:
             '-init.*':
                 name: init
-            '-item':
-                name: getItem
     UIActivityViewController: # DONE
         properties:
             'completionHandler':
                 type: '@Block VoidBlock2<String, Boolean>'
             'excludedActivityTypes':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
             'completionWithItemsHandler':
                 type: '@Block VoidBlock4<String, Boolean, NSArray<NSObject>, NSError>'
         methods:
@@ -807,9 +829,9 @@ classes:
                 type: NSArray<UILocalNotification>
             'applicationSupportsShakeToEdit':
                 name: supportsShakeToEdit
+            'shortcutItems':
+                type: NSArray<UIApplicationShortcutItem>
         methods:
-            '+sharedApplication':
-                name: getSharedApplication
             '+registerObjectForStateRestoration:restorationIdentifier:':
                 trim_after_first_colon: true
             '-beginBackgroundTaskWith.*':
@@ -830,8 +852,21 @@ classes:
                 trim_after_first_colon: true
             '-registerUserNotificationSettings:':
                 trim_after_first_colon: true
-            '-currentUserNotificationSettings':
-                property: true
+            '-openURL:options:completionHandler:':
+                trim_after_first_colon: true
+                parameters:
+                    options:
+                        type: UIApplicationOpenURLOptions
+    UIApplicationShortcutIcon: # DONE
+        methods:
+            '+iconWith.*':
+                name: create
+                constructor: true
+    UIApplicationShortcutItem: # DONE
+        skip_def_constructor: true
+        methods:
+            '-init.*':
+                name: init
     UIAttachmentBehavior: # DONE
         properties:
             'items':
@@ -850,7 +885,8 @@ classes:
     UIBarButtonItem: # DONE
         properties:
             'possibleTitles':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSSet.AsStringListMarshaler.class) List<String>'
+                type: Set<String>
+                marshaler: NSSet.AsStringListMarshaler
         methods:
             '-initWithImage:style:target:action:':
                 name: init
@@ -968,7 +1004,7 @@ classes:
                 constructor: true
     UIButton: # DONE
         methods:
-            '+buttonWithType:': ########################### # TODO remove deprecated method!!!!!
+            '+buttonWithType:':
                 name: create0
                 constructor: true
             '-backgroundImageForState:':
@@ -993,6 +1029,12 @@ classes:
                 name: getAttributedTitle
             '-(set.*):forState:.*':
                 name: '#{g[0]}'
+   # UICloudSharingController: # DONE
+   #     methods:
+   #         '-init.*':                         >>>>> TODO need to update CloudKit
+    #            name: init     
+    #        '-activityItemSource':
+    #            property: true
     UICollectionReusableView: # DONE
         methods:
             '-didTransitionFromLayout:toLayout:':
@@ -1014,9 +1056,6 @@ classes:
                 name: getCellForItem
             '-deleteItemsAtIndexPaths:':
                 name: deleteItems
-                parameters:
-                    indexPaths:
-                        type: NSArray<NSIndexPath>
             '-dequeueReusableCellWithReuseIdentifier:forIndexPath:':
                 name: dequeueReusableCell
                 return_type: UICollectionReusableView
@@ -1032,25 +1071,14 @@ classes:
                 name: getIndexPathForCell
             '-indexPathForItemAtPoint:':
                 name: getIndexPathForItem
-            '-indexPathsForSelectedItems':
-                name: getIndexPathsForSelectedItems
-                return_type: NSArray<NSIndexPath>
-            '-indexPathsForVisibleItems':
-                name: getIndexPathsForVisibleItems
-                return_type: NSArray<NSIndexPath>
             '-supplementaryViewForElementKind:atIndexPath:':
                 name: getSupplementaryView
             '-visibleSupplementaryViewsOfKind:':
                 name: getVisibleSupplementaryViews
-                return_type: NSArray<UICollectionReusableView>
             '-indexPathsForVisibleSupplementaryElementsOfKind:':
                 name: getIndexPathsForVisibleSupplementaryElements
-                return_type: NSArray<NSIndexPath>
             '-insertItemsAtIndexPaths:':
                 name: insertItems
-                parameters:
-                    indexPaths:
-                        type: NSArray<NSIndexPath>
             '-layoutAttributesForItemAtIndexPath:':
                 name: getLayoutAttributesForItem
             '-layoutAttributesForSupplementaryElementOfKind:atIndexPath:':
@@ -1062,8 +1090,6 @@ classes:
                 name: moveItem
             '-numberOfItemsInSection:':
                 name: getNumberOfItemsInSection
-            '-numberOfSections':
-                name: getNumberOfSections
             '-registerClass:forCellWithReuseIdentifier:':
                 name: registerReusableCellClass
                 parameters:
@@ -1085,16 +1111,10 @@ classes:
                         type: UICollectionElementKind
             '-reloadItemsAtIndexPaths:':
                 name: reloadItems
-                parameters:
-                    indexPaths:
-                        type: NSArray<NSIndexPath>
             '-scrollToItemAtIndexPath:atScrollPosition:animated:':
                 name: scrollToItem
             '-selectItemAtIndexPath:animated:scrollPosition:':
                 name: selectItem
-            '-visibleCells':
-                name: getVisibleCells
-                return_type: NSArray<UICollectionViewCell>
             '-setCollectionViewLayout:animated:':
                 trim_after_first_colon: true
             '-setCollectionViewLayout:animated:completion:':
@@ -1132,16 +1152,14 @@ classes:
                 name: invalidatesFlowLayoutDelegateMetrics
             'invalidateFlowLayoutAttributes':
                 name: invalidatesFlowLayoutAttributes
+    UICollectionViewFocusUpdateContext: {} # DONE
     UICollectionViewLayout: # DONE
+        properties:
+            'layoutAttributesClass':
+                type: 'Class<? extends UICollectionViewLayoutAttributes>'
+            'invalidationContextClass':
+                type: 'Class<? extends UICollectionViewLayoutInvalidationContext>'
         methods:
-            '+layoutAttributesClass':
-                property: true
-                return_type: 'Class<? extends UICollectionViewLayoutAttributes>'
-            '+invalidationContextClass':
-                property: true
-                return_type: 'Class<? extends UICollectionViewLayoutInvalidationContext>'
-            '-collectionViewContentSize':
-                name: getCollectionViewContentSize
             '-finalLayoutAttributesForDisappearingDecorationElementOfKind:atIndexPath:':
                 name: getFinalLayoutAttributesForDisappearingDecorationElement
             '-finalLayoutAttributesForDisappearingItemAtIndexPath:':
@@ -1206,16 +1224,8 @@ classes:
                 name: getLayoutAttributesForInteractivelyMovingItem
             '-invalidationContextForInteractivelyMovingItems:withTargetPosition:previousIndexPaths:previousPosition:':
                 name: getInvalidationContextForInteractivelyMovingItems
-                parameters:
-                    previousIndexPaths:
-                        type: NSArray<NSIndexPath>
             '-invalidationContextForEndingInteractiveMovementOfItemsToFinalIndexPaths:previousIndexPaths:movementCancelled:':
                 name: getInvalidationContextForEndingInteractiveMovement
-                parameters:
-                    indexPaths:
-                        type: NSArray<NSIndexPath>
-                    previousIndexPaths:
-                        type: NSArray<NSIndexPath>
     UICollectionViewLayoutAttributes: # DONE
         methods:
             '+layoutAttributesForCellWithIndexPath:':
@@ -1286,20 +1296,20 @@ classes:
             '-boundaryWithIdentifier:':
                 name: getBoundary
     UIColor: # DONE
+        properties:
+            '(CIColor|CGColor)': {}
+            '(.*)Color':
+                getter: '#{g[0]}'
         methods:
             '-init.*':
                 name: init
-            '+(black|darkGray|lightGray|white|gray|red|green|blue|cyan|yellow|magenta|orange)Color':
-                name: '#{g[0][0].downcase}#{g[0][1..-1]}'
-            '+(purple|brown|clear|lightText|darkText)Color':
-                name: '#{g[0][0].downcase}#{g[0][1..-1]}'
-            '+(groupTableViewBackground|viewFlipsideBackground|scrollViewTexturedBackground|underPageBackground)Color':
-                name: '#{g[0][0].downcase}#{g[0][1..-1]}'
             '-initWithHue:saturation:brightness:alpha:':
                 exclude: true
             '-initWithPatternImage:':
                 exclude: true
             '-initWithWhite:alpha:':
+                exclude: true
+            '-initWithDisplayP3Red:green:blue:alpha:':
                 exclude: true
             '+colorWithCGColor:':
                 name: fromCGColor
@@ -1313,6 +1323,8 @@ classes:
                 name: fromPatternImage
             '+colorWithWhite:alpha:':
                 name: fromWhiteAlpha
+            '+colorWithDisplayP3Red:green:blue:alpha:':
+                name: fromDisplayP3
             '-colorWithAlphaComponent:':
                 name: addAlpha
             '-getHue:saturation:brightness:alpha:':
@@ -1326,16 +1338,14 @@ classes:
                 visibility: protected
             '-set':
                 name: setFillAndStroke
+    UIContentSizeCategoryAdjusting: {} # DONE
     UIControl: # DONE
         skip_handle_constructor: false
         methods:
             '-actionsForTarget:forControlEvent:':
                 name: getActions
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
-            '-allControlEvents':
-                property: true
-            '-allTargets':
-                property: true
+                return_type: List<String>
+                return_marshaler: NSArray.AsStringListMarshaler
             '-beginTrackingWithTouch:withEvent:':
                 name: beginTracking
             '-cancelTrackingWithEvent:':
@@ -1352,24 +1362,24 @@ classes:
                 name: removeTarget
             '-sendAction:to:forEvent:':
                 name: sendAction
+    UICubicTimingParameters: # DONE
+        methods:
+            '-init.*':
+                name: init
     UIDatePicker: # DONE
         methods:
             '-setDate:animated:':
                 name: setDate
-    UIDevice: # DONE
-        methods:
-            '+currentDevice':
-                property: true
+    UIDevice: {} # DONE
     UIDictationPhrase: # DONE
         properties:
             'alternativeInterpretations':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
     UIDocument: # DONE
         methods:
             '-init.*':
                 name: init
-            '-savingFileType':
-                name: getSavingFileType
             '-autosaveWithCompletionHandler:':
                 name: autoSave
             '-closeWithCompletionHandler:':
@@ -1428,7 +1438,8 @@ classes:
                 name: init
                 parameters:
                     allowedUTIs:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                        type: List<String>
+                        marshaler: NSArray.AsStringListMarshaler
             '-init.*':
                 name: init
             '-addOptionWithTitle:image:order:handler:':
@@ -1460,7 +1471,8 @@ classes:
     UIDocumentPickerExtensionViewController: # DONE
         properties:
             'validTypes':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
         methods:
             '-dismissGrantingAccessToURL:':
                 trim_after_first_colon: true
@@ -1472,7 +1484,8 @@ classes:
                 name: init
                 parameters:
                     allowedUTIs:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                        type: List<String>
+                        marshaler: NSArray.AsStringListMarshaler
             '-init.*':
                 name: init
     UIDynamicAnimator: # DONE
@@ -1488,8 +1501,6 @@ classes:
                 trim_after_first_colon: true
             '-updateItemUsingCurrentState:':
                 trim_after_first_colon: true
-            '-elapsedTime':
-                property: true
             '-layoutAttributesForCellAtIndexPath:':
                 name: getLayoutAttributesForCell
             '-layoutAttributesForSupplementaryViewOfKind:atIndexPath:':
@@ -1532,27 +1543,59 @@ classes:
                 name: addAngularVelocityForItem
             '-angularVelocityForItem:':
                 name: getAngularVelocityForItem
+    UIDynamicItemGroup: # DONE
+        properties:
+            'items':
+                type: List<UIDynamicItem>
+                marshaler: NSArray.AsListMarshaler
+        methods:
+            '-initWithItems:':
+                name: init
+                parameters:
+                    items:
+                        type: List<UIDynamicItem>
+                        marshaler: NSArray.AsListMarshaler
     UIEvent: # DONE
         methods:
-            '-allTouches':
-                name: getAllTouches
-                return_type: NSSet<UITouch>
             '-touchesForGestureRecognizer:':
                 name: getTouches
-                return_type: NSSet<UITouch>
             '-touchesForView:':
                 name: getTouches
-                return_type: NSSet<UITouch>
             '-touchesForWindow:':
                 name: getTouches
-                return_type: NSSet<UITouch>
             '-coalescedTouchesForTouch:':
                 name: getCoalescedTouches
-                return_type: NSArray<UITouch>
             '-predictedTouchesForTouch:':
                 name: getPredictedTouches
-                return_type: NSArray<UITouch>
+    UIFieldBehavior: # DONE
+        properties:
+            'items':
+                type: List<UIDynamicItem>
+                marshaler: NSArray.AsListMarshaler
+        methods:
+            '+fieldWithEvaluationBlock:':
+                exclude: true
+            '+(.*)Field.*':
+                name: '#{g[0]}'
+            '-addItem:':
+                trim_after_first_colon: true
+            '-removeItem:':
+                trim_after_first_colon: true
+    UIFocusAnimationCoordinator: # DONE
+        methods:
+            '-addCoordinatedAnimations:completion:':
+                trim_after_first_colon: true
+    UIFocusGuide: # DONE
+        properties:
+            'preferredFocusEnvironments':
+                type: List<UIFocusEnvironment>
+                marshaler: NSArray.AsListMarshaler
+    UIFocusUpdateContext: {} # DONE
     UIFont: # DONE
+        properties:
+            'familyNames':
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
         methods:
             '+boldSystemFontOfSize:':
                 name: getBoldSystemFont
@@ -1564,10 +1607,6 @@ classes:
                 return_marshaler: NSArray.AsStringListMarshaler
             '+buttonFontSize':
                 name: getButtonFontSize
-            '+familyNames':
-                name: getFamilyNames
-                return_type: List<String>
-                return_marshaler: NSArray.AsStringListMarshaler
             '+italicSystemFontOfSize:':
                 name: getItalicSystemFont
             '+labelFontSize':
@@ -1584,16 +1623,17 @@ classes:
                 name: getFont
             '+fontWithDescriptor:size:':
                 name: getFont
-            '+preferredFontForTextStyle:':
+            '+preferredFontForTextStyle.*':
                 name: getPreferredFont
                 parameters:
                     style:
                         type: UIFontTextStyle
             '-fontWithSize:':
                 name: newWithSize
-            '-fontDescriptor':
-                property: true
     UIFontDescriptor: # DONE
+        properties:
+            'fontAttributes':
+                type: UIFontDescriptorAttributes
         methods:
             '-initWithFontAttributes:':
                 name: init
@@ -1610,21 +1650,17 @@ classes:
             '+fontDescriptorWithName:matrix:':
                 name: create
                 constructor: true
-            '+preferredFontDescriptorWithTextStyle:':
+            '+preferredFontDescriptorWithTextStyle.*':
                 name: getPreferredFontDescriptor
-                visibility: protected
                 parameters:
                     style:
-                        type: NSString
+                        type: UIFontTextStyle
             '-objectForKey:':
                 name: getValue
                 visibility: protected
                 parameters:
                     anAttribute:
                         type: NSString
-            '-fontAttributes':
-                property: true
-                return_type: UIFontDescriptorAttributes
             '-matchingFontDescriptorsWithMandatoryKeys:':
                 name: getMatchingFontDescriptors
                 return_type: NSArray<UIFontDescriptor>
@@ -1648,6 +1684,13 @@ classes:
             '-fontDescriptorWithFamily:':
                 name: newWithFamily
     UIGestureRecognizer: # DONE
+        properties:
+            'allowedTouchTypes':
+                type: List<UITouchType>
+                marshaler: UITouchType.AsListMarshaler
+            'allowedPressTypes':
+                type: List<UIPressType>
+                marshaler: UIPressType.AsListMarshaler
         methods:
             '-initWithTarget:action:':
                 name: init
@@ -1666,6 +1709,54 @@ classes:
                 trim_after_first_colon: true
             '-requireGestureRecognizerToFail:':
                 trim_after_first_colon: true
+    UIGraphicsImageRenderer: # DONE
+        methods:
+            '-init.*':
+                name: init
+            '-imageWithActions:':
+                name: toImage
+            '-PNGDataWithActions:':
+                name: toPNG
+            '-JPEGDataWithCompressionQuality:actions:':
+                name: toJPEG
+    UIGraphicsImageRendererContext: {} # DONE
+    UIGraphicsImageRendererFormat: {} # DONE
+    UIGraphicsPDFRenderer: # DONE
+        methods:
+            '-init.*':
+                name: init
+            '-writePDFToURL:withActions:error:':
+                name: writePDFToURL
+                throws: NSErrorException
+            '-PDFDataWithActions:':
+                name: toPDFData
+    UIGraphicsPDFRendererContext: # DONE
+        methods:
+            '-beginPageWithBounds:pageInfo:':
+                name: beginPage
+            '-setURL:forRect:':
+                name: setURLForRect
+            '-addDestinationWithName:atPoint:':
+                name: addDestination
+            '-setDestinationWithName:forRect:':
+                name: setDestination
+    UIGraphicsPDFRendererFormat: {} # DONE
+    UIGraphicsRenderer: # DONE
+        methods:
+            '-init.*':
+                name: init
+    UIGraphicsRendererContext: # DONE
+        methods:
+            '-fillRect.*':
+                trim_after_first_colon: true
+            '-strokeRect.*':
+                trim_after_first_colon: true
+            '-clipToRect:':
+                trim_after_first_colon: true
+    UIGraphicsRendererFormat: # DONE
+        methods:
+            '+defaultFormat':
+                property: true
     UIGravityBehavior: # DONE
         properties:
             'items':
@@ -1693,7 +1784,7 @@ classes:
                 name: flipsHorizontally
             'CIImage':
                 annotations: ['@WeaklyLinked']
-        methods:  ########################### # TODO remove deprecated methods!!!!!
+        methods:
             '+animatedImageNamed:duration:':
                 name: getAnimatedImage
             '+animatedImageWithImages:duration:':
@@ -1710,7 +1801,8 @@ classes:
             '+imageNamed:inBundle:compatibleWithTraitCollection:':
                 name: getImage
             '+imageWithContentsOfFile:':
-                exclude: true
+                name: getImageWithContentsOfFile
+                visibility: private
             '+imageWithCGImage:':
                 exclude: true
             '+imageWithCGImage:scale:orientation:':
@@ -1768,14 +1860,17 @@ classes:
             'delegate':
                 type: UIImagePickerControllerDelegate
             'mediaTypes':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
         methods:
             '+availableCaptureModesForCameraDevice:':
                 name: getAvailableCaptureModes
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(UIImagePickerControllerCameraCaptureMode.AsListMarshaler.class) List<UIImagePickerControllerCameraCaptureMode>'
+                return_type: List<UIImagePickerControllerCameraCaptureMode>
+                return_marshaler: UIImagePickerControllerCameraCaptureMode.AsListMarshaler
             '+availableMediaTypesForSourceType:':
                 name: getAvailableMediaTypes
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                return_type: List<String>
+                return_marshaler: NSArray.AsStringListMarshaler
             '+isSourceTypeAvailable:':
                 trim_after_first_colon: true
             '+isCameraDeviceAvailable:':
@@ -1799,6 +1894,8 @@ classes:
         methods:
             '-requestSupplementaryLexiconWithCompletion:':
                 name: requestSupplementaryLexicon
+            '-handleInputModeListFromView:withEvent:':
+                name: handleInputModeList
     UIInterpolatingMotionEffect: # DONE
         properties:
             'minimumRelativeValue':
@@ -1815,7 +1912,10 @@ classes:
             '+keyCommandWithInput:modifierFlags.*':
                 name: create
                 constructor: true
-    UILayoutGuide: {} # DONE
+    UILayoutGuide: # DONE
+        methods:
+            '-constraintsAffectingLayoutForAxis:':
+                name: getConstraintsAffectingLayout
     UILabel: # DONE
         methods:
             '-drawTextInRect:':
@@ -1829,10 +1929,9 @@ classes:
     UILexiconEntry: {} # DONE
     UILocalizedIndexedCollation: # DONE
         properties:
-            'sectionTitles':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
-            'sectionIndexTitles':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+            '(sectionTitles|sectionIndexTitles)':
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
         methods:
             '+currentCollation':
                 name: getCurrentCollation
@@ -1861,8 +1960,6 @@ classes:
                 type: NSPersistentStoreOptions
                 annotations: ['@WeaklyLinked']
         methods:
-            '+persistentStoreName':
-                name: getPersistentStoreName
             '-additionalContentForURL:error:':
                 name: getAdditionalContent
                 throws: NSErrorException
@@ -1889,11 +1986,8 @@ classes:
         properties:
             'menuItems':
                 name: menuItems0
-                type: NSArray<UIMenuItem>
                 visibility: private
         methods:
-            '+sharedMenuController':
-                name: getSharedMenuController
             '-setMenuVisible:animated:':
                 trim_after_first_colon: true
             '-setTargetRect:inView:':
@@ -1909,16 +2003,11 @@ classes:
             '-keyPathsAndRelativeValuesForViewerOffset:':
                 name: getKeyPathsAndRelativeValues
                 return_type: UIMotionEffectViewerOffsetValues
-    UIMotionEffectGroup: # DONE
-        properties:
-            'motionEffects':
-                type: NSArray<UIMotionEffect>
+    UIMotionEffectGroup: {} # DONE
     UINavigationBar: # DONE
         properties:
             'delegate':
                 type: UINavigationBarDelegate
-            'items':
-                type: NSArray<UINavigationItem>
             'titleTextAttributes':
                 name: titleTextAttributesDictionary
                 type: 'NSDictionary<NSString, ?>'
@@ -2055,38 +2144,30 @@ classes:
         properties:
             'items':
                 name: items0
-                type: 'NSArray<NSDictionary>'
+                type: NSArray<NSDictionary>
                 visibility: private
-            'images':
-                type: NSArray<UIImage>
-            'URLs':
-                type: NSArray<NSURL>
-            'colors':
-                type: NSArray<UIColor>
-            'strings':
-                type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+            '(pasteboardTypes|strings)':
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
         methods:
-            '+generalPasteboard':
-                name: getGeneralPasteboard
             '+pasteboardWithUniqueName':
                 name: getUniquePasteboard
             '+pasteboardWithName:create:':
                 name: getPasteboard
             '+removePasteboardWithName:':
                 name: removePasteboard
-            '-pasteboardTypes':
-                name: getTypes
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
             '-containsPasteboardTypes:':
                 name: contains
                 parameters:
                     pasteboardTypes:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                        type: List<String>
+                        marshaler: NSArray.AsStringListMarshaler
             '-containsPasteboardTypes:inItemSet:':
                 name: contains
                 parameters:
                     pasteboardTypes:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                        type: List<String>
+                        marshaler: NSArray.AsStringListMarshaler
             '-dataForPasteboardType:':
                 name: getData
             '-dataForPasteboardType:inItemSet:':
@@ -2096,7 +2177,8 @@ classes:
                 name: getItemsWithTypes
                 parameters:
                     pasteboardTypes:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                        type: List<String>
+                        marshaler: NSArray.AsStringListMarshaler
             '-pasteboardTypesForItemSet:':
                 name: getTypes0
                 visibility: private
@@ -2114,7 +2196,15 @@ classes:
                 visibility: private
                 parameters:
                     items:
-                        type: 'NSArray<NSDictionary>'
+                        type: NSArray<NSDictionary>
+            '-setItems:options:':
+                name: setItems0
+                visibility: private
+                parameters:
+                    items:
+                        type: NSArray<NSDictionary>
+                    options:
+                        type: UIPasteboardOptions
     UIPercentDrivenInteractiveTransition: # DONE
         methods:
             '-updateInteractiveTransition:':
@@ -2175,8 +2265,6 @@ classes:
         methods:
             '-init.*':
                 name: init
-            '-(adaptivePresentationStyle|presentedView)':
-                property: true
             '-adaptivePresentationStyleForTraitCollection:':
                 name: getAdaptivePresentationStyleForTraitCollection
             '-frameOfPresentedViewInContainerView':
@@ -2185,6 +2273,33 @@ classes:
                 trim_after_first_colon: true
             '-dismissalTransitionDidEnd:':
                 trim_after_first_colon: true
+    UIPress: {} # DONE
+    UIPressesEvent: # DONE
+        methods:
+            '-pressesForGestureRecognizer:':
+                name: getPressesForGestureRecognizer
+    UIPreviewAction: # DONE
+        properties:
+            'handler':
+                type: '@Block VoidBlock2<UIPreviewActionItem, UIViewController>'
+        methods:
+            '+actionWithTitle:style:handler:':
+                name: create
+                constructor: true
+                parameters:
+                    handler:
+                        type: '@Block VoidBlock2<UIPreviewActionItem, UIViewController>'
+    UIPreviewActionGroup: # DONE
+        methods:
+            '+actionGroupWithTitle:style:actions:':
+                name: create
+                constructor: true
+    UIPreviewInteraction: # DONE
+        methods:
+            '-init.*':
+                name: init
+            '-locationInCoordinateSpace:':
+                name: getLocationInCoordinateSpace
     UIPrinter: # DONE
         methods:
             '-contactPrinter:':
@@ -2199,6 +2314,9 @@ classes:
             '-rectForPageAtIndex:':
                 name: getRectForPage
     UIPrintInfo: # DONE
+        properties:
+            'dictionaryRepresentation':
+                getter: toDictionary
         methods:
             '-init.*':
                 name: init
@@ -2207,19 +2325,16 @@ classes:
             '+printInfoWithDictionary:':
                 name: create
                 constructor: true
-            '-dictionaryRepresentation':
-                name: toDictionary
     UIPrintInteractionController: # DONE
+        properties:
+            'printableUTIs':
+                type: Set<String>
+                marshaler: NSSet.AsStringSetMarshaler
         methods:
             '+canPrintData:':
                 name: canPrint
             '+canPrintURL:':
                 name: canPrint
-            '+printableUTIs':
-                name: getPrintableUTIs
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
-            '+sharedPrintController':
-                name: getSharedPrintController
             '-dismissAnimated:':
                 name: dismiss
             '-presentAnimated:completionHandler:':
@@ -2247,8 +2362,6 @@ classes:
             'printFormatters':
                 type: NSArray<UIPrintFormatter>
         methods:
-            '-numberOfPages':
-                name: getNumberOfPages
             '-drawContentForPageAtIndex:inRect:':
                 name: drawContent
             '-drawFooterForPageAtIndex:inRect:':
@@ -2344,8 +2457,6 @@ classes:
                 name: intersection
             '-containsPoint:':
                 trim_after_first_colon: true
-            '+infiniteRegion':
-                property: true
     UIResponder: # DONE
         skip_handle_constructor: false
         protocols: [UIAccessibility]
@@ -2353,8 +2464,6 @@ classes:
             'keyCommands':
                 type: NSArray<UIKeyCommand>
         methods:
-            '-nextResponder':
-                name: getNextResponder
             '-remoteControlReceivedWithEvent:':
                 name: remoteControlReceived
             '-(touches.*):withEvent:':
@@ -2377,20 +2486,22 @@ classes:
                 trim_after_first_colon: true
             '-restoreUserActivityState:':
                 trim_after_first_colon: true
+            '-touchesEstimatedPropertiesUpdated:':
+                trim_after_first_colon: true
+            '-pressesBegan:withEvent:':
+                trim_after_first_colon: true
+            '-pressesChanged:withEvent:':
+                trim_after_first_colon: true
+            '-pressesEnded:withEvent:':
+                trim_after_first_colon: true
+            '-pressesCancelled:withEvent:':
+                trim_after_first_colon: true
     UIRotationGestureRecognizer: {} # DONE
     UIScreen: # DONE
-        properties:
-            'availableModes':
-                type: NSArray<UIScreenMode>
         methods:
-            '+mainScreen':
-                name: getMainScreen
-            '+screens':
-                name: getScreens
-                return_type: NSArray<UIScreen>
             '-displayLinkWithTarget:selector:':
                 name: getDisplayLink
-                annotations: ['@WeaklyLinked'] # TODO make listenerwrapper!!!!
+                annotations: ['@WeaklyLinked']
             '-snapshotViewAfterScreenUpdates:':
                 name: snapshotView
     UIScreenEdgePanGestureRecognizer: {} # DONE
@@ -2454,6 +2565,10 @@ classes:
                 parameters:
                     attributes:
                         type: 'NSDictionary<NSString, ?>'
+    UISearchContainerViewController: # DONE
+        methods:
+            '-init.*':
+                name: init
     UISearchController: # DONE
         methods:
             '-init.*':
@@ -2552,26 +2667,22 @@ classes:
             '-init.*':
                 name: init
     UISplitViewController: # DONE
-        properties:
-            'viewControllers':
-                type: NSArray<UIViewController>
         methods:
-            '-displayModeButtonItem':
-                property: true
             '-showViewController:sender:':
                 trim_after_first_colon: true
             '-showDetailViewController:sender:':
                 trim_after_first_colon: true
+    UISpringTimingParameters: # DONE
+        methods:
+            '-init.*':
+                name: init
     UIStackView: # DONE
         properties:
             'arrangedSubviews':
                 type: NSArray<UIView>
         methods:
-            '-initWithArrangedSubviews:':
+            '-init.*':
                 name: init
-                parameters:
-                    views:
-                        type: NSArray<UIView>
             '-addArrangedSubview:':
                 trim_after_first_colon: true
             '-removeArrangedSubview:':
@@ -2671,6 +2782,14 @@ classes:
                 name: setFinishedImages
             '-titlePositionAdjustment':
                 name: getTitlePositionAdjustment
+            '-setBadgeTextAttributes:forState:':
+                trim_after_first_colon: true
+                parameters:
+                    textAttributes:
+                        type: 'NSDictionary<NSString, ?>'
+            '-badgeTextAttributesForState:':
+                name: getBadgeTextAttributes
+                return_type: 'NSDictionary<NSString, ?>'
     UITableView: # DONE
         properties:
             'indexPathsForVisibleRows':
@@ -2785,6 +2904,7 @@ classes:
         methods:
             '-init.*':
                 name: init
+    UITableViewFocusUpdateContext: {} # DONE
     UITableViewHeaderFooterView: # DONE
         methods:
             '-init.*':
@@ -2796,22 +2916,23 @@ classes:
                 constructor: true
     UITapGestureRecognizer: {} # DONE
     UITextChecker: # DONE
+        properties:
+            '(ignoredWords|availableLanguages)':
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
         methods:
             '-rangeOfMisspelledWordInString:range:startingAt:wrap:language:':
                 name: getRangeOfMisspelledWordInString
             '-guessesForWordRange:inString:language:':
                 name: getGuessesForWord
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                return_type: List<String>
+                return_marshaler: NSArray.AsStringListMarshaler
             '-completionsForPartialWordRange:inString:language:':
                 name: getCompletionsForPartialWord
                 return_type: List<String>
                 return_marshaler: NSArray.AsStringListMarshaler
             '-ignoreWord:':
                 trim_after_first_colon: true
-            '-ignoredWords':
-                property: true
-                return_type: List<String>
-                return_marshaler: NSArray.AsStringListMarshaler
             '-setIgnoredWords:':
                 trim_after_first_colon: true
                 parameters:
@@ -2824,10 +2945,6 @@ classes:
                 trim_after_first_colon: true
             '+unlearnWord:':
                 trim_after_first_colon: true
-            '+availableLanguages':
-                property: true
-                return_type: List<String>
-                return_marshaler: NSArray.AsStringListMarshaler
     UITextField: # DONE
         properties:
             'defaultTextAttributes':
@@ -2857,9 +2974,6 @@ classes:
                 name: drawPlaceholder
     UITextInputMode: # DONE
         methods:
-            '+activeInputModes':
-                name: getActiveInputModes
-                return_type: NSArray<UITextInputMode>
             '+currentInputMode':
                 name: getCurrentInputMode
     UITextInputAssistantItem: # DONE
@@ -2919,6 +3033,14 @@ classes:
                 name: getLocationInView
             '-previousLocationInView:':
                 name: getPreviousLocationInView
+            '-preciseLocationInView:':
+                name: getPreciseLocationInView
+            '-precisePreviousLocationInView:':
+                name: getPrecisePreviousLocationInView
+            '-azimuthAngleInView:':
+                name: getAzimuthAngleInView
+            '-azimuthUnitVectorInView:':
+                name: getAzimuthUnitVectorInView
     UITraitCollection: # DONE
         methods:
             '-init.*':
@@ -2938,6 +3060,26 @@ classes:
                 name: createWithHorizontalSizeClass
             '+traitCollectionWithVerticalSizeClass:':
                 name: createWithVerticalSizeClass
+            '+traitCollectionWithForceTouchCapability:':
+                name: create
+                constructor: true
+            '+traitCollectionWithUserInterfaceStyle:':
+                name: create
+                constructor: true
+            '+traitCollectionWithLayoutDirection:':
+                name: create
+                constructor: true
+            '+traitCollectionWithPreferredContentSizeCategory:':
+                name: create
+                constructor: true
+                parameters:
+                    preferredContentSizeCategory:
+                        type: UIContentSizeCategory
+            '+traitCollectionWithDisplayGamut:':
+                name: create
+                constructor: true
+    UIMutableApplicationShortcutItem: # DONE
+        skip_def_constructor: true
     UIMutableUserNotificationAction: {} # DONE
     UIMutableUserNotificationCategory: # DONE
         methods:
@@ -2996,6 +3138,9 @@ classes:
                 type: NSArray<NSLayoutConstraint>
             'layoutGuides':
                 type: NSArray<UILayoutGuide>
+            'layerClass':
+                type: 'Class<? extends CALayer>'
+                annotations: ['@WeaklyLinked']
         methods:
             '-init.*':
                 name: init
@@ -3011,10 +3156,6 @@ classes:
                 name: transition
             '+transitionWithView:duration:options:animations:completion:':
                 name: transition
-            '+layerClass':
-                name: getLayerClass
-                return_type: 'Class<? extends CALayer>'
-                annotations: ['@WeaklyLinked']
             '+performSystemAnimation:onViews:options:animations:completion:':
                 trim_after_first_colon: true
                 parameters:
@@ -3024,16 +3165,14 @@ classes:
                 name: animateKeyframes
             '+addKeyframeWithRelativeStartTime:relativeDuration:animations:':
                 name: addKeyframe
-            '+userInterfaceLayoutDirectionForSemanticContentAttribute:':
-                name: getUserInterfaceLayoutDirectionForSemanticContentAttribute
+            '+userInterfaceLayoutDirectionForSemanticContentAttribute.*':
+                name: getUserInterfaceLayoutDirection
             '+beginAnimations:context:':
                 trim_after_first_colon: true
             '+setAnimationTransition:forView:cache:':
                 trim_after_first_colon: true
             '+performWithoutAnimation:':
                 trim_after_first_colon: true
-            '+inheritedAnimationDuration':
-                property: true
             '-convertPoint:fromView:':
                 name: convertPointFromView
             '-convertPoint:toView:':
@@ -3072,8 +3211,6 @@ classes:
                 name: getContentHuggingPriority
             '-alignmentRectForFrame:':
                 name: getAlignmentRectForFrame
-            '-alignmentRectInsets':
-                name: getAlignmentRectInsets
             '-constraints':
                 name: getConstraints
                 return_type: NSArray<NSLayoutConstraint>
@@ -3082,8 +3219,6 @@ classes:
                 return_type: NSArray<NSLayoutConstraint>
             '-frameForAlignmentRect:':
                 name: getFrameForAlignmentRect
-            '-intrinsicContentSize':
-                name: getIntrinsicContentSize
             '-systemLayoutSizeFittingSize:':
                 name: getSystemLayoutSizeFittingSize
                 parameters:
@@ -3174,6 +3309,9 @@ classes:
                 getter: modalPresentationCapturesStatusBarAppearance
             'extendedLayoutIncludesOpaqueBars':
                 getter: extendedLayoutIncludesOpaqueBars
+            'previewActionItems':
+                type: List<UIPreviewActionItem>
+                marshaler: NSArray.AsListMarshaler
         methods:
             '-init.*':
                 name: init
@@ -3202,14 +3340,10 @@ classes:
                 name: willRotate
             '-willMoveToParentViewController:':
                 name: willMoveToParentViewController
-            '-editButtonItem':
-                name: getEditButtonItem
             '-decodeRestorableStateWithCoder:':
                 name: decodeRestorableState
             '-encodeRestorableStateWithCoder:':
                 name: encodeRestorableState
-            '-preferredInterfaceOrientationForPresentation':
-                name: getPreferredInterfaceOrientation
             '-segueForUnwindingToViewController:fromViewController:identifier:':
                 name: getSegueForUnwinding
             '-shouldPerformSegueWithIdentifier:sender:':
@@ -3259,16 +3393,6 @@ classes:
                 name: willAnimateFirstHalfOfRotation
             '-willAnimateSecondHalfOfRotationFromInterfaceOrientation:duration:':
                 name: willAnimateSecondHalfOfRotation
-            '-preferredStatusBarStyle':
-                property: true
-            '-preferredStatusBarUpdateAnimation':
-                property: true
-            '-childViewControllerForStatusBarStyle':
-                property: true
-            '-childViewControllerForStatusBarHidden':
-                property: true
-            '-transitionCoordinator':
-                property: true
             '-targetViewControllerForAction:sender:':
                 name: getTargetViewControllerForAction
             '-showViewController:sender:':
@@ -3294,7 +3418,23 @@ classes:
                 name: getChildViewControllerContainingSegueSource
             '-unwindForSegue:towardsViewController:':
                 name: unwind
+            '-registerForPreviewingWithDelegate:sourceView:':
+                name: registerForPreviewing
+            '-unregisterForPreviewingWithContext:':
+                name: unregisterForPreviewing
     UIViewPrintFormatter: {} # DONE
+    UIViewPropertyAnimator: # DONE
+        methods:
+            '-init.*':
+                name: init
+            '+runningPropertyAnimatorWithDuration:delay:options:animations:completion:':
+                name: getRunningPropertyAnimator
+            '-addAnimations.*':
+                trim_after_first_colon: true
+            '-addCompletion:':
+                trim_after_first_colon: true
+            '-continueAnimationWithTimingParameters:durationFactor:':
+                name: continueAnimation
     UIVisualEffect: # DONE
         skip_handle_constructor: false
     UIVisualEffectView: # DONE
@@ -3417,8 +3557,6 @@ protocols:
                 name: willPresent
             '-alertViewShouldEnableFirstOtherButton:':
                 name: shouldEnableFirstOtherButton
-    # UIAppearance is bound as a class with static methods rather than an interface.
-    # UIAppearance: {}
     UIAppearanceContainer: # DONE
         skip_adapter: true
     UIApplicationDelegate: # DONE
@@ -3452,9 +3590,6 @@ protocols:
                 name: handleOpenURL
             '-application:openURL:sourceApplication:annotation:':
                 name: openURL
-                parameters:
-                    annotation:
-                        type: NSPropertyList
             '-application:openURL:options:':
                 name: openURL
                 parameters:
@@ -3495,7 +3630,8 @@ protocols:
                 name: getViewController
                 parameters:
                     identifierComponents:
-                        type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                        type: List<String>
+                        marshaler: NSArray.AsStringListMarshaler
             '-application:willEncodeRestorableStateWithCoder:':
                 name: willEncodeRestorableState
             '-application:willFinishLaunchingWithOptions:':
@@ -3508,6 +3644,8 @@ protocols:
                 parameters:
                     userInfo:
                         type: UIRemoteNotification
+            '-application:performActionForShortcutItem:completionHandler:':
+                name: performAction
             '-application:performFetchWithCompletionHandler:':
                 name: performFetch
             '-application:handleEventsForBackgroundURLSession:completionHandler:':
@@ -3551,11 +3689,28 @@ protocols:
                         type: '@Block VoidBlock1<NSDictionary<?, ?>>'
             '-applicationShouldRequestHealthAuthorization:':
                 name: shouldRequestHealthAuthorization
+            '-application:userDidAcceptCloudKitShareWithMetadata:':
+                name: didAcceptCloudKitShare
+                exclude: true # >>>>> TODO need to update CloudKit
     UIBarPositioning: {} # DONE
     UIBarPositioningDelegate: # DONE
         methods:
             '-positionForBar:':
                 name: getPosition
+  #  UICloudSharingControllerDelegate: # DONE
+   #     methods:                    >>>>> TODO need to update CloudKit
+  #          '-cloudSharingController:failedToSaveShareWithError:':
+   #             name: failedToSaveShare
+   #         '-itemTitleForCloudSharingController:':
+   #             name: getItemTitle
+   #         '-itemThumbnailDataForCloudSharingController:':
+    #            name: getItemThumbnailData
+   #         '-itemTypeForCloudSharingController:':
+   #             name: getItemType
+   #         '-cloudSharingControllerDidSaveShare:':
+   #             name: didSaveShare
+   #         '-cloudSharingControllerDidStopSharing:':
+   #             name: didStopSharing
     UICollectionViewDataSource: # DONE
         methods:
             '-collectionView:cellForItemAtIndexPath:':
@@ -3570,6 +3725,12 @@ protocols:
                 name: canMoveItemAt
             '-collectionView:moveItemAtIndexPath:toIndexPath:':
                 name: moveItemAt
+    UICollectionViewDataSourcePrefetching: # DONE
+        methods:
+            '-collectionView:prefetchItemsAtIndexPaths:':
+                name: prefetchItems
+            '-collectionView:cancelPrefetchingForItemsAtIndexPaths:':
+                name: cancelPrefetchingForItems
     UICollectionViewDelegate: # DONE
         methods:
             '-collectionView:canPerformAction:forItemAtIndexPath:withSender:':
@@ -3606,6 +3767,14 @@ protocols:
                 name: getTargetIndexPathForMoveFromItem
             '-collectionView:targetContentOffsetForProposedContentOffset:':
                 name: getTargetContentOffsetForProposedContentOffset
+            '-collectionView:canFocusItemAtIndexPath:':
+                name: canFocusItem
+            '-collectionView:shouldUpdateFocusInContext:':
+                name: shouldUpdateFocus
+            '-collectionView:didUpdateFocusInContext:withAnimationCoordinator:':
+                name: didUpdateFocus
+            '-indexPathForPreferredFocusedViewInCollectionView:':
+                name: getIndexPathForPreferredFocusedView
     UICollectionViewDelegateFlowLayout: # DONE
         methods:
             '-collectionView:layout:insetForSectionAtIndex:':
@@ -3693,8 +3862,17 @@ protocols:
             '-dynamicAnimatorDidPause:':
                 name: didPause
     UIDynamicItem: {} # DONE
-    UIDynamicItemGroup: {}
-    UIFieldBehavior: {}
+    UIFocusEnvironment: # DONE
+        properties:
+            'preferredFocusEnvironments':
+                type: List<UIFocusEnvironment>
+                marshaler: NSArray.AsListMarshaler
+        methods:
+            '-shouldUpdateFocusInContext:':
+                name: shouldUpdateFocus
+            '-didUpdateFocusInContext:withAnimationCoordinator:':
+                name: didUpdateFocus
+    UIFocusItem: {} # DONE
     UIGestureRecognizerDelegate: # DONE
         methods:
             '-gestureRecognizer:shouldReceiveTouch:':
@@ -3707,11 +3885,15 @@ protocols:
                 name: shouldRequireFailure
             '-gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:':
                 name: shouldBeRequiredToFail
+            '-gestureRecognizer:shouldReceivePress:':
+                name: shouldReceivePress
     UIGuidedAccessRestrictionDelegate: # DONE
+        properties:
+            'guidedAccessRestrictionIdentifiers':
+                name: identifiers
+                type: List<String>
+                marshaler: NSArray.AsStringListMarshaler
         methods:
-            '-guidedAccessRestrictionIdentifiers':
-                name: getIdentifiers
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
             '-guidedAccessRestrictionWithIdentifier:didChangeState:':
                 name: didChangeState
             '-textForGuidedAccessRestrictionWithIdentifier:':
@@ -3754,17 +3936,14 @@ protocols:
                 name: didShowViewController
             '-navigationController:willShowViewController:animated:':
                 name: willShowViewController
-            '-navigationControllerSupportedInterfaceOrientations:':
-                name: getSupportedInterfaceOrientations
-                return_type: UIInterfaceOrientationMask
             '-navigationControllerPreferredInterfaceOrientationForPresentation:':
                 name: getPreferredInterfaceOrientation
             '-navigationController:interactionControllerForAnimationController:':
                 name: getInteractionController
             '-navigationController:animationControllerForOperation:fromViewController:toViewController:':
                 name: getAnimationController
-# Has a single static mehtod
-#    UIObjectRestoration: {}
+            '-navigationControllerSupportedInterfaceOrientations:':
+                name: getSupportedInterfaceOrientations
     UIPageViewControllerDataSource: # DONE
         methods:
             '-pageViewController:viewControllerAfterViewController:':
@@ -3838,6 +4017,17 @@ protocols:
                 name: didDismissPopover
             '-popoverPresentationController:willRepositionPopoverToRect:inView:':
                 name: willRepositionPopover
+    UIPreviewActionItem: {} # DONE
+    UIPreviewInteractionDelegate: # DONE
+        methods:
+            '-previewInteraction:didUpdatePreviewTransition:ended:':
+                name: didUpdatePreviewTransition
+            '-previewInteractionDidCancel:':
+                name: didCancel
+            '-previewInteractionShouldBegin:':
+                name: shouldBegin
+            '-previewInteraction:didUpdateCommitTransition:ended:':
+                name: didUpdateCommitTransition
     UIPrintInteractionControllerDelegate: # DONE
         methods:
             '-printInteractionController:choosePaper:':
@@ -4073,7 +4263,8 @@ protocols:
                 name: getNumberOfSections
             '-sectionIndexTitlesForTableView:':
                 name: getSectionIndexTitles
-                return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+                return_type: List<String>
+                return_marshaler: NSArray.AsStringListMarshaler
             '-tableView:commitEditingStyle:forRowAtIndexPath:':
                 name: commitEditingStyleForRow
             '-tableView:canMoveRowAtIndexPath:':
@@ -4092,6 +4283,12 @@ protocols:
                 name: getTitleForFooter
             '-tableView:titleForHeaderInSection:':
                 name: getTitleForHeader
+    UITableViewDataSourcePrefetching: # DONE
+        methods:
+            '-tableView:prefetchRowsAtIndexPaths:':
+                name: prefetchRows
+            '-tableView:cancelPrefetchingForRowsAtIndexPaths:':
+                name: cancelPrefetchingForRows
     UITableViewDelegate: # DONE
         methods:
             '-tableView:accessoryButtonTappedForRowWithIndexPath:':
@@ -4163,6 +4360,16 @@ protocols:
             '-tableView:editActionsForRowAtIndexPath:':
                 name: getEditActionsForRow
                 return_type: NSArray<UITableViewRowAction>
+            '-tableView:canFocusRowAtIndexPath:':
+                name: canFocusRow
+                default: true
+            '-tableView:shouldUpdateFocusInContext:':
+                name: shouldUpdateFocus
+                default: true
+            '-tableView:didUpdateFocusInContext:withAnimationCoordinator:':
+                name: didUpdateFocus
+            '-indexPathForPreferredFocusedViewInTableView:':
+                name: getIndexPathForPreferredFocusedView
     UITextDocumentProxy: # DONE
         methods:
             '-adjustTextPositionByCharacterOffset:':
@@ -4174,7 +4381,7 @@ protocols:
                 default: true
             '-textFieldDidBeginEditing:':
                 name: didBeginEditing
-            '-textFieldDidEndEditing:':
+            '-textFieldDidEndEditing.*':
                 name: didEndEditing
             '-textFieldShouldBeginEditing:':
                 name: shouldBeginEditing
@@ -4241,8 +4448,6 @@ protocols:
                 name: setMarkedText
             '-setBaseWritingDirection:forRange:':
                 name: setBaseWritingDirection
-            '-insertDictationResultPlaceholder':
-                property: true
             '-insertDictationResult:':
                 name: insertDictationResult
                 parameters:
@@ -4303,10 +4508,11 @@ protocols:
                 name: shouldBeginEditing
             '-textViewShouldEndEditing:':
                 name: shouldEndEditing
-            '-textView:shouldInteractWithURL:inRange:':
+            '-textView:shouldInteractWithURL:inRange.*':
                 name: shouldInteractWithURL
-            '-textView:shouldInteractWithTextAttachment:inRange:':
+            '-textView:shouldInteractWithTextAttachment:inRange.*':
                 name: shouldInteractWithTextAttachment
+    UITimingCurveProvider: {} # DONE
     UIToolbarDelegate: {} # DONE
     UITraitEnvironment: # DONE
         methods:
@@ -4321,6 +4527,22 @@ protocols:
                 name: didSave
             '-videoEditorControllerDidCancel:':
                 name: didCancel
+    UIViewAnimating: # DONE
+        methods:
+            '-startAnimationAfterDelay:':
+                name: startAnimation
+            '-stopAnimation:':
+                trim_after_first_colon: true
+            '-finishAnimationAtPosition:':
+                name: finishAnimation
+    UIViewImplicitlyAnimating: # DONE
+        methods:
+            '-addAnimations.*':
+                trim_after_first_colon: true
+            '-addCompletion:':
+                trim_after_first_colon: true
+            '-continueAnimationWithTimingParameters:durationFactor:':
+                name: continueAnimation
     UIViewControllerAnimatedTransitioning: # DONE
         methods:
             '-transitionDuration:':
@@ -4329,10 +4551,10 @@ protocols:
                 name: animateTransition
             '-animationEnded:':
                 name: animationEnded
+            '-interruptibleAnimatorForTransition:':
+                name: getInterruptibleAnimator
     UIViewControllerContextTransitioning: # DONE
         methods:
-            '-(containerView|presentationStyle|targetTransform)':
-                property: true
             '-updateInteractiveTransition:':
                 name: updateInteractiveTransition
             '-completeTransition:':
@@ -4357,8 +4579,13 @@ protocols:
                 property: true
             '-startInteractiveTransition:':
                 name: startInteractiveTransition
-# Contains a single static method
-#    UIViewControllerRestoration: {}
+    UIViewControllerPreviewingDelegate: # DONE
+        methods:
+            '-previewingContext:commitViewController:':
+                name: commitViewController
+            '-previewingContext:viewControllerForLocation:':
+                name: getViewControllerForLocation
+    UIViewControllerPreviewing: {} # DONE
     UIViewControllerTransitionCoordinator: # DONE
         methods:
             '-animateAlongsideTransition:completion:':
@@ -4367,6 +4594,8 @@ protocols:
                 name: animateAlongsideTransition
             '-notifyWhenInteractionEndsUsingBlock:':
                 name: notifyWhenInteractionEnds
+            '-notifyWhenInteractionChangesUsingBlock:':
+                name: notifyWhenInteractionChanges
     UIViewControllerTransitionCoordinatorContext: # DONE
         methods:
             '-(presentationStyle|initiallyInteractive|transitionDuration|percentComplete|completionVelocity|completionCurve|containerView|targetTransform)':
@@ -4493,6 +4722,9 @@ functions:
     UIAccessibility(FocusedElement):
         class: UIAccessibilityGlobals
         name: 'get#{g[0]}'
+    UIAccessibilityHearingDevicePairedEar:
+        class: UIAccessibilityGlobals
+        name: getHearingDevicePairingStatus
     UIAccessibility(.*):
         class: UIAccessibilityGlobals
         name: '#{g[0]}'
@@ -4633,17 +4865,11 @@ values:
         constructor_visibility: public
         name: '#{g[0]}'
         type: NSString
-    NS(.*)AttributeName:
+    UIAccessibilitySpeechAttribute(.*):
         dictionary: NSAttributedStringAttributes
         enum: NSAttributedStringAttribute
         constructor_visibility: public
-        name: '#{g[0]}'
-        type: NSString
-    UITextAttribute(Font):
-        dictionary: NSAttributedStringAttributes
-        enum: NSAttributedStringAttribute
-        constructor_visibility: public
-        name: 'Text#{g[0]}'
+        name: 'Speech#{g[0]}'
         type: NSString
         methods:
             Font:
@@ -4692,6 +4918,16 @@ values:
                 type: String
             SpeechPitch:
                 type: double
+    NS(.*)AttributeName:
+        dictionary: NSAttributedStringAttributes
+        enum: NSAttributedStringAttribute
+        name: '#{g[0]}'
+        type: NSString
+    UITextAttribute(Font):
+        dictionary: NSAttributedStringAttributes
+        enum: NSAttributedStringAttribute
+        name: 'Text#{g[0]}'
+        type: NSString
     UITextAttribute(.*):
         dictionary: NSAttributedStringAttributes
         enum: NSAttributedStringAttribute
@@ -4776,11 +5012,6 @@ values:
         visibility: protected
         type: long
         readonly: true
-    UIAccessibilitySpeechAttribute(.*):
-        dictionary: NSAttributedStringAttributes
-        enum: NSAttributedStringAttribute
-        name: 'Speech#{g[0]}'
-        type: NSString
 
     # UIActivity
     UIActivityType(.*):
@@ -4800,7 +5031,6 @@ values:
         dictionary: UIApplicationLaunchOptions
         name: '#{g[0]}'
         type: NSString
-        mutable: false
         methods:
             URL:
                 type: NSURL
@@ -4809,7 +5039,7 @@ values:
             LocalNotification:
                 type: UILocalNotification
             Annotation:
-                type: NSPropertyList
+                type: NSObject
             Location:
                 name: locationStart
                 type: boolean
@@ -4825,6 +5055,11 @@ values:
             UserActivityDictionary:
                 name: UserActivityInfo
                 type: UIApplicationLaunchOptionsUserActivityInfo
+            ShortcutItem:
+                type: UIApplicationShortcutItem
+      #      CloudKitShareMetadata:
+      #          type: CKShareMetadata               >>>>> TODO need to update CloudKit
+
     UIApplication(.*Notification):
         class: UIApplication
         name: '#{g[0]}'
@@ -4879,12 +5114,23 @@ values:
             OpenInPlace:
                 name: opensInPlace
                 type: boolean
+            UniversalLinksOnly:
+                type: boolean
+    UIApplicationOpenURLOption(UniversalLinksOnly):
+        dictionary: UIApplicationOpenURLOptions
+        name: '#{g[0]}'
+        type: NSString
 
     # UICollectionView
     UICollectionElementKind(.*):
         enum: UICollectionElementKind
         name: '#{g[0]}'
         type: NSString
+
+    # UICollectionViewFlowLayout
+    UICollectionViewFlowLayout(AutomaticSize):
+        class: UICollectionViewFlowLayout
+        name: 'get#{g[0]}'
 
     # UIDevice
     UIDevice(.*Notification):
@@ -5041,6 +5287,15 @@ values:
         class: UIPasteboard
         name: '#{g[0]}'
         type: NSString
+    UIPasteboardOption(.*):
+        dictionary: UIPasteboardOptions
+        name: '#{g[0]}'
+        type: NSString
+        methods:
+            ExpirationDate:
+                type: NSDate
+            LocalOnly:
+                type: boolean
     UIPasteboardChanged(.*)Key:
         dictionary: UIPasteboardChangedNotification
         name: '#{g[0]}'
@@ -5053,6 +5308,9 @@ values:
             TypesRemoved:
                 name: removedTypes
                 type: List<String>
+    UIPasteboardTypeAutomatic:
+        class: UIPasteboard
+        name: getAutomaticType
     UIPasteboardNameGeneral:
         exclude: true # use UIPasteboard.getGeneralPasteboard() instead
     UI(PasteboardNameFind):
@@ -5109,6 +5367,11 @@ values:
         class: UITextField
         name: '#{g[0]}'
         type: NSString
+    UITextField(DidEndEditingReasonKey):
+        class: UITextField
+        name: '#{g[0]}'
+        type: NSString
+        visibility: protected
 
     # UITextInput
     UITextInputText(.*)Key:
@@ -5123,6 +5386,10 @@ values:
                 type: UIColor
             Font:
                 type: UIFont
+    UITextContentType(.*):
+        enum: UITextContentType
+        name: '#{g[0]}'
+        type: NSString
 
     # UITextInputMode
     UITextInput(.*)Notification:

--- a/compiler/cocoatouch/src/main/bro-gen/uikit.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/uikit.yaml
@@ -99,6 +99,7 @@ enums:
     UIImagePickerControllerSourceType: {}
     UIImageRenderingMode: {prefix: UIImageRenderingMode}
     UIImageResizingMode: {}
+    UIImpactFeedbackStyle: {}
     UIInputViewStyle: {}
     UIInterfaceOrientation: {}
     UIInterfaceOrientationMask: {}
@@ -112,6 +113,7 @@ enums:
     UIModalPresentationStyle: {}
     UIModalTransitionStyle: {}
     UINavigationControllerOperation: {}
+    UINotificationFeedbackType: {}
     UIPageViewControllerNavigationDirection: {}
     UIPageViewControllerNavigationOrientation: {}
     UIPageViewControllerSpineLocation: {}
@@ -1567,6 +1569,7 @@ classes:
                 name: getCoalescedTouches
             '-predictedTouchesForTouch:':
                 name: getPredictedTouches
+    UIFeedbackGenerator: {} # DONE
     UIFieldBehavior: # DONE
         properties:
             'items':
@@ -1886,6 +1889,10 @@ classes:
         methods:
             '-init.*':
                 name: init
+    UIImpactFeedbackGenerator: # DONE
+        methods:
+            '-init.*':
+                name: init
     UIInputView: # DONE
         methods:
             '-init.*':
@@ -2109,6 +2116,10 @@ classes:
                 parameters:
                     optionsOrNil:
                         type: UINibLoadingOptions
+    UINotificationFeedbackGenerator: # DONE
+        methods:
+            '-notificationOccurred:':
+                trim_after_first_colon: true
     UIPageControl: # DONE
         methods:
             '-sizeForNumberOfPages:':
@@ -2634,6 +2645,7 @@ classes:
                         type: 'NSDictionary<NSString, ?>'
             '-setContentPositionAdjustment:forSegmentType:barMetrics:':
                 name: setContentPositionAdjustment
+    UISelectionFeedbackGenerator: {} # DONE
     UISimpleTextPrintFormatter: # DONE
         methods:
             '-init.*':

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSBundleResourceRequest.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSBundleResourceRequest.java
@@ -66,7 +66,7 @@ import org.robovm.apple.dispatch.*;
     /*<bind>*/static { ObjCRuntime.bind(NSBundleResourceRequest.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public NSBundleResourceRequest() {}
+    protected NSBundleResourceRequest() {}
     protected NSBundleResourceRequest(Handle h, long handle) { super(h, handle); }
     protected NSBundleResourceRequest(SkipInit skipInit) { super(skipInit); }
     public NSBundleResourceRequest(@org.robovm.rt.bro.annotation.Marshaler(NSSet.AsStringSetMarshaler.class) Set<String> tags) { super((SkipInit) null); initObject(init(tags)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSCalendar.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSCalendar.java
@@ -64,7 +64,7 @@ import org.robovm.apple.dispatch.*;
     /*<bind>*/static { ObjCRuntime.bind(NSCalendar.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public NSCalendar() {}
+    protected NSCalendar() {}
     protected NSCalendar(Handle h, long handle) { super(h, handle); }
     protected NSCalendar(SkipInit skipInit) { super(skipInit); }
     public NSCalendar(NSCalendarIdentifier ident) { super((SkipInit) null); initObject(init(ident)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSCocoaErrorCode.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSCocoaErrorCode.java
@@ -76,8 +76,6 @@ public enum /*<name>*/NSCocoaErrorCode/*</name>*/ implements NSErrorCode {
      * @since Available in iOS 4.0 and later.
      */
     FileWriteVolumeReadOnly(642L),
-    FileManagerUnmountUnknown(768L),
-    FileManagerUnmountBusy(769L),
     KeyValueValidation(1024L),
     Formatting(2048L),
     UserCancelled(3072L),

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDecimalNumberHandler.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDecimalNumberHandler.java
@@ -53,7 +53,7 @@ import org.robovm.apple.dispatch.*;
     protected NSDecimalNumberHandler(Handle h, long handle) { super(h, handle); }
     protected NSDecimalNumberHandler(SkipInit skipInit) { super(skipInit); }
     public NSDecimalNumberHandler(NSRoundingMode roundingMode, short scale, boolean exact, boolean overflow, boolean underflow, boolean divideByZero) { super((SkipInit) null); initObject(init(roundingMode, scale, exact, overflow, underflow, divideByZero)); }
-    public NSDecimalNumberHandler(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    public NSDecimalNumberHandler(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     
@@ -73,6 +73,6 @@ import org.robovm.apple.dispatch.*;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSException.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSException.java
@@ -49,7 +49,7 @@ import org.robovm.apple.security.*;
     protected NSException(Handle h, long handle) { super(h, handle); }
     protected NSException(SkipInit skipInit) { super(skipInit); }
     public NSException(String aName, String aReason, NSDictionary<?, ?> aUserInfo) { super((SkipInit) null); initObject(init(aName, aReason, aUserInfo)); }
-    public NSException(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    public NSException(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "name")
@@ -131,6 +131,6 @@ import org.robovm.apple.security.*;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFileManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFileManager.java
@@ -146,7 +146,7 @@ import org.robovm.apple.dispatch.*;
     /**
      * @since Available in iOS 4.0 and later.
      */
-    public NSArray<NSURL> getContentsOfDirectoryAtURL(NSURL url, @org.robovm.rt.bro.annotation.Marshaler(NSURLFileSystemProperty.AsListMarshaler.class) List<NSURLFileSystemProperty> keys, NSDirectoryEnumerationOptions mask) throws NSErrorException {
+    public NSArray<NSURL> getContentsOfDirectoryAtURL(NSURL url, List<NSURLFileSystemProperty> keys, NSDirectoryEnumerationOptions mask) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        NSArray<NSURL> result = getContentsOfDirectoryAtURL(url, keys, mask, ptr);
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
@@ -277,7 +277,7 @@ import org.robovm.apple.dispatch.*;
     /**
      * @since Available in iOS 2.0 and later.
      */
-    public @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getSubpathsOfDirectoryAtPath(String path) throws NSErrorException {
+    public List<String> getSubpathsOfDirectoryAtPath(String path) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        List<String> result = getSubpathsOfDirectoryAtPath(path, ptr);
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFilePresenterAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFilePresenterAdapter.java
@@ -56,8 +56,6 @@ import org.robovm.apple.dispatch.*;
     public NSURL getPresentedItemURL() { return null; }
     @NotImplemented("presentedItemOperationQueue")
     public NSOperationQueue getPresentedItemOperationQueue() { return null; }
-    @NotImplemented("primaryPresentedItemURL")
-    public NSURL getPrimaryPresentedItemURL() { return null; }
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFormatter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFormatter.java
@@ -53,7 +53,7 @@ import org.robovm.apple.dispatch.*;
     public NSFormatter() {}
     protected NSFormatter(Handle h, long handle) { super(h, handle); }
     protected NSFormatter(SkipInit skipInit) { super(skipInit); }
-    public NSFormatter(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    public NSFormatter(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     
@@ -63,6 +63,6 @@ import org.robovm.apple.dispatch.*;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSHashTable.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSHashTable.java
@@ -115,7 +115,7 @@ import org.robovm.apple.foundation.NSSet.SetAdapter;
     protected NSHashTable(Handle h, long handle) { super(h, handle); }
     protected NSHashTable(SkipInit skipInit) { super(skipInit); }
     public NSHashTable(NSHashTableOptions options, @MachineSizedUInt long initialCapacity) { super((SkipInit) null); initObject(init(options, initialCapacity)); }
-    public NSHashTable(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    public NSHashTable(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     
     private static void checkNull(Object o) {
@@ -234,6 +234,6 @@ import org.robovm.apple.foundation.NSSet.SetAdapter;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMapTable.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMapTable.java
@@ -180,7 +180,7 @@ import org.robovm.apple.foundation.NSObject.SkipInit;
     protected NSMapTable(Handle h, long handle) { super(h, handle); }
     protected NSMapTable(SkipInit skipInit) { super(skipInit); }
     public NSMapTable(NSMapTableOptions keyOptions, NSMapTableOptions valueOptions, @MachineSizedUInt long initialCapacity) { super((SkipInit) null); initObject(init(keyOptions, valueOptions, initialCapacity)); }
-    public NSMapTable(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    public NSMapTable(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "count")
@@ -291,6 +291,6 @@ import org.robovm.apple.foundation.NSObject.SkipInit;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMeasurement.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMeasurement.java
@@ -52,7 +52,7 @@ import org.robovm.apple.dispatch.*;
     /*<bind>*/static { ObjCRuntime.bind(NSMeasurement.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public NSMeasurement() {}
+    protected NSMeasurement() {}
     protected NSMeasurement(Handle h, long handle) { super(h, handle); }
     protected NSMeasurement(SkipInit skipInit) { super(skipInit); }
     public NSMeasurement(double doubleValue, T unit) { super((SkipInit) null); initObject(init(doubleValue, unit)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMetadataItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMetadataItem.java
@@ -52,7 +52,7 @@ import org.robovm.apple.dispatch.*;
     /*<bind>*/static { ObjCRuntime.bind(NSMetadataItem.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public NSMetadataItem() {}
+    protected NSMetadataItem() {}
     protected NSMetadataItem(Handle h, long handle) { super(h, handle); }
     protected NSMetadataItem(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSPort.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSPort.java
@@ -64,7 +64,7 @@ import org.robovm.apple.dispatch.*;
     public NSPort() {}
     protected NSPort(Handle h, long handle) { super(h, handle); }
     protected NSPort(SkipInit skipInit) { super(skipInit); }
-    public NSPort(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    public NSPort(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "isValid")
@@ -100,6 +100,6 @@ import org.robovm.apple.dispatch.*;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSSearchPathDirectory.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSSearchPathDirectory.java
@@ -93,14 +93,12 @@ public enum /*<name>*/NSSearchPathDirectory/*</name>*/ implements ValuedEnum {
      * @since Available in iOS 4.0 and later.
      */
     PreferencePanesDirectory(22L),
-    ApplicationScriptsDirectory(23L),
     /**
      * @since Available in iOS 4.0 and later.
      */
     ItemReplacementDirectory(99L),
     AllApplicationsDirectory(100L),
-    AllLibrariesDirectory(101L),
-    TrashDirectory(102L);
+    AllLibrariesDirectory(101L);
     /*</values>*/
 
     private final long n;

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURL.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURL.java
@@ -428,7 +428,7 @@ import org.robovm.apple.foundation.NSError.NSErrorPtr;
     /**
      * @since Available in iOS 4.0 and later.
      */
-    public NSURLProperties getResourceValues(@org.robovm.rt.bro.annotation.Marshaler(NSURLProperty.AsListMarshaler.class) List<NSURLProperty> keys) throws NSErrorException {
+    public NSURLProperties getResourceValues(List<NSURLProperty> keys) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        NSURLProperties result = getResourceValues(keys, ptr);
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
@@ -485,7 +485,7 @@ import org.robovm.apple.foundation.NSError.NSErrorPtr;
     /**
      * @since Available in iOS 4.0 and later.
      */
-    public NSData toBookmarkData(NSURLBookmarkCreationOptions options, @org.robovm.rt.bro.annotation.Marshaler(NSURLProperty.AsListMarshaler.class) List<NSURLProperty> keys, NSURL relativeURL) throws NSErrorException {
+    public NSData toBookmarkData(NSURLBookmarkCreationOptions options, List<NSURLProperty> keys, NSURL relativeURL) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        NSData result = toBookmarkData(options, keys, relativeURL, ptr);
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
@@ -561,7 +561,7 @@ import org.robovm.apple.foundation.NSError.NSErrorPtr;
     /**
      * @since Available in iOS 8.0 and later.
      */
-    public NSURLProperties getPromisedItemResourceValues(@org.robovm.rt.bro.annotation.Marshaler(NSURLProperty.AsListMarshaler.class) List<NSURLProperty> keys) throws NSErrorException {
+    public NSURLProperties getPromisedItemResourceValues(List<NSURLProperty> keys) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        NSURLProperties result = getPromisedItemResourceValues(keys, ptr);
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLBookmarkCreationOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLBookmarkCreationOptions.java
@@ -55,8 +55,6 @@ public final class /*<name>*/NSURLBookmarkCreationOptions/*</name>*/ extends Bit
     public static final NSURLBookmarkCreationOptions PreferFileIDResolution = new NSURLBookmarkCreationOptions(256L);
     public static final NSURLBookmarkCreationOptions MinimalBookmark = new NSURLBookmarkCreationOptions(512L);
     public static final NSURLBookmarkCreationOptions SuitableForBookmarkFile = new NSURLBookmarkCreationOptions(1024L);
-    public static final NSURLBookmarkCreationOptions WithSecurityScope = new NSURLBookmarkCreationOptions(2048L);
-    public static final NSURLBookmarkCreationOptions SecurityScopeAllowOnlyReadAccess = new NSURLBookmarkCreationOptions(4096L);
     /*</values>*/
 
     private static final /*<name>*/NSURLBookmarkCreationOptions/*</name>*/[] values = _values(/*<name>*/NSURLBookmarkCreationOptions/*</name>*/.class);

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLBookmarkResolutionOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLBookmarkResolutionOptions.java
@@ -49,7 +49,6 @@ public final class /*<name>*/NSURLBookmarkResolutionOptions/*</name>*/ extends B
     public static final NSURLBookmarkResolutionOptions None = new NSURLBookmarkResolutionOptions(0L);
     public static final NSURLBookmarkResolutionOptions WithoutUI = new NSURLBookmarkResolutionOptions(256L);
     public static final NSURLBookmarkResolutionOptions WithoutMounting = new NSURLBookmarkResolutionOptions(512L);
-    public static final NSURLBookmarkResolutionOptions WithSecurityScope = new NSURLBookmarkResolutionOptions(1024L);
     /*</values>*/
 
     private static final /*<name>*/NSURLBookmarkResolutionOptions/*</name>*/[] values = _values(/*<name>*/NSURLBookmarkResolutionOptions/*</name>*/.class);

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSUserActivity.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSUserActivity.java
@@ -52,7 +52,7 @@ import org.robovm.apple.dispatch.*;
     /*<bind>*/static { ObjCRuntime.bind(NSUserActivity.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public NSUserActivity() {}
+    protected NSUserActivity() {}
     protected NSUserActivity(Handle h, long handle) { super(h, handle); }
     protected NSUserActivity(SkipInit skipInit) { super(skipInit); }
     public NSUserActivity(String activityType) { super((SkipInit) null); initObject(init(activityType)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/social/SLComposeServiceViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/social/SLComposeServiceViewController.java
@@ -48,6 +48,7 @@ import org.robovm.apple.accounts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public SLComposeServiceViewController() {}
+    protected SLComposeServiceViewController(Handle h, long handle) { super(h, handle); }
     protected SLComposeServiceViewController(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
@@ -107,13 +108,27 @@ import org.robovm.apple.accounts.*;
     @Method(selector = "textViewDidChangeSelection:")
     public native void didChangeSelection(UITextView textView);
     /**
-     * @since Available in iOS 7.0 and later.
+     * @since Available in iOS 10.0 and later.
      */
+    @Method(selector = "textView:shouldInteractWithURL:inRange:interaction:")
+    public native boolean shouldInteractWithURL(UITextView textView, NSURL URL, @ByVal NSRange characterRange, UITextItemInteraction interaction);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "textView:shouldInteractWithTextAttachment:inRange:interaction:")
+    public native boolean shouldInteractWithTextAttachment(UITextView textView, NSTextAttachment textAttachment, @ByVal NSRange characterRange, UITextItemInteraction interaction);
+    /**
+     * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
     @Method(selector = "textView:shouldInteractWithURL:inRange:")
     public native boolean shouldInteractWithURL(UITextView textView, NSURL URL, @ByVal NSRange characterRange);
     /**
      * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @Method(selector = "textView:shouldInteractWithTextAttachment:inRange:")
     public native boolean shouldInteractWithTextAttachment(UITextView textView, NSTextAttachment textAttachment, @ByVal NSRange characterRange);
     @Method(selector = "scrollViewDidScroll:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/social/SLComposeSheetConfigurationItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/social/SLComposeSheetConfigurationItem.java
@@ -48,6 +48,7 @@ import org.robovm.apple.accounts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public SLComposeSheetConfigurationItem() {}
+    protected SLComposeSheetConfigurationItem(Handle h, long handle) { super(h, handle); }
     protected SLComposeSheetConfigurationItem(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/social/SLComposeViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/social/SLComposeViewController.java
@@ -48,8 +48,9 @@ import org.robovm.apple.accounts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public SLComposeViewController() {}
+    protected SLComposeViewController(Handle h, long handle) { super(h, handle); }
     protected SLComposeViewController(SkipInit skipInit) { super(skipInit); }
-    public SLComposeViewController(SLServiceType serviceType) { super(create(serviceType)); retain(getHandle()); }
+    public SLComposeViewController(SLServiceType serviceType) { super((Handle) null, create(serviceType)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "serviceType")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/social/SLRequest.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/social/SLRequest.java
@@ -48,8 +48,9 @@ import org.robovm.apple.accounts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public SLRequest() {}
+    protected SLRequest(Handle h, long handle) { super(h, handle); }
     protected SLRequest(SkipInit skipInit) { super(skipInit); }
-    public SLRequest(SLServiceType serviceType, SLRequestMethod requestMethod, NSURL url, NSDictionary<NSString, ?> parameters) { super(create(serviceType, requestMethod, url, parameters)); retain(getHandle()); }
+    public SLRequest(SLServiceType serviceType, SLRequestMethod requestMethod, NSURL url, NSDictionary<NSString, ?> parameters) { super((Handle) null, create(serviceType, requestMethod, url, parameters)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @WeaklyLinked

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/systemconfiguration/SCNetworkReachability.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/systemconfiguration/SCNetworkReachability.java
@@ -76,9 +76,9 @@ import org.robovm.apple.dispatch.*;
     /**
      * @since Available in iOS 2.0 and later.
      */
-    public static SCNetworkReachability create(java.net.InetSocketAddress address) {
+    public SCNetworkReachability(java.net.InetSocketAddress address) {
         long refconId = SCNetworkReachability.refconId.getAndIncrement();
-        SCNetworkReachability reachability;
+        long reachability;
         
         java.net.InetAddress addr = address.getAddress();
         if (addr instanceof java.net.Inet4Address) {
@@ -88,13 +88,13 @@ import org.robovm.apple.dispatch.*;
         } else {
             throw new IllegalArgumentException("address is not a valid IPv4 or IPv6 address!");
         }
-        reachability.localRefconId = refconId;
-        return reachability;
+        localRefconId = refconId;
+        setHandle(reachability);
     }
     /**
      * @since Available in iOS 2.0 and later.
      */
-    public static SCNetworkReachability create(java.net.InetSocketAddress localAddress, java.net.InetSocketAddress remoteAddress) {
+    public SCNetworkReachability(java.net.InetSocketAddress localAddress, java.net.InetSocketAddress remoteAddress) {
         long refconId = SCNetworkReachability.refconId.getAndIncrement();
         Struct<?> l;
         Struct<?> r;
@@ -112,19 +112,19 @@ import org.robovm.apple.dispatch.*;
         } else {
             throw new IllegalArgumentException("remoteAddress is not a valid IPv4 or IPv6 address!");
         }
-        SCNetworkReachability reachability = create(null, l, r);
-        reachability.localRefconId = refconId;
-        return reachability;
+        long reachability = create(null, l, r);
+        localRefconId = refconId;
+        setHandle(reachability);
     }
     /**
      * @since Available in iOS 2.0 and later.
      */
-    public static SCNetworkReachability create(String nodename) {
+    public SCNetworkReachability(String nodename) {
         long refconId = SCNetworkReachability.refconId.getAndIncrement();
         BytePtr ptr = BytePtr.toBytePtrZ(nodename);
-        SCNetworkReachability reachability = create(null, ptr);
-        reachability.localRefconId = refconId;
-        return reachability;
+        long reachability = create(null, ptr);
+        localRefconId = refconId;
+        setHandle(reachability);
     }
     /**
      * @since Available in iOS 2.0 and later.
@@ -150,17 +150,17 @@ import org.robovm.apple.dispatch.*;
      * @since Available in iOS 2.0 and later.
      */
     @Bridge(symbol="SCNetworkReachabilityCreateWithAddress", optional=true)
-    private static native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) SCNetworkReachability create(CFAllocator allocator, Struct<?> address);
+    private static native @Pointer long create(CFAllocator allocator, Struct<?> address);
     /**
      * @since Available in iOS 2.0 and later.
      */
     @Bridge(symbol="SCNetworkReachabilityCreateWithAddressPair", optional=true)
-    private static native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) SCNetworkReachability create(CFAllocator allocator, Struct<?> localAddress, Struct<?> remoteAddress);
+    private static native @Pointer long create(CFAllocator allocator, Struct<?> localAddress, Struct<?> remoteAddress);
     /**
      * @since Available in iOS 2.0 and later.
      */
     @Bridge(symbol="SCNetworkReachabilityCreateWithName", optional=true)
-    private static native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) SCNetworkReachability create(CFAllocator allocator, BytePtr nodename);
+    private static native @Pointer long create(CFAllocator allocator, BytePtr nodename);
     /**
      * @since Available in iOS 2.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSAttributedStringAttribute.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSAttributedStringAttribute.java
@@ -94,6 +94,18 @@ import org.robovm.apple.corelocation.*;
 
     /*<constants>*/
     /**
+     * @since Available in iOS 7.0 and later.
+     */
+    public static final NSAttributedStringAttribute SpeechPunctuation = new NSAttributedStringAttribute("SpeechPunctuation");
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    public static final NSAttributedStringAttribute SpeechLanguage = new NSAttributedStringAttribute("SpeechLanguage");
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    public static final NSAttributedStringAttribute SpeechPitch = new NSAttributedStringAttribute("SpeechPitch");
+    /**
      * @since Available in iOS 5.0 and later.
      * @deprecated Deprecated in iOS 7.0.
      */
@@ -117,18 +129,6 @@ import org.robovm.apple.corelocation.*;
      */
     @Deprecated
     public static final NSAttributedStringAttribute TextShadowOffset = new NSAttributedStringAttribute("TextShadowOffset");
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    public static final NSAttributedStringAttribute SpeechPunctuation = new NSAttributedStringAttribute("SpeechPunctuation");
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    public static final NSAttributedStringAttribute SpeechLanguage = new NSAttributedStringAttribute("SpeechLanguage");
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    public static final NSAttributedStringAttribute SpeechPitch = new NSAttributedStringAttribute("SpeechPitch");
     /**
      * @since Available in iOS 6.0 and later.
      */
@@ -215,7 +215,7 @@ import org.robovm.apple.corelocation.*;
     public static final NSAttributedStringAttribute VerticalGlyphForm = new NSAttributedStringAttribute("VerticalGlyphForm");
     /*</constants>*/
     
-    private static /*<name>*/NSAttributedStringAttribute/*</name>*/[] values = new /*<name>*/NSAttributedStringAttribute/*</name>*/[] {/*<value_list>*/TextFont, TextColor, TextShadowColor, TextShadowOffset, SpeechPunctuation, SpeechLanguage, SpeechPitch, Font, ParagraphStyle, ForegroundColor, BackgroundColor, Ligature, Kern, StrikethroughStyle, UnderlineStyle, StrokeColor, StrokeWidth, Shadow, TextEffect, Attachment, Link, BaselineOffset, UnderlineColor, StrikethroughColor, Obliqueness, Expansion, WritingDirection, VerticalGlyphForm/*</value_list>*/};
+    private static /*<name>*/NSAttributedStringAttribute/*</name>*/[] values = new /*<name>*/NSAttributedStringAttribute/*</name>*/[] {/*<value_list>*/SpeechPunctuation, SpeechLanguage, SpeechPitch, TextFont, TextColor, TextShadowColor, TextShadowOffset, Font, ParagraphStyle, ForegroundColor, BackgroundColor, Ligature, Kern, StrikethroughStyle, UnderlineStyle, StrokeColor, StrokeWidth, Shadow, TextEffect, Attachment, Link, BaselineOffset, UnderlineColor, StrikethroughColor, Obliqueness, Expansion, WritingDirection, VerticalGlyphForm/*</value_list>*/};
     
     /*<name>*/NSAttributedStringAttribute/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -238,6 +238,21 @@ import org.robovm.apple.corelocation.*;
     	static { Bro.bind(Values.class); }
 
         /*<values>*/
+        /**
+         * @since Available in iOS 7.0 and later.
+         */
+        @GlobalValue(symbol="UIAccessibilitySpeechAttributePunctuation", optional=true)
+        public static native NSString SpeechPunctuation();
+        /**
+         * @since Available in iOS 7.0 and later.
+         */
+        @GlobalValue(symbol="UIAccessibilitySpeechAttributeLanguage", optional=true)
+        public static native NSString SpeechLanguage();
+        /**
+         * @since Available in iOS 7.0 and later.
+         */
+        @GlobalValue(symbol="UIAccessibilitySpeechAttributePitch", optional=true)
+        public static native NSString SpeechPitch();
         /**
          * @since Available in iOS 5.0 and later.
          * @deprecated Deprecated in iOS 7.0.
@@ -266,21 +281,6 @@ import org.robovm.apple.corelocation.*;
         @Deprecated
         @GlobalValue(symbol="UITextAttributeTextShadowOffset", optional=true)
         public static native NSString TextShadowOffset();
-        /**
-         * @since Available in iOS 7.0 and later.
-         */
-        @GlobalValue(symbol="UIAccessibilitySpeechAttributePunctuation", optional=true)
-        public static native NSString SpeechPunctuation();
-        /**
-         * @since Available in iOS 7.0 and later.
-         */
-        @GlobalValue(symbol="UIAccessibilitySpeechAttributeLanguage", optional=true)
-        public static native NSString SpeechLanguage();
-        /**
-         * @since Available in iOS 7.0 and later.
-         */
-        @GlobalValue(symbol="UIAccessibilitySpeechAttributePitch", optional=true)
-        public static native NSString SpeechPitch();
         /**
          * @since Available in iOS 6.0 and later.
          */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSAttributedStringExtensions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSAttributedStringExtensions.java
@@ -58,7 +58,7 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 9.0 and later.
      */
-    public static @Pointer long init(NSAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr dict) throws NSErrorException {
+    public static @Pointer long init(NSAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        long result = init(thiz, url, options, dict, ptr);
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
@@ -68,11 +68,11 @@ import org.robovm.apple.corelocation.*;
      * @since Available in iOS 9.0 and later.
      */
     @Method(selector = "initWithURL:options:documentAttributes:error:")
-    private static native @Pointer long init(NSAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr dict, NSError.NSErrorPtr error);
+    private static native @Pointer long init(NSAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict, NSError.NSErrorPtr error);
     /**
      * @since Available in iOS 7.0 and later.
      */
-    public static @Pointer long init(NSAttributedString thiz, NSData data, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr dict) throws NSErrorException {
+    public static @Pointer long init(NSAttributedString thiz, NSData data, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        long result = init(thiz, data, options, dict, ptr);
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
@@ -82,7 +82,7 @@ import org.robovm.apple.corelocation.*;
      * @since Available in iOS 7.0 and later.
      */
     @Method(selector = "initWithData:options:documentAttributes:error:")
-    private static native @Pointer long init(NSAttributedString thiz, NSData data, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr dict, NSError.NSErrorPtr error);
+    private static native @Pointer long init(NSAttributedString thiz, NSData data, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict, NSError.NSErrorPtr error);
     /**
      * @since Available in iOS 7.0 and later.
      */
@@ -121,7 +121,7 @@ import org.robovm.apple.corelocation.*;
      * @deprecated Deprecated in iOS 9.0.
      */
     @Deprecated
-    public static @Pointer long initWithFileURL(NSAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr dict) throws NSErrorException {
+    public static @Pointer long initWithFileURL(NSAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        long result = initWithFileURL(thiz, url, options, dict, ptr);
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
@@ -133,7 +133,7 @@ import org.robovm.apple.corelocation.*;
      */
     @Deprecated
     @Method(selector = "initWithFileURL:options:documentAttributes:error:")
-    private static native @Pointer long initWithFileURL(NSAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr dict, NSError.NSErrorPtr error);
+    private static native @Pointer long initWithFileURL(NSAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes options, NSDictionary.NSDictionaryPtr<?, ?> dict, NSError.NSErrorPtr error);
     /**
      * @since Available in iOS 6.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSDataAsset.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSDataAsset.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSDataAsset() {}
+    protected NSDataAsset(Handle h, long handle) { super(h, handle); }
     protected NSDataAsset(SkipInit skipInit) { super(skipInit); }
     public NSDataAsset(String name) { super((SkipInit) null); initObject(init(name)); }
     public NSDataAsset(String name, NSBundle bundle) { super((SkipInit) null); initObject(init(name, bundle)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSDataAsset.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSDataAsset.java
@@ -50,7 +50,7 @@ import org.robovm.apple.corelocation.*;
     /*<bind>*/static { ObjCRuntime.bind(NSDataAsset.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public NSDataAsset() {}
+    protected NSDataAsset() {}
     protected NSDataAsset(Handle h, long handle) { super(h, handle); }
     protected NSDataAsset(SkipInit skipInit) { super(skipInit); }
     public NSDataAsset(String name) { super((SkipInit) null); initObject(init(name)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSFileProviderExtension.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSFileProviderExtension.java
@@ -51,17 +51,17 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSFileProviderExtension() {}
+    protected NSFileProviderExtension(Handle h, long handle) { super(h, handle); }
     protected NSFileProviderExtension(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
-    
+    @Property(selector = "providerIdentifier")
+    public native String getProviderIdentifier();
+    @Property(selector = "documentStorageURL")
+    public native NSURL getDocumentStorageURL();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
-    @Method(selector = "providerIdentifier")
-    public native String getProviderIdentifier();
-    @Method(selector = "documentStorageURL")
-    public native NSURL getDocumentStorageURL();
     @Method(selector = "URLForItemWithPersistentIdentifier:")
     public native NSURL getURLForItem(String identifier);
     @Method(selector = "persistentIdentifierForItemAtURL:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSIndexPathExtensions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSIndexPathExtensions.java
@@ -51,26 +51,26 @@ import org.robovm.apple.corelocation.*;
     private NSIndexPathExtensions() {}
     /*</constructors>*/
     /*<properties>*/
-    @Property(selector = "section")
-    public static native @MachineSizedSInt long getSection(NSIndexPath thiz);
-    @Property(selector = "row")
-    public static native @MachineSizedSInt long getRow(NSIndexPath thiz);
     /**
      * @since Available in iOS 6.0 and later.
      */
     @Property(selector = "item")
     public static native @MachineSizedSInt long getItem(NSIndexPath thiz);
+    @Property(selector = "section")
+    public static native @MachineSizedSInt long getSection(NSIndexPath thiz);
+    @Property(selector = "row")
+    public static native @MachineSizedSInt long getRow(NSIndexPath thiz);
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
-    @Method(selector = "indexPathForRow:inSection:")
-    protected static native NSIndexPath createIndexPathForRowInSection(ObjCClass clazz, @MachineSizedSInt long row, @MachineSizedSInt long section);
-    public static NSIndexPath createIndexPathForRowInSection(@MachineSizedSInt long row, @MachineSizedSInt long section) { return createIndexPathForRowInSection(ObjCClass.getByType(NSIndexPath.class), row, section); }
     /**
      * @since Available in iOS 6.0 and later.
      */
     @Method(selector = "indexPathForItem:inSection:")
     protected static native NSIndexPath createIndexPathForItemInSection(ObjCClass clazz, @MachineSizedSInt long item, @MachineSizedSInt long section);
     public static NSIndexPath createIndexPathForItemInSection(@MachineSizedSInt long item, @MachineSizedSInt long section) { return createIndexPathForItemInSection(ObjCClass.getByType(NSIndexPath.class), item, section); }
+    @Method(selector = "indexPathForRow:inSection:")
+    protected static native NSIndexPath createIndexPathForRowInSection(ObjCClass clazz, @MachineSizedSInt long row, @MachineSizedSInt long section);
+    public static NSIndexPath createIndexPathForRowInSection(@MachineSizedSInt long row, @MachineSizedSInt long section) { return createIndexPathForRowInSection(ObjCClass.getByType(NSIndexPath.class), row, section); }
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutAnchor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutAnchor.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSLayoutAnchor() {}
+    protected NSLayoutAnchor(Handle h, long handle) { super(h, handle); }
     protected NSLayoutAnchor(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutAttribute.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutAttribute.java
@@ -52,8 +52,8 @@ public enum /*<name>*/NSLayoutAttribute/*</name>*/ implements ValuedEnum {
     Height(8L),
     CenterX(9L),
     CenterY(10L),
-    Baseline(11L),
     LastBaseline(11L),
+    Baseline(11L),
     /**
      * @since Available in iOS 8.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutConstraint.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutConstraint.java
@@ -51,8 +51,9 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSLayoutConstraint() {}
+    protected NSLayoutConstraint(Handle h, long handle) { super(h, handle); }
     protected NSLayoutConstraint(SkipInit skipInit) { super(skipInit); }
-    public NSLayoutConstraint(NSObject view1, NSLayoutAttribute attr1, NSLayoutRelation relation, NSObject view2, NSLayoutAttribute attr2, @MachineSizedFloat double multiplier, @MachineSizedFloat double c) { super(create(view1, attr1, relation, view2, attr2, multiplier, c)); retain(getHandle()); }
+    public NSLayoutConstraint(NSObject view1, NSLayoutAttribute attr1, NSLayoutRelation relation, NSObject view2, NSLayoutAttribute attr2, @MachineSizedFloat double multiplier, @MachineSizedFloat double c) { super((Handle) null, create(view1, attr1, relation, view2, attr2, multiplier, c)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "priority")
@@ -67,12 +68,22 @@ import org.robovm.apple.corelocation.*;
     public native NSObject getFirstItem();
     @Property(selector = "firstAttribute")
     public native NSLayoutAttribute getFirstAttribute();
-    @Property(selector = "relation")
-    public native NSLayoutRelation getRelation();
     @Property(selector = "secondItem")
     public native NSObject getSecondItem();
     @Property(selector = "secondAttribute")
     public native NSLayoutAttribute getSecondAttribute();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "firstAnchor")
+    public native NSLayoutAnchor getFirstAnchor();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "secondAnchor")
+    public native NSLayoutAnchor getSecondAnchor();
+    @Property(selector = "relation")
+    public native NSLayoutRelation getRelation();
     @Property(selector = "multiplier")
     public native @MachineSizedFloat double getMultiplier();
     @Property(selector = "constant")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutDimension.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutDimension.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSLayoutDimension() {}
+    protected NSLayoutDimension(Handle h, long handle) { super(h, handle); }
     protected NSLayoutDimension(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutFormatOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutFormatOptions.java
@@ -51,8 +51,8 @@ public final class /*<name>*/NSLayoutFormatOptions/*</name>*/ extends Bits</*<na
     public static final NSLayoutFormatOptions AlignAllTrailing = new NSLayoutFormatOptions(64L);
     public static final NSLayoutFormatOptions AlignAllCenterX = new NSLayoutFormatOptions(512L);
     public static final NSLayoutFormatOptions AlignAllCenterY = new NSLayoutFormatOptions(1024L);
-    public static final NSLayoutFormatOptions AlignAllBaseline = new NSLayoutFormatOptions(2048L);
     public static final NSLayoutFormatOptions AlignAllLastBaseline = new NSLayoutFormatOptions(2048L);
+    public static final NSLayoutFormatOptions AlignAllBaseline = new NSLayoutFormatOptions(2048L);
     /**
      * @since Available in iOS 8.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutManager.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSLayoutManager() {}
+    protected NSLayoutManager(Handle h, long handle) { super(h, handle); }
     protected NSLayoutManager(SkipInit skipInit) { super(skipInit); }
     public NSLayoutManager(NSCoder coder) { super((SkipInit) null); initObject(init(coder)); }
     /*</constructors>*/
@@ -98,6 +99,10 @@ import org.robovm.apple.corelocation.*;
     public native boolean hasNonContiguousLayout();
     @Property(selector = "numberOfGlyphs")
     public native @MachineSizedUInt long getNumberOfGlyphs();
+    @Property(selector = "firstUnlaidCharacterIndex")
+    public native @MachineSizedUInt long getFirstUnlaidCharacterIndex();
+    @Property(selector = "firstUnlaidGlyphIndex")
+    public native @MachineSizedUInt long getFirstUnlaidGlyphIndex();
     @Property(selector = "extraLineFragmentRect")
     public native @ByVal CGRect getExtraLineFragmentRect();
     @Property(selector = "extraLineFragmentUsedRect")
@@ -176,6 +181,9 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "setGlyphs:properties:characterIndexes:font:forGlyphRange:")
     public native void setGlyphs(ShortPtr glyphs, MachineSizedSIntPtr props, MachineSizedUIntPtr charIndexes, UIFont aFont, @ByVal NSRange glyphRange);
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
     @Method(selector = "isValidGlyphIndex:")
     public native boolean isValidGlyphIndex(@MachineSizedUInt long glyphIndex);
     /**
@@ -208,10 +216,6 @@ import org.robovm.apple.corelocation.*;
     public native void setAttachmentSize(@ByVal CGSize attachmentSize, @ByVal NSRange glyphRange);
     @Method(selector = "getFirstUnlaidCharacterIndex:glyphIndex:")
     public native void getFirstUnlaidCharacterIndex(MachineSizedUIntPtr charIndex, MachineSizedUIntPtr glyphIndex);
-    @Method(selector = "firstUnlaidCharacterIndex")
-    public native @MachineSizedUInt long getFirstUnlaidCharacterIndex();
-    @Method(selector = "firstUnlaidGlyphIndex")
-    public native @MachineSizedUInt long getFirstUnlaidGlyphIndex();
     @Method(selector = "textContainerForGlyphAtIndex:effectiveRange:")
     public native NSTextContainer getTextContainer(@MachineSizedUInt long glyphIndex, NSRange effectiveGlyphRange);
     /**
@@ -276,12 +280,12 @@ import org.robovm.apple.corelocation.*;
      * @since Available in iOS 7.0 and later.
      */
     @Method(selector = "enumerateLineFragmentsForGlyphRange:usingBlock:")
-    public native void enumerateLineFragments(@ByVal NSRange glyphRange, @Block("(@ByVal, @ByVal, , @ByVal, )") VoidBlock5<CGRect, CGRect, NSTextContainer, NSRange, BytePtr> block);
+    public native void enumerateLineFragments(@ByVal NSRange glyphRange, @Block("(@ByVal, @ByVal, , @ByVal, )") VoidBlock5<CGRect, CGRect, NSTextContainer, NSRange, BooleanPtr> block);
     /**
      * @since Available in iOS 7.0 and later.
      */
     @Method(selector = "enumerateEnclosingRectsForGlyphRange:withinSelectedGlyphRange:inTextContainer:usingBlock:")
-    public native void enumerateEnclosingRects(@ByVal NSRange glyphRange, @ByVal NSRange selectedRange, NSTextContainer textContainer, @Block("(@ByVal, )") VoidBlock2<CGRect, BytePtr> block);
+    public native void enumerateEnclosingRects(@ByVal NSRange glyphRange, @ByVal NSRange selectedRange, NSTextContainer textContainer, @Block("(@ByVal, )") VoidBlock2<CGRect, BooleanPtr> block);
     @Method(selector = "drawBackgroundForGlyphRange:atPoint:")
     public native void drawBackground(@ByVal NSRange glyphsToShow, @ByVal CGPoint origin);
     @Method(selector = "drawGlyphsForGlyphRange:atPoint:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutXAxisAnchor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutXAxisAnchor.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSLayoutXAxisAnchor() {}
+    protected NSLayoutXAxisAnchor(Handle h, long handle) { super(h, handle); }
     protected NSLayoutXAxisAnchor(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutYAxisAnchor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutYAxisAnchor.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSLayoutYAxisAnchor() {}
+    protected NSLayoutYAxisAnchor(Handle h, long handle) { super(h, handle); }
     protected NSLayoutYAxisAnchor(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSMutableAttributedStringExtensions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSMutableAttributedStringExtensions.java
@@ -69,7 +69,7 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 9.0 and later.
      */
-    public static boolean read(NSMutableAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes opts, NSDictionary.NSDictionaryPtr dict) throws NSErrorException {
+    public static boolean read(NSMutableAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes opts, NSDictionary.NSDictionaryPtr<?, ?> dict) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        boolean result = read(thiz, url, opts, dict, ptr);
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
@@ -79,11 +79,11 @@ import org.robovm.apple.corelocation.*;
      * @since Available in iOS 9.0 and later.
      */
     @Method(selector = "readFromURL:options:documentAttributes:error:")
-    private static native boolean read(NSMutableAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes opts, NSDictionary.NSDictionaryPtr dict, NSError.NSErrorPtr error);
+    private static native boolean read(NSMutableAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes opts, NSDictionary.NSDictionaryPtr<?, ?> dict, NSError.NSErrorPtr error);
     /**
      * @since Available in iOS 7.0 and later.
      */
-    public static boolean read(NSMutableAttributedString thiz, NSData data, NSAttributedStringDocumentAttributes opts, NSDictionary.NSDictionaryPtr dict) throws NSErrorException {
+    public static boolean read(NSMutableAttributedString thiz, NSData data, NSAttributedStringDocumentAttributes opts, NSDictionary.NSDictionaryPtr<?, ?> dict) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        boolean result = read(thiz, data, opts, dict, ptr);
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
@@ -93,13 +93,13 @@ import org.robovm.apple.corelocation.*;
      * @since Available in iOS 7.0 and later.
      */
     @Method(selector = "readFromData:options:documentAttributes:error:")
-    private static native boolean read(NSMutableAttributedString thiz, NSData data, NSAttributedStringDocumentAttributes opts, NSDictionary.NSDictionaryPtr dict, NSError.NSErrorPtr error);
+    private static native boolean read(NSMutableAttributedString thiz, NSData data, NSAttributedStringDocumentAttributes opts, NSDictionary.NSDictionaryPtr<?, ?> dict, NSError.NSErrorPtr error);
     /**
      * @since Available in iOS 7.0 and later.
      * @deprecated Deprecated in iOS 9.0.
      */
     @Deprecated
-    public static boolean readFromFileURL(NSMutableAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes opts, NSDictionary.NSDictionaryPtr dict) throws NSErrorException {
+    public static boolean readFromFileURL(NSMutableAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes opts, NSDictionary.NSDictionaryPtr<?, ?> dict) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        boolean result = readFromFileURL(thiz, url, opts, dict, ptr);
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
@@ -111,6 +111,6 @@ import org.robovm.apple.corelocation.*;
      */
     @Deprecated
     @Method(selector = "readFromFileURL:options:documentAttributes:error:")
-    private static native boolean readFromFileURL(NSMutableAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes opts, NSDictionary.NSDictionaryPtr dict, NSError.NSErrorPtr error);
+    private static native boolean readFromFileURL(NSMutableAttributedString thiz, NSURL url, NSAttributedStringDocumentAttributes opts, NSDictionary.NSDictionaryPtr<?, ?> dict, NSError.NSErrorPtr error);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSMutableParagraphStyle.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSMutableParagraphStyle.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSMutableParagraphStyle() {}
+    protected NSMutableParagraphStyle(Handle h, long handle) { super(h, handle); }
     protected NSMutableParagraphStyle(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSParagraphStyle.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSParagraphStyle.java
@@ -51,9 +51,12 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSParagraphStyle() {}
+    protected NSParagraphStyle(Handle h, long handle) { super(h, handle); }
     protected NSParagraphStyle(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
+    @Property(selector = "defaultParagraphStyle")
+    public static native NSParagraphStyle getDefaultParagraphStyle();
     @Property(selector = "lineSpacing")
     public native @MachineSizedFloat double getLineSpacing();
     @Property(selector = "paragraphSpacing")
@@ -96,10 +99,83 @@ import org.robovm.apple.corelocation.*;
     @Property(selector = "allowsDefaultTighteningForTruncation")
     public native boolean allowsDefaultTighteningForTruncation();
     /*</properties>*/
+    public void setLineSpacing(double v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setParagraphSpacing(double v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setAlignment(NSTextAlignment v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setFirstLineHeadIndent(double v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setHeadIndent(double v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setTailIndent(double v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setLineBreakMode(NSLineBreakMode v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setMinimumLineHeight(double v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setMaximumLineHeight(double v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setBaseWritingDirection(NSWritingDirection v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setLineHeightMultiple(double v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setParagraphSpacingBefore(double v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setHyphenationFactor(float v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setTabStops(NSArray<NSTextTab> v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setDefaultTabInterval(double v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setAllowsDefaultTighteningForTruncation(boolean v) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void addTabStop(NSTextTab tab) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void removeTabStop(NSTextTab tab) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
+
+    public void setParagraphStyle(NSParagraphStyle style) {
+        throw new UnsupportedOperationException("NSParagraphStyle is immutable");
+    }
     /*<members>*//*</members>*/
     /*<methods>*/
-    @Method(selector = "defaultParagraphStyle")
-    public static native NSParagraphStyle getDefaultParagraphStyle();
     @Method(selector = "defaultWritingDirectionForLanguage:")
     public static native NSWritingDirection getDefaultWritingDirection(String languageName);
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSShadow.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSShadow.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSShadow() {}
+    protected NSShadow(Handle h, long handle) { super(h, handle); }
     protected NSShadow(SkipInit skipInit) { super(skipInit); }
     public NSShadow(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSStringDrawingContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSStringDrawingContext.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSStringDrawingContext() {}
+    protected NSStringDrawingContext(Handle h, long handle) { super(h, handle); }
     protected NSStringDrawingContext(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextAttachment.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextAttachment.java
@@ -53,12 +53,13 @@ import org.robovm.apple.corelocation.*;
     /*</constants>*/
     /*<constructors>*/
     public NSTextAttachment() {}
+    protected NSTextAttachment(Handle h, long handle) { super(h, handle); }
     protected NSTextAttachment(SkipInit skipInit) { super(skipInit); }
     /**
      * @since Available in iOS 7.0 and later.
      */
     public NSTextAttachment(NSData contentData, String uti) { super((SkipInit) null); initObject(init(contentData, uti)); }
-    public NSTextAttachment(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    public NSTextAttachment(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     /**
@@ -126,6 +127,6 @@ import org.robovm.apple.corelocation.*;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextContainer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextContainer.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSTextContainer() {}
+    protected NSTextContainer(Handle h, long handle) { super(h, handle); }
     protected NSTextContainer(SkipInit skipInit) { super(skipInit); }
     /**
      * @since Available in iOS 7.0 and later.

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextStorage.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextStorage.java
@@ -75,6 +75,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSTextStorage() {}
+    protected NSTextStorage(Handle h, long handle) { super(h, handle); }
     protected NSTextStorage(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextTab.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextTab.java
@@ -51,9 +51,10 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSTextTab() {}
+    protected NSTextTab(Handle h, long handle) { super(h, handle); }
     protected NSTextTab(SkipInit skipInit) { super(skipInit); }
     public NSTextTab(NSTextAlignment alignment, @MachineSizedFloat double loc, NSTextTabOptions options) { super((SkipInit) null); initObject(init(alignment, loc, options)); }
-    public NSTextTab(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    public NSTextTab(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "alignment")
@@ -75,6 +76,6 @@ import org.robovm.apple.corelocation.*;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSValueExtensions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSValueExtensions.java
@@ -51,27 +51,26 @@ import org.robovm.apple.corelocation.*;
     private NSValueExtensions() {}
     /*</constructors>*/
     /*<properties>*/
-    
-    /*</properties>*/
-    /*<members>*//*</members>*/
-    /*<methods>*/
-    @Method(selector = "CGPointValue")
+    @Property(selector = "CGPointValue")
     public static native @ByVal CGPoint getPointValue(NSValue thiz);
-    @Method(selector = "CGVectorValue")
+    @Property(selector = "CGVectorValue")
     public static native @ByVal CGVector getVectorValue(NSValue thiz);
-    @Method(selector = "CGSizeValue")
+    @Property(selector = "CGSizeValue")
     public static native @ByVal CGSize getSizeValue(NSValue thiz);
-    @Method(selector = "CGRectValue")
+    @Property(selector = "CGRectValue")
     public static native @ByVal CGRect getRectValue(NSValue thiz);
-    @Method(selector = "CGAffineTransformValue")
+    @Property(selector = "CGAffineTransformValue")
     public static native @ByVal CGAffineTransform getAffineTransformValue(NSValue thiz);
-    @Method(selector = "UIEdgeInsetsValue")
+    @Property(selector = "UIEdgeInsetsValue")
     public static native @ByVal UIEdgeInsets getEdgeInsetsValue(NSValue thiz);
     /**
      * @since Available in iOS 5.0 and later.
      */
-    @Method(selector = "UIOffsetValue")
+    @Property(selector = "UIOffsetValue")
     public static native @ByVal UIOffset getOffsetValue(NSValue thiz);
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
     @Method(selector = "valueWithCGPoint:")
     protected static native NSValue create(ObjCClass clazz, @ByVal CGPoint point);
     public static NSValue create(@ByVal CGPoint point) { return create(ObjCClass.getByType(NSValue.class), point); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityAdapter.java
@@ -138,6 +138,10 @@ import org.robovm.apple.corelocation.*;
      */
     @NotImplemented("setAccessibilityNavigationStyle:")
     public void setAccessibilityNavigationStyle(UIAccessibilityNavigationStyle v) {}
+    @NotImplemented("accessibilityHeaderElements")
+    public NSArray<?> getAccessibilityHeaderElements() { return null; }
+    @NotImplemented("setAccessibilityHeaderElements:")
+    public void setAccessibilityHeaderElements(NSArray<?> v) {}
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityAdapter.java
@@ -138,10 +138,6 @@ import org.robovm.apple.corelocation.*;
      */
     @NotImplemented("setAccessibilityNavigationStyle:")
     public void setAccessibilityNavigationStyle(UIAccessibilityNavigationStyle v) {}
-    @NotImplemented("accessibilityHeaderElements")
-    public NSArray<?> getAccessibilityHeaderElements() { return null; }
-    @NotImplemented("setAccessibilityHeaderElements:")
-    public void setAccessibilityHeaderElements(NSArray<?> v) {}
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomAction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomAction.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIAccessibilityCustomAction() {}
+    protected UIAccessibilityCustomAction(Handle h, long handle) { super(h, handle); }
     protected UIAccessibilityCustomAction(SkipInit skipInit) { super(skipInit); }
     public UIAccessibilityCustomAction(String name, NSObject target, Selector selector) { super((SkipInit) null); initObject(init(name, target, selector)); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomRotor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomRotor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIAccessibilityCustomRotor/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIAccessibilityCustomRotorPtr extends Ptr<UIAccessibilityCustomRotor, UIAccessibilityCustomRotorPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIAccessibilityCustomRotor.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIAccessibilityCustomRotor() {}
+    protected UIAccessibilityCustomRotor(Handle h, long handle) { super(h, handle); }
+    protected UIAccessibilityCustomRotor(SkipInit skipInit) { super(skipInit); }
+    public UIAccessibilityCustomRotor(String name, FunctionPtr itemSearchBlock) { super((SkipInit) null); initObject(init(name, itemSearchBlock)); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "name")
+    public native String getName();
+    @Property(selector = "setName:")
+    public native void setName(String v);
+    @Property(selector = "itemSearchBlock")
+    public native FunctionPtr getItemSearchBlock();
+    @Property(selector = "setItemSearchBlock:")
+    public native void setItemSearchBlock(FunctionPtr v);
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "initWithName:itemSearchBlock:")
+    protected native @Pointer long init(String name, FunctionPtr itemSearchBlock);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomRotorDirection.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomRotorDirection.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UIAccessibilityCustomRotorDirection/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    Previous(0L),
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    Next(1L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UIAccessibilityCustomRotorDirection/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UIAccessibilityCustomRotorDirection/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UIAccessibilityCustomRotorDirection/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UIAccessibilityCustomRotorDirection/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomRotorItemResult.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomRotorItemResult.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIAccessibilityCustomRotorItemResult/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIAccessibilityCustomRotorItemResultPtr extends Ptr<UIAccessibilityCustomRotorItemResult, UIAccessibilityCustomRotorItemResultPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIAccessibilityCustomRotorItemResult.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIAccessibilityCustomRotorItemResult() {}
+    protected UIAccessibilityCustomRotorItemResult(Handle h, long handle) { super(h, handle); }
+    protected UIAccessibilityCustomRotorItemResult(SkipInit skipInit) { super(skipInit); }
+    public UIAccessibilityCustomRotorItemResult(NSObject targetElement, UITextRange targetRange) { super((SkipInit) null); initObject(init(targetElement, targetRange)); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "targetElement")
+    public native NSObject getTargetElement();
+    @Property(selector = "setTargetElement:", strongRef = true)
+    public native void setTargetElement(NSObject v);
+    @Property(selector = "targetRange")
+    public native UITextRange getTargetRange();
+    @Property(selector = "setTargetRange:")
+    public native void setTargetRange(UITextRange v);
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "initWithTargetElement:targetRange:")
+    protected native @Pointer long init(NSObject targetElement, UITextRange targetRange);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomRotorSearchPredicate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomRotorSearchPredicate.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIAccessibilityCustomRotorSearchPredicate/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIAccessibilityCustomRotorSearchPredicatePtr extends Ptr<UIAccessibilityCustomRotorSearchPredicate, UIAccessibilityCustomRotorSearchPredicatePtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIAccessibilityCustomRotorSearchPredicate.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIAccessibilityCustomRotorSearchPredicate() {}
+    protected UIAccessibilityCustomRotorSearchPredicate(Handle h, long handle) { super(h, handle); }
+    protected UIAccessibilityCustomRotorSearchPredicate(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "currentItem")
+    public native UIAccessibilityCustomRotorItemResult getCurrentItem();
+    @Property(selector = "setCurrentItem:")
+    public native void setCurrentItem(UIAccessibilityCustomRotorItemResult v);
+    @Property(selector = "searchDirection")
+    public native UIAccessibilityCustomRotorDirection getSearchDirection();
+    @Property(selector = "setSearchDirection:")
+    public native void setSearchDirection(UIAccessibilityCustomRotorDirection v);
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityElement.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityElement.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIAccessibilityElement() {}
+    protected UIAccessibilityElement(Handle h, long handle) { super(h, handle); }
     protected UIAccessibilityElement(SkipInit skipInit) { super(skipInit); }
     public UIAccessibilityElement(UIAccessibilityContainer container) { super((SkipInit) null); initObject(init(container)); }
     /*</constructors>*/
@@ -83,6 +84,16 @@ import org.robovm.apple.corelocation.*;
     public native UIAccessibilityTraits getAccessibilityTraits();
     @Property(selector = "setAccessibilityTraits:", strongRef = true)
     public native void setAccessibilityTraits(UIAccessibilityTraits v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "accessibilityFrameInContainerSpace")
+    public native @ByVal CGRect getAccessibilityFrameInContainerSpace();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setAccessibilityFrameInContainerSpace:")
+    public native void setAccessibilityFrameInContainerSpace(@ByVal CGRect v);
     /**
      * @since Available in iOS 5.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityGlobals.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityGlobals.java
@@ -155,6 +155,16 @@ import org.robovm.apple.corelocation.*;
      */
     @GlobalValue(symbol="UIAccessibilityShakeToUndoDidChangeNotification", optional=true)
     public static native NSString ShakeToUndoDidChangeNotification();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="UIAccessibilityAssistiveTouchStatusDidChangeNotification", optional=true)
+    public static native NSString AssistiveTouchStatusDidChangeNotification();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="UIAccessibilityHearingDevicePairedEarDidChangeNotification", optional=true)
+    public static native NSString HearingDevicePairedEarDidChangeNotification();
     
     /**
      * @since Available in iOS 5.0 and later.
@@ -254,9 +264,19 @@ import org.robovm.apple.corelocation.*;
     @Bridge(symbol="UIAccessibilityIsShakeToUndoEnabled", optional=true)
     public static native boolean isShakeToUndoEnabled();
     /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Bridge(symbol="UIAccessibilityIsAssistiveTouchRunning", optional=true)
+    public static native boolean isAssistiveTouchRunning();
+    /**
      * @since Available in iOS 7.0 and later.
      */
     @Bridge(symbol="UIAccessibilityRequestGuidedAccessSession", optional=true)
     public static native void requestGuidedAccessSession(boolean enable, @Block VoidBooleanBlock completionHandler);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Bridge(symbol="UIAccessibilityHearingDevicePairedEar", optional=true)
+    public static native UIAccessibilityHearingDeviceEar getHearingDevicePairingStatus();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityHearingDeviceEar.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityHearingDeviceEar.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(Bits.AsMachineSizedIntMarshaler.class)/*</annotations>*/
+public final class /*<name>*/UIAccessibilityHearingDeviceEar/*</name>*/ extends Bits</*<name>*/UIAccessibilityHearingDeviceEar/*</name>*/> {
+    /*<values>*/
+    public static final UIAccessibilityHearingDeviceEar None = new UIAccessibilityHearingDeviceEar(0L);
+    public static final UIAccessibilityHearingDeviceEar Left = new UIAccessibilityHearingDeviceEar(2L);
+    public static final UIAccessibilityHearingDeviceEar Right = new UIAccessibilityHearingDeviceEar(4L);
+    public static final UIAccessibilityHearingDeviceEar Both = new UIAccessibilityHearingDeviceEar(6L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private static final /*<name>*/UIAccessibilityHearingDeviceEar/*</name>*/[] values = _values(/*<name>*/UIAccessibilityHearingDeviceEar/*</name>*/.class);
+
+    public /*<name>*/UIAccessibilityHearingDeviceEar/*</name>*/(long value) { super(value); }
+    private /*<name>*/UIAccessibilityHearingDeviceEar/*</name>*/(long value, long mask) { super(value, mask); }
+    protected /*<name>*/UIAccessibilityHearingDeviceEar/*</name>*/ wrap(long value, long mask) {
+        return new /*<name>*/UIAccessibilityHearingDeviceEar/*</name>*/(value, mask);
+    }
+    protected /*<name>*/UIAccessibilityHearingDeviceEar/*</name>*/[] _values() {
+        return values;
+    }
+    public static /*<name>*/UIAccessibilityHearingDeviceEar/*</name>*/[] values() {
+        return values.clone();
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityTraits.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityTraits.java
@@ -42,6 +42,7 @@ import org.robovm.apple.corelocation.*;
 /*<visibility>*/public final/*</visibility>*/ class /*<name>*/UIAccessibilityTraits/*</name>*/ 
     extends /*<extends>*/Bits<UIAccessibilityTraits>/*</extends>*/  {
 
+    /*<values>*/
     public static final UIAccessibilityTraits None = new UIAccessibilityTraits(NoneValue());
     public static final UIAccessibilityTraits Button = new UIAccessibilityTraits(ButtonValue());
     public static final UIAccessibilityTraits Link = new UIAccessibilityTraits(LinkValue());
@@ -73,6 +74,11 @@ import org.robovm.apple.corelocation.*;
      * @since Available in iOS 5.0 and later.
      */
     public static final UIAccessibilityTraits CausesPageTurn = new UIAccessibilityTraits(CausesPageTurnValue());
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UIAccessibilityTraits TabBarValue = new UIAccessibilityTraits(TabBarValue());
+    /*</values>*/
 
     private static final /*<name>*/UIAccessibilityTraits/*</name>*/[] values = _values(/*<name>*/UIAccessibilityTraits/*</name>*/.class);
 
@@ -138,5 +144,10 @@ import org.robovm.apple.corelocation.*;
      */
     @GlobalValue(symbol="UIAccessibilityTraitCausesPageTurn", optional=true)
     protected static native long CausesPageTurnValue();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="UIAccessibilityTraitTabBar", optional=true)
+    protected static native long TabBarValue();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActionSheet.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActionSheet.java
@@ -53,13 +53,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIActionSheet() {}
+    protected UIActionSheet(Handle h, long handle) { super(h, handle); }
     protected UIActionSheet(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UIActionSheet(CGRect frame) {
         super(frame);
     }
-
+    public UIActionSheet(NSCoder decoder) {
+        super(decoder);
+    }
     public UIActionSheet(String title, UIActionSheetDelegate delegate, String cancelButtonTitle, 
             String destructiveButtonTitle, String ... otherButtonTitles) {
         super((SkipInit) null);

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivity.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivity.java
@@ -51,33 +51,33 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIActivity() {}
+    protected UIActivity(Handle h, long handle) { super(h, handle); }
     protected UIActivity(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
-    
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @Property(selector = "activityCategory")
+    public static native UIActivityCategory getCategory();
+    @Property(selector = "activityType")
+    public native String getType();
+    @Property(selector = "activityTitle")
+    public native String getTitle();
+    @Property(selector = "activityImage")
+    public native UIImage getImage();
+    @Property(selector = "activityViewController")
+    public native UIViewController getViewController();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
-    @Method(selector = "activityType")
-    public native String getType();
-    @Method(selector = "activityTitle")
-    public native String getTitle();
-    @Method(selector = "activityImage")
-    public native UIImage getImage();
     @Method(selector = "canPerformWithActivityItems:")
     public native boolean canPerform(NSArray<?> activityItems);
     @Method(selector = "prepareWithActivityItems:")
     public native void prepare(NSArray<?> activityItems);
-    @Method(selector = "activityViewController")
-    public native UIViewController getViewController();
     @Method(selector = "performActivity")
     public native void perform();
     @Method(selector = "activityDidFinish:")
     public native void didFinish(boolean completed);
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    @Method(selector = "activityCategory")
-    public static native UIActivityCategory getActivityCategory();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityIndicatorView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityIndicatorView.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIActivityIndicatorView() {}
+    protected UIActivityIndicatorView(Handle h, long handle) { super(h, handle); }
     protected UIActivityIndicatorView(SkipInit skipInit) { super(skipInit); }
     public UIActivityIndicatorView(UIActivityIndicatorViewStyle style) { super((SkipInit) null); initObject(init(style)); }
     public UIActivityIndicatorView(@ByVal CGRect frame) { super((SkipInit) null); initObject(init(frame)); }
@@ -75,6 +76,8 @@ import org.robovm.apple.corelocation.*;
      */
     @Property(selector = "setColor:")
     public native void setColor(UIColor v);
+    @Property(selector = "isAnimating")
+    public native boolean isAnimating();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -88,7 +91,5 @@ import org.robovm.apple.corelocation.*;
     public native void startAnimating();
     @Method(selector = "stopAnimating")
     public native void stopAnimating();
-    @Method(selector = "isAnimating")
-    public native boolean isAnimating();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityItemProvider.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityItemProvider.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIActivityItemProvider() {}
+    protected UIActivityItemProvider(Handle h, long handle) { super(h, handle); }
     protected UIActivityItemProvider(SkipInit skipInit) { super(skipInit); }
     public UIActivityItemProvider(NSObject placeholderItem) { super((SkipInit) null); initObject(init(placeholderItem)); }
     /*</constructors>*/
@@ -59,13 +60,13 @@ import org.robovm.apple.corelocation.*;
     public native NSObject getPlaceholderItem();
     @Property(selector = "activityType")
     public native String getActivityType();
+    @Property(selector = "item")
+    public native NSObject getItem();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
     @Method(selector = "initWithPlaceholderItem:")
     protected native @Pointer long init(NSObject placeholderItem);
-    @Method(selector = "item")
-    public native NSObject getItem();
     @Method(selector = "activityViewControllerPlaceholderItem:")
     public native NSObject getPlaceholderItem(UIActivityViewController activityViewController);
     @Method(selector = "activityViewController:itemForActivityType:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityItemProvider.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityItemProvider.java
@@ -50,7 +50,7 @@ import org.robovm.apple.corelocation.*;
     /*<bind>*/static { ObjCRuntime.bind(UIActivityItemProvider.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public UIActivityItemProvider() {}
+    protected UIActivityItemProvider() {}
     protected UIActivityItemProvider(Handle h, long handle) { super(h, handle); }
     protected UIActivityItemProvider(SkipInit skipInit) { super(skipInit); }
     public UIActivityItemProvider(NSObject placeholderItem) { super((SkipInit) null); initObject(init(placeholderItem)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityViewController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIActivityViewController() {}
+    protected UIActivityViewController(Handle h, long handle) { super(h, handle); }
     protected UIActivityViewController(SkipInit skipInit) { super(skipInit); }
     public UIActivityViewController(String nibNameOrNil, NSBundle nibBundleOrNil) { super((SkipInit) null); initObject(init(nibNameOrNil, nibBundleOrNil)); }
     public UIActivityViewController(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityViewController.java
@@ -50,11 +50,9 @@ import org.robovm.apple.corelocation.*;
     /*<bind>*/static { ObjCRuntime.bind(UIActivityViewController.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public UIActivityViewController() {}
+    protected UIActivityViewController() {}
     protected UIActivityViewController(Handle h, long handle) { super(h, handle); }
     protected UIActivityViewController(SkipInit skipInit) { super(skipInit); }
-    public UIActivityViewController(String nibNameOrNil, NSBundle nibBundleOrNil) { super((SkipInit) null); initObject(init(nibNameOrNil, nibBundleOrNil)); }
-    public UIActivityViewController(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     public UIActivityViewController(NSArray<?> activityItems, NSArray<UIActivity> applicationActivities) { super((SkipInit) null); initObject(init(activityItems, applicationActivities)); }
     /*</constructors>*/
     public UIActivityViewController(List<?> activityItems, NSArray<UIActivity> applicationActivities) {
@@ -107,10 +105,6 @@ import org.robovm.apple.corelocation.*;
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
-    @Method(selector = "initWithNibName:bundle:")
-    protected native @Pointer long init(String nibNameOrNil, NSBundle nibBundleOrNil);
-    @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
     @Method(selector = "initWithActivityItems:applicationActivities:")
     protected native @Pointer long init(NSArray<?> activityItems, NSArray<UIActivity> applicationActivities);
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAlertAction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAlertAction.java
@@ -51,8 +51,9 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIAlertAction() {}
+    protected UIAlertAction(Handle h, long handle) { super(h, handle); }
     protected UIAlertAction(SkipInit skipInit) { super(skipInit); }
-    public UIAlertAction(String title, UIAlertActionStyle style, @Block VoidBlock1<UIAlertAction> handler) { super(create(title, style, handler)); retain(getHandle()); }
+    public UIAlertAction(String title, UIAlertActionStyle style, @Block VoidBlock1<UIAlertAction> handler) { super((Handle) null, create(title, style, handler)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "title")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAlertController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAlertController.java
@@ -51,8 +51,9 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIAlertController() {}
+    protected UIAlertController(Handle h, long handle) { super(h, handle); }
     protected UIAlertController(SkipInit skipInit) { super(skipInit); }
-    public UIAlertController(String title, String message, UIAlertControllerStyle preferredStyle) { super(create(title, message, preferredStyle)); retain(getHandle()); }
+    public UIAlertController(String title, String message, UIAlertControllerStyle preferredStyle) { super((Handle) null, create(title, message, preferredStyle)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "actions")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAlertView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAlertView.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIAlertView() {}
+    protected UIAlertView(Handle h, long handle) { super(h, handle); }
     protected UIAlertView(SkipInit skipInit) { super(skipInit); }
     public UIAlertView(@ByVal CGRect frame) { super((SkipInit) null); initObject(init(frame)); }
     public UIAlertView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplication.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplication.java
@@ -223,13 +223,18 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIApplication() {}
+    protected UIApplication(Handle h, long handle) { super(h, handle); }
     protected UIApplication(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
+    @Property(selector = "sharedApplication")
+    public static native UIApplication getSharedApplication();
     @Property(selector = "delegate")
     public native UIApplicationDelegate getDelegate();
     @Property(selector = "setDelegate:", strongRef = true)
     public native void setDelegate(UIApplicationDelegate v);
+    @Property(selector = "isIgnoringInteractionEvents")
+    public native boolean isIgnoringInteractionEvents();
     @Property(selector = "isIdleTimerDisabled")
     public native boolean isIdleTimerDisabled();
     @Property(selector = "setIdleTimerDisabled:")
@@ -297,15 +302,39 @@ import org.robovm.apple.corelocation.*;
     @Property(selector = "preferredContentSizeCategory")
     public native String getPreferredContentSizeCategory();
     /**
-     * @since Available in iOS 4.0 and later.
+     * @since Available in iOS 8.0 and later.
      */
+    @Property(selector = "isRegisteredForRemoteNotifications")
+    public native boolean isRegisteredForRemoteNotifications();
+    /**
+     * @since Available in iOS 4.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
     @Property(selector = "scheduledLocalNotifications")
     public native NSArray<UILocalNotification> getScheduledLocalNotifications();
     /**
      * @since Available in iOS 4.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @Property(selector = "setScheduledLocalNotifications:")
     public native void setScheduledLocalNotifications(NSArray<UILocalNotification> v);
+    /**
+     * @since Available in iOS 8.0 and later.
+     */
+    @Property(selector = "currentUserNotificationSettings")
+    public native UIUserNotificationSettings getCurrentUserNotificationSettings();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "shortcutItems")
+    public native NSArray<UIApplicationShortcutItem> getShortcutItems();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "setShortcutItems:")
+    public native void setShortcutItems(NSArray<UIApplicationShortcutItem> v);
     /**
      * @since Available in iOS 2.0 and later.
      * @deprecated Deprecated in iOS 9.0.
@@ -407,6 +436,16 @@ import org.robovm.apple.corelocation.*;
     
     /*<methods>*/
     /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @GlobalValue(symbol="UIContentSizeCategoryDidChangeNotification", optional=true)
+    public static native NSString ContentSizeCategoryDidChangeNotification();
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @GlobalValue(symbol="UIContentSizeCategoryNewValueKey", optional=true)
+    protected static native NSString ContentSizeCategoryNewValueKey();
+    /**
      * @since Available in iOS 4.0 and later.
      */
     @GlobalValue(symbol="UIBackgroundTaskInvalid", optional=true)
@@ -483,16 +522,6 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 7.0 and later.
      */
-    @GlobalValue(symbol="UIContentSizeCategoryDidChangeNotification", optional=true)
-    public static native NSString ContentSizeCategoryDidChangeNotification();
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    @GlobalValue(symbol="UIContentSizeCategoryNewValueKey", optional=true)
-    protected static native NSString ContentSizeCategoryNewValueKey();
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
     @GlobalValue(symbol="UIApplicationUserDidTakeScreenshotNotification", optional=true)
     public static native NSString UserDidTakeScreenshotNotification();
     
@@ -503,8 +532,11 @@ import org.robovm.apple.corelocation.*;
     public native void beginIgnoringInteractionEvents();
     @Method(selector = "endIgnoringInteractionEvents")
     public native void endIgnoringInteractionEvents();
-    @Method(selector = "isIgnoringInteractionEvents")
-    public native boolean isIgnoringInteractionEvents();
+    /**
+     * @since Available in iOS 2.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
     @Method(selector = "openURL:")
     public native boolean openURL(NSURL url);
     /**
@@ -512,6 +544,11 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "canOpenURL:")
     public native boolean canOpenURL(NSURL url);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "openURL:options:completionHandler:")
+    public native void openURL(NSURL url, UIApplicationOpenURLOptions options, @Block VoidBooleanBlock completion);
     @Method(selector = "sendEvent:")
     public native void sendEvent(UIEvent event);
     @Method(selector = "sendAction:to:from:forEvent:")
@@ -541,8 +578,6 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "setMinimumBackgroundFetchInterval:")
     public native void setMinimumBackgroundFetchInterval(double minimumBackgroundFetchInterval);
-    @Method(selector = "sharedApplication")
-    public static native UIApplication getSharedApplication();
     /**
      * @since Available in iOS 8.0 and later.
      */
@@ -553,11 +588,6 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "unregisterForRemoteNotifications")
     public native void unregisterForRemoteNotifications();
-    /**
-     * @since Available in iOS 8.0 and later.
-     */
-    @Method(selector = "isRegisteredForRemoteNotifications")
-    public native boolean isRegisteredForRemoteNotifications();
     /**
      * @since Available in iOS 3.0 and later.
      * @deprecated Deprecated in iOS 8.0.
@@ -574,22 +604,30 @@ import org.robovm.apple.corelocation.*;
     public native UIRemoteNotificationType getEnabledRemoteNotificationTypes();
     /**
      * @since Available in iOS 4.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @Method(selector = "presentLocalNotificationNow:")
     public native void presentLocalNotificationNow(UILocalNotification notification);
     /**
      * @since Available in iOS 4.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @Method(selector = "scheduleLocalNotification:")
     public native void scheduleLocalNotification(UILocalNotification notification);
     /**
      * @since Available in iOS 4.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @Method(selector = "cancelLocalNotification:")
     public native void cancelLocalNotification(UILocalNotification notification);
     /**
      * @since Available in iOS 4.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @Method(selector = "cancelAllLocalNotifications")
     public native void cancelAllLocalNotifications();
     /**
@@ -597,11 +635,6 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "registerUserNotificationSettings:")
     public native void registerUserNotificationSettings(UIUserNotificationSettings notificationSettings);
-    /**
-     * @since Available in iOS 8.0 and later.
-     */
-    @Method(selector = "currentUserNotificationSettings")
-    public native UIUserNotificationSettings getCurrentUserNotificationSettings();
     /**
      * @since Available in iOS 4.0 and later.
      */
@@ -613,7 +646,7 @@ import org.robovm.apple.corelocation.*;
     @Method(selector = "endReceivingRemoteControlEvents")
     public native void endReceivingRemoteControlEvents();
     /**
-     * @since Available in iOS 9.0 and later.
+     * @since Available in iOS 5.0 and later.
      * @deprecated Deprecated in iOS 9.0.
      */
     @Deprecated

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationDelegate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationDelegate.java
@@ -90,7 +90,7 @@ import org.robovm.apple.corelocation.*;
      */
     @Deprecated
     @Method(selector = "application:openURL:sourceApplication:annotation:")
-    boolean openURL(UIApplication application, NSURL url, String sourceApplication, NSPropertyList annotation);
+    boolean openURL(UIApplication application, NSURL url, String sourceApplication, NSObject annotation);
     /**
      * @since Available in iOS 9.0 and later.
      */
@@ -127,32 +127,44 @@ import org.robovm.apple.corelocation.*;
     void didFailToRegisterForRemoteNotifications(UIApplication application, NSError error);
     /**
      * @since Available in iOS 3.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @Method(selector = "application:didReceiveRemoteNotification:")
     void didReceiveRemoteNotification(UIApplication application, UIRemoteNotification userInfo);
     /**
      * @since Available in iOS 4.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @Method(selector = "application:didReceiveLocalNotification:")
     void didReceiveLocalNotification(UIApplication application, UILocalNotification notification);
     /**
      * @since Available in iOS 8.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @Method(selector = "application:handleActionWithIdentifier:forLocalNotification:completionHandler:")
     void handleLocalNotificationAction(UIApplication application, String identifier, UILocalNotification notification, @Block Runnable completionHandler);
     /**
      * @since Available in iOS 9.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @Method(selector = "application:handleActionWithIdentifier:forRemoteNotification:withResponseInfo:completionHandler:")
     void handleRemoteNotificationAction(UIApplication application, String identifier, UIRemoteNotification userInfo, NSDictionary<?, ?> responseInfo, @Block Runnable completionHandler);
     /**
      * @since Available in iOS 8.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @Method(selector = "application:handleActionWithIdentifier:forRemoteNotification:completionHandler:")
     void handleRemoteNotificationAction(UIApplication application, String identifier, UIRemoteNotification userInfo, @Block Runnable completionHandler);
     /**
      * @since Available in iOS 9.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @Method(selector = "application:handleActionWithIdentifier:forLocalNotification:withResponseInfo:completionHandler:")
     void handleLocalNotificationAction(UIApplication application, String identifier, UILocalNotification notification, NSDictionary<?, ?> responseInfo, @Block Runnable completionHandler);
     /**
@@ -165,6 +177,11 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "application:performFetchWithCompletionHandler:")
     void performFetch(UIApplication application, @Block VoidBlock1<UIBackgroundFetchResult> completionHandler);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "application:performActionForShortcutItem:completionHandler:")
+    void performAction(UIApplication application, UIApplicationShortcutItem shortcutItem, @Block VoidBooleanBlock completionHandler);
     /**
      * @since Available in iOS 7.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationDelegateAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationDelegateAdapter.java
@@ -113,7 +113,7 @@ import org.robovm.apple.corelocation.*;
      */
     @Deprecated
     @NotImplemented("application:openURL:sourceApplication:annotation:")
-    public boolean openURL(UIApplication application, NSURL url, String sourceApplication, NSPropertyList annotation) { return false; }
+    public boolean openURL(UIApplication application, NSURL url, String sourceApplication, NSObject annotation) { return false; }
     /**
      * @since Available in iOS 9.0 and later.
      */
@@ -148,32 +148,44 @@ import org.robovm.apple.corelocation.*;
     public void didFailToRegisterForRemoteNotifications(UIApplication application, NSError error) {}
     /**
      * @since Available in iOS 3.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @NotImplemented("application:didReceiveRemoteNotification:")
     public void didReceiveRemoteNotification(UIApplication application, UIRemoteNotification userInfo) {}
     /**
      * @since Available in iOS 4.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @NotImplemented("application:didReceiveLocalNotification:")
     public void didReceiveLocalNotification(UIApplication application, UILocalNotification notification) {}
     /**
      * @since Available in iOS 8.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @NotImplemented("application:handleActionWithIdentifier:forLocalNotification:completionHandler:")
     public void handleLocalNotificationAction(UIApplication application, String identifier, UILocalNotification notification, @Block Runnable completionHandler) {}
     /**
      * @since Available in iOS 9.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @NotImplemented("application:handleActionWithIdentifier:forRemoteNotification:withResponseInfo:completionHandler:")
     public void handleRemoteNotificationAction(UIApplication application, String identifier, UIRemoteNotification userInfo, NSDictionary<?, ?> responseInfo, @Block Runnable completionHandler) {}
     /**
      * @since Available in iOS 8.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @NotImplemented("application:handleActionWithIdentifier:forRemoteNotification:completionHandler:")
     public void handleRemoteNotificationAction(UIApplication application, String identifier, UIRemoteNotification userInfo, @Block Runnable completionHandler) {}
     /**
      * @since Available in iOS 9.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @NotImplemented("application:handleActionWithIdentifier:forLocalNotification:withResponseInfo:completionHandler:")
     public void handleLocalNotificationAction(UIApplication application, String identifier, UILocalNotification notification, NSDictionary<?, ?> responseInfo, @Block Runnable completionHandler) {}
     /**
@@ -186,6 +198,11 @@ import org.robovm.apple.corelocation.*;
      */
     @NotImplemented("application:performFetchWithCompletionHandler:")
     public void performFetch(UIApplication application, @Block VoidBlock1<UIBackgroundFetchResult> completionHandler) {}
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("application:performActionForShortcutItem:completionHandler:")
+    public void performAction(UIApplication application, UIApplicationShortcutItem shortcutItem, @Block VoidBooleanBlock completionHandler) {}
     /**
      * @since Available in iOS 7.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationLaunchOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationLaunchOptions.java
@@ -93,6 +93,7 @@ import org.robovm.apple.corelocation.*;
     UIApplicationLaunchOptions(NSDictionary data) {
         super(data);
     }
+    public UIApplicationLaunchOptions() {}
     /*</constructors>*/
 
     /*<methods>*/
@@ -104,6 +105,10 @@ import org.robovm.apple.corelocation.*;
             return data.get(key);
         }
         return null;
+    }
+    public UIApplicationLaunchOptions set(NSString key, NSObject value) {
+        data.put(key, value);
+        return this;
     }
     
 
@@ -120,6 +125,13 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 3.0 and later.
      */
+    public UIApplicationLaunchOptions setURL(NSURL uRL) {
+        set(Keys.URL(), uRL);
+        return this;
+    }
+    /**
+     * @since Available in iOS 3.0 and later.
+     */
     public String getSourceApplication() {
         if (has(Keys.SourceApplication())) {
             NSString val = (NSString) get(Keys.SourceApplication());
@@ -128,8 +140,17 @@ import org.robovm.apple.corelocation.*;
         return null;
     }
     /**
-     * @since Available in iOS 4.0 and later.
+     * @since Available in iOS 3.0 and later.
      */
+    public UIApplicationLaunchOptions setSourceApplication(String sourceApplication) {
+        set(Keys.SourceApplication(), new NSString(sourceApplication));
+        return this;
+    }
+    /**
+     * @since Available in iOS 4.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
     public UILocalNotification getLocalNotification() {
         if (has(Keys.LocalNotification())) {
             UILocalNotification val = (UILocalNotification) get(Keys.LocalNotification());
@@ -138,14 +159,30 @@ import org.robovm.apple.corelocation.*;
         return null;
     }
     /**
+     * @since Available in iOS 4.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    public UIApplicationLaunchOptions setLocalNotification(UILocalNotification localNotification) {
+        set(Keys.LocalNotification(), localNotification);
+        return this;
+    }
+    /**
      * @since Available in iOS 3.2 and later.
      */
-    public NSPropertyList getAnnotation() {
+    public NSObject getAnnotation() {
         if (has(Keys.Annotation())) {
-            NSPropertyList val = (NSPropertyList) get(Keys.Annotation());
+            NSObject val = (NSObject) get(Keys.Annotation());
             return val;
         }
         return null;
+    }
+    /**
+     * @since Available in iOS 3.2 and later.
+     */
+    public UIApplicationLaunchOptions setAnnotation(NSObject annotation) {
+        set(Keys.Annotation(), annotation);
+        return this;
     }
     /**
      * @since Available in iOS 4.0 and later.
@@ -158,6 +195,13 @@ import org.robovm.apple.corelocation.*;
         return false;
     }
     /**
+     * @since Available in iOS 4.0 and later.
+     */
+    public UIApplicationLaunchOptions setLocationStart(boolean locationStart) {
+        set(Keys.Location(), NSNumber.valueOf(locationStart));
+        return this;
+    }
+    /**
      * @since Available in iOS 5.0 and later.
      */
     public List<String> getNewsstandDownloadIdentifiers() {
@@ -166,6 +210,13 @@ import org.robovm.apple.corelocation.*;
             return val.asStringList();
         }
         return null;
+    }
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
+    public UIApplicationLaunchOptions setNewsstandDownloadIdentifiers(List<String> newsstandDownloadIdentifiers) {
+        set(Keys.NewsstandDownloads(), NSArray.fromStrings(newsstandDownloadIdentifiers));
+        return this;
     }
     /**
      * @since Available in iOS 7.0 and later.
@@ -180,12 +231,43 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 7.0 and later.
      */
+    public UIApplicationLaunchOptions setBluetoothCentralIdentifiers(List<String> bluetoothCentralIdentifiers) {
+        set(Keys.BluetoothCentrals(), NSArray.fromStrings(bluetoothCentralIdentifiers));
+        return this;
+    }
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
     public List<String> getBluetoothPeripheralIdentifiers() {
         if (has(Keys.BluetoothPeripherals())) {
             NSArray<NSString> val = (NSArray<NSString>) get(Keys.BluetoothPeripherals());
             return val.asStringList();
         }
         return null;
+    }
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    public UIApplicationLaunchOptions setBluetoothPeripheralIdentifiers(List<String> bluetoothPeripheralIdentifiers) {
+        set(Keys.BluetoothPeripherals(), NSArray.fromStrings(bluetoothPeripheralIdentifiers));
+        return this;
+    }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public UIApplicationShortcutItem getShortcutItem() {
+        if (has(Keys.ShortcutItem())) {
+            UIApplicationShortcutItem val = (UIApplicationShortcutItem) get(Keys.ShortcutItem());
+            return val;
+        }
+        return null;
+    }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public UIApplicationLaunchOptions setShortcutItem(UIApplicationShortcutItem shortcutItem) {
+        set(Keys.ShortcutItem(), shortcutItem);
+        return this;
     }
     /**
      * @since Available in iOS 8.0 and later.
@@ -196,6 +278,13 @@ import org.robovm.apple.corelocation.*;
             return new UIApplicationLaunchOptionsUserActivityInfo(val);
         }
         return null;
+    }
+    /**
+     * @since Available in iOS 8.0 and later.
+     */
+    public UIApplicationLaunchOptions setUserActivityInfo(UIApplicationLaunchOptionsUserActivityInfo userActivityInfo) {
+        set(Keys.UserActivityDictionary(), userActivityInfo.getDictionary());
+        return this;
     }
     /*</methods>*/
     /**
@@ -230,7 +319,9 @@ import org.robovm.apple.corelocation.*;
         public static native NSString RemoteNotification();
         /**
          * @since Available in iOS 4.0 and later.
+         * @deprecated Deprecated in iOS 10.0.
          */
+        @Deprecated
         @GlobalValue(symbol="UIApplicationLaunchOptionsLocalNotificationKey", optional=true)
         public static native NSString LocalNotification();
         /**
@@ -259,10 +350,20 @@ import org.robovm.apple.corelocation.*;
         @GlobalValue(symbol="UIApplicationLaunchOptionsBluetoothPeripheralsKey", optional=true)
         public static native NSString BluetoothPeripherals();
         /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="UIApplicationLaunchOptionsShortcutItemKey", optional=true)
+        public static native NSString ShortcutItem();
+        /**
          * @since Available in iOS 8.0 and later.
          */
         @GlobalValue(symbol="UIApplicationLaunchOptionsUserActivityDictionaryKey", optional=true)
         public static native NSString UserActivityDictionary();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UIApplicationLaunchOptionsCloudKitShareMetadataKey", optional=true)
+        public static native NSString CloudKitShareMetadata();
     }
     /*</keys>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationOpenURLOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationOpenURLOptions.java
@@ -163,6 +163,23 @@ import org.robovm.apple.corelocation.*;
         set(Keys.OpenInPlace(), NSNumber.valueOf(opensInPlace));
         return this;
     }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public boolean isUniversalLinksOnly() {
+        if (has(Keys.UniversalLinksOnly())) {
+            NSNumber val = (NSNumber) get(Keys.UniversalLinksOnly());
+            return val.booleanValue();
+        }
+        return false;
+    }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public UIApplicationOpenURLOptions setUniversalLinksOnly(boolean universalLinksOnly) {
+        set(Keys.UniversalLinksOnly(), NSNumber.valueOf(universalLinksOnly));
+        return this;
+    }
     /*</methods>*/
     
     /*<keys>*/
@@ -184,6 +201,11 @@ import org.robovm.apple.corelocation.*;
          */
         @GlobalValue(symbol="UIApplicationOpenURLOptionsOpenInPlaceKey", optional=true)
         public static native NSString OpenInPlace();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UIApplicationOpenURLOptionUniversalLinksOnly", optional=true)
+        public static native NSString UniversalLinksOnly();
     }
     /*</keys>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationShortcutIcon.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationShortcutIcon.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIApplicationShortcutIcon/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIApplicationShortcutIconPtr extends Ptr<UIApplicationShortcutIcon, UIApplicationShortcutIconPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIApplicationShortcutIcon.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIApplicationShortcutIcon() {}
+    protected UIApplicationShortcutIcon(Handle h, long handle) { super(h, handle); }
+    protected UIApplicationShortcutIcon(SkipInit skipInit) { super(skipInit); }
+    public UIApplicationShortcutIcon(UIApplicationShortcutIconType type) { super((Handle) null, create(type)); retain(getHandle()); }
+    public UIApplicationShortcutIcon(String templateImageName) { super((Handle) null, create(templateImageName)); retain(getHandle()); }
+    /*</constructors>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "iconWithType:")
+    protected static native @Pointer long create(UIApplicationShortcutIconType type);
+    @Method(selector = "iconWithTemplateImageName:")
+    protected static native @Pointer long create(String templateImageName);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationShortcutIconType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationShortcutIconType.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UIApplicationShortcutIconType/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Compose(0L),
+    Play(1L),
+    Pause(2L),
+    Add(3L),
+    Location(4L),
+    Search(5L),
+    Share(6L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Prohibit(7L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Contact(8L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Home(9L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    MarkLocation(10L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Favorite(11L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Love(12L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Cloud(13L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Invitation(14L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Confirmation(15L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Mail(16L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Message(17L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Date(18L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Time(19L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    CapturePhoto(20L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    CaptureVideo(21L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Task(22L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    TaskCompleted(23L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Alarm(24L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Bookmark(25L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Shuffle(26L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Audio(27L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Update(28L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UIApplicationShortcutIconType/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UIApplicationShortcutIconType/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UIApplicationShortcutIconType/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UIApplicationShortcutIconType/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationShortcutItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationShortcutItem.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIApplicationShortcutItem/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIApplicationShortcutItemPtr extends Ptr<UIApplicationShortcutItem, UIApplicationShortcutItemPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIApplicationShortcutItem.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    protected UIApplicationShortcutItem(Handle h, long handle) { super(h, handle); }
+    protected UIApplicationShortcutItem(SkipInit skipInit) { super(skipInit); }
+    public UIApplicationShortcutItem(String type, String localizedTitle, String localizedSubtitle, UIApplicationShortcutIcon icon, NSDictionary<?, ?> userInfo) { super((SkipInit) null); initObject(init(type, localizedTitle, localizedSubtitle, icon, userInfo)); }
+    public UIApplicationShortcutItem(String type, String localizedTitle) { super((SkipInit) null); initObject(init(type, localizedTitle)); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "type")
+    public native String getType();
+    @Property(selector = "localizedTitle")
+    public native String getLocalizedTitle();
+    @Property(selector = "localizedSubtitle")
+    public native String getLocalizedSubtitle();
+    @Property(selector = "icon")
+    public native UIApplicationShortcutIcon getIcon();
+    @Property(selector = "userInfo")
+    public native NSDictionary<?, ?> getUserInfo();
+    /*</properties>*/
+    public void setType(String v) {
+        throw new UnsupportedOperationException("UIApplicationShortcutItem is immutable");
+    }
+
+    public void setLocalizedTitle(String v) {
+        throw new UnsupportedOperationException("UIApplicationShortcutItem is immutable");
+    }
+
+    public void setLocalizedSubtitle(String v) {
+        throw new UnsupportedOperationException("UIApplicationShortcutItem is immutable");
+    }
+
+    public void setIcon(UIApplicationShortcutIcon v) {
+        throw new UnsupportedOperationException("UIApplicationShortcutItem is immutable");
+    }
+
+    public void setUserInfo(NSDictionary<?, ?> v) {
+        throw new UnsupportedOperationException("UIApplicationShortcutItem is immutable");
+    }
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "initWithType:localizedTitle:localizedSubtitle:icon:userInfo:")
+    protected native @Pointer long init(String type, String localizedTitle, String localizedSubtitle, UIApplicationShortcutIcon icon, NSDictionary<?, ?> userInfo);
+    @Method(selector = "initWithType:localizedTitle:")
+    protected native @Pointer long init(String type, String localizedTitle);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAttachmentBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAttachmentBehavior.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIAttachmentBehavior() {}
+    protected UIAttachmentBehavior(Handle h, long handle) { super(h, handle); }
     protected UIAttachmentBehavior(SkipInit skipInit) { super(skipInit); }
     public UIAttachmentBehavior(UIDynamicItem item, @ByVal CGPoint point) { super((SkipInit) null); initObject(init(item, point)); }
     public UIAttachmentBehavior(UIDynamicItem item, @ByVal UIOffset offset, @ByVal CGPoint point) { super((SkipInit) null); initObject(init(item, offset, point)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBarButtonItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBarButtonItem.java
@@ -66,6 +66,9 @@ import org.robovm.apple.corelocation.*;
         }
     }
     
+    public UIBarButtonItem(UIImage image, UIBarButtonItemStyle style) { 
+        this(image, style, null);
+    }
     public UIBarButtonItem(UIImage image, UIBarButtonItemStyle style, OnClickListener listener) { 
         super((SkipInit) null);
         if (listener != null) {
@@ -75,6 +78,9 @@ import org.robovm.apple.corelocation.*;
         } else {
             initObject(init(image, style, null, null));
         }
+    }
+    public UIBarButtonItem(UIImage image, UIImage landscapeImagePhone, UIBarButtonItemStyle style) {
+        this(image, landscapeImagePhone, style, null);
     }
     public UIBarButtonItem(UIImage image, UIImage landscapeImagePhone, UIBarButtonItemStyle style, OnClickListener listener) {
         super((SkipInit) null);
@@ -86,6 +92,9 @@ import org.robovm.apple.corelocation.*;
             initObject(init(image, landscapeImagePhone, style, null, null));
         }
     }
+    public UIBarButtonItem(String title, UIBarButtonItemStyle style) {
+        this(title, style, null);
+    }
     public UIBarButtonItem(String title, UIBarButtonItemStyle style, OnClickListener listener) {
         super((SkipInit) null);
         if (listener != null) {
@@ -95,6 +104,9 @@ import org.robovm.apple.corelocation.*;
         } else {
             initObject(init(title, style, null, null));
         }
+    }
+    public UIBarButtonItem(UIBarButtonSystemItem systemItem) {
+        this(systemItem, null);
     }
     public UIBarButtonItem(UIBarButtonSystemItem systemItem, OnClickListener listener) {
         super((SkipInit) null);
@@ -109,6 +121,7 @@ import org.robovm.apple.corelocation.*;
     
     /*<constructors>*/
     public UIBarButtonItem() {}
+    protected UIBarButtonItem(Handle h, long handle) { super(h, handle); }
     protected UIBarButtonItem(SkipInit skipInit) { super(skipInit); }
     public UIBarButtonItem(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     public UIBarButtonItem(UIImage image, UIBarButtonItemStyle style, NSObject target, Selector action) { super((SkipInit) null); initObject(init(image, style, target, action)); }
@@ -142,9 +155,9 @@ import org.robovm.apple.corelocation.*;
     @Property(selector = "setWidth:")
     public native void setWidth(@MachineSizedFloat double v);
     @Property(selector = "possibleTitles")
-    public native @org.robovm.rt.bro.annotation.Marshaler(NSSet.AsStringListMarshaler.class) List<String> getPossibleTitles();
+    public native @org.robovm.rt.bro.annotation.Marshaler(NSSet.AsStringListMarshaler.class) Set<String> getPossibleTitles();
     @Property(selector = "setPossibleTitles:")
-    public native void setPossibleTitles(@org.robovm.rt.bro.annotation.Marshaler(NSSet.AsStringListMarshaler.class) List<String> v);
+    public native void setPossibleTitles(@org.robovm.rt.bro.annotation.Marshaler(NSSet.AsStringListMarshaler.class) Set<String> v);
     @Property(selector = "customView")
     public native UIView getCustomView();
     @Property(selector = "setCustomView:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBarButtonItemGroup.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBarButtonItemGroup.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIBarButtonItemGroup() {}
+    protected UIBarButtonItemGroup(Handle h, long handle) { super(h, handle); }
     protected UIBarButtonItemGroup(SkipInit skipInit) { super(skipInit); }
     public UIBarButtonItemGroup(NSArray<UIBarButtonItem> barButtonItems, UIBarButtonItem representativeItem) { super((SkipInit) null); initObject(init(barButtonItems, representativeItem)); }
     public UIBarButtonItemGroup(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBarItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBarItem.java
@@ -53,6 +53,7 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIBarItem() {}
+    protected UIBarItem(Handle h, long handle) { super(h, handle); }
     protected UIBarItem(SkipInit skipInit) { super(skipInit); }
     public UIBarItem(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBezierPath.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBezierPath.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIBezierPath() {}
+    protected UIBezierPath(Handle h, long handle) { super(h, handle); }
     protected UIBezierPath(SkipInit skipInit) { super(skipInit); }
     public UIBezierPath(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBlurEffect.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBlurEffect.java
@@ -51,8 +51,9 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIBlurEffect() {}
+    protected UIBlurEffect(Handle h, long handle) { super(h, handle); }
     protected UIBlurEffect(SkipInit skipInit) { super(skipInit); }
-    public UIBlurEffect(UIBlurEffectStyle style) { super(create(style)); retain(getHandle()); }
+    public UIBlurEffect(UIBlurEffectStyle style) { super((Handle) null, create(style)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBlurEffectStyle.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBlurEffectStyle.java
@@ -46,7 +46,19 @@ public enum /*<name>*/UIBlurEffectStyle/*</name>*/ implements ValuedEnum {
     /*<values>*/
     ExtraLight(0L),
     Light(1L),
-    Dark(2L);
+    Dark(2L),
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    ExtraDark(3L),
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    Regular(4L),
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    Prominent(5L);
     /*</values>*/
 
     /*<bind>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIButton.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIButton.java
@@ -51,11 +51,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIButton() {}
+    protected UIButton(Handle h, long handle) { super(h, handle); }
     protected UIButton(SkipInit skipInit) { super(skipInit); }
-    public UIButton(UIButtonType buttonType) { super(create0(buttonType)); retain(getHandle()); }
+    public UIButton(UIButtonType buttonType) { super((Handle) null, create0(buttonType)); retain(getHandle()); }
     /*</constructors>*/
     public UIButton(CGRect frame) {
         super(frame);
+    }
+    public UIButton(NSCoder decoder) {
+        super(decoder);
     }
     /*<properties>*/
     @Property(selector = "contentEdgeInsets")
@@ -167,11 +171,4 @@ import org.robovm.apple.corelocation.*;
     @Method(selector = "buttonWithType:")
     protected static native @Pointer long create0(UIButtonType buttonType);
     /*</methods>*/
-    /**
-     * @Deprecated Use the constructor instead.
-     */
-    @Deprecated
-    public static UIButton create(UIButtonType buttonType) {
-        return new UIButton(buttonType);
-    }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICloudSharingPermissionOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICloudSharingPermissionOptions.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(Bits.AsMachineSizedIntMarshaler.class)/*</annotations>*/
+public final class /*<name>*/UICloudSharingPermissionOptions/*</name>*/ extends Bits</*<name>*/UICloudSharingPermissionOptions/*</name>*/> {
+    /*<values>*/
+    public static final UICloudSharingPermissionOptions None = new UICloudSharingPermissionOptions(0L);
+    public static final UICloudSharingPermissionOptions Standard = new UICloudSharingPermissionOptions(0L);
+    public static final UICloudSharingPermissionOptions AllowPublic = new UICloudSharingPermissionOptions(1L);
+    public static final UICloudSharingPermissionOptions AllowPrivate = new UICloudSharingPermissionOptions(2L);
+    public static final UICloudSharingPermissionOptions AllowReadOnly = new UICloudSharingPermissionOptions(4L);
+    public static final UICloudSharingPermissionOptions AllowReadWrite = new UICloudSharingPermissionOptions(8L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private static final /*<name>*/UICloudSharingPermissionOptions/*</name>*/[] values = _values(/*<name>*/UICloudSharingPermissionOptions/*</name>*/.class);
+
+    public /*<name>*/UICloudSharingPermissionOptions/*</name>*/(long value) { super(value); }
+    private /*<name>*/UICloudSharingPermissionOptions/*</name>*/(long value, long mask) { super(value, mask); }
+    protected /*<name>*/UICloudSharingPermissionOptions/*</name>*/ wrap(long value, long mask) {
+        return new /*<name>*/UICloudSharingPermissionOptions/*</name>*/(value, mask);
+    }
+    protected /*<name>*/UICloudSharingPermissionOptions/*</name>*/[] _values() {
+        return values;
+    }
+    public static /*<name>*/UICloudSharingPermissionOptions/*</name>*/[] values() {
+        return values.clone();
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionReusableView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionReusableView.java
@@ -51,13 +51,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UICollectionReusableView() {}
+    protected UICollectionReusableView(Handle h, long handle) { super(h, handle); }
     protected UICollectionReusableView(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UICollectionReusableView(CGRect frame) {
         super(frame);
     }
-    
+    public UICollectionReusableView(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "reuseIdentifier")
     public native String getReuseIdentifier();

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionView.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UICollectionView() {}
+    protected UICollectionView(Handle h, long handle) { super(h, handle); }
     protected UICollectionView(SkipInit skipInit) { super(skipInit); }
     public UICollectionView(@ByVal CGRect frame, UICollectionViewLayout layout) { super((SkipInit) null); initObject(init(frame, layout)); }
     public UICollectionView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
@@ -68,6 +69,26 @@ import org.robovm.apple.corelocation.*;
     public native UICollectionViewDataSource getDataSource();
     @Property(selector = "setDataSource:", strongRef = true)
     public native void setDataSource(UICollectionViewDataSource v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "prefetchDataSource")
+    public native UICollectionViewDataSourcePrefetching getPrefetchDataSource();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setPrefetchDataSource:", strongRef = true)
+    public native void setPrefetchDataSource(UICollectionViewDataSourcePrefetching v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "isPrefetchingEnabled")
+    public native boolean isPrefetchingEnabled();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setPrefetchingEnabled:")
+    public native void setPrefetchingEnabled(boolean v);
     @Property(selector = "backgroundView")
     public native UIView getBackgroundView();
     @Property(selector = "setBackgroundView:")
@@ -80,8 +101,35 @@ import org.robovm.apple.corelocation.*;
     public native boolean allowsMultipleSelection();
     @Property(selector = "setAllowsMultipleSelection:")
     public native void setAllowsMultipleSelection(boolean v);
+    @Property(selector = "indexPathsForSelectedItems")
+    public native NSArray<NSIndexPath> getIndexPathsForSelectedItems();
+    @Property(selector = "numberOfSections")
+    public native @MachineSizedSInt long getNumberOfSections();
+    @Property(selector = "visibleCells")
+    public native NSArray<UICollectionViewCell> getVisibleCells();
+    @Property(selector = "indexPathsForVisibleItems")
+    public native NSArray<NSIndexPath> getIndexPathsForVisibleItems();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "remembersLastFocusedIndexPath")
+    public native boolean remembersLastFocusedIndexPath();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "setRemembersLastFocusedIndexPath:")
+    public native void setRemembersLastFocusedIndexPath(boolean v);
     /*</properties>*/
     /*<members>*//*</members>*/
+    private UICollectionViewModel model;
+    public void setModel(UICollectionViewModel model) {
+        this.model = model;
+        setDelegate(model);
+        setDataSource(model);
+    }
+    public UICollectionViewModel getModel() {
+        return model;
+    }
     /*<methods>*/
     @Method(selector = "initWithFrame:collectionViewLayout:")
     protected native @Pointer long init(@ByVal CGRect frame, UICollectionViewLayout layout);
@@ -99,8 +147,6 @@ import org.robovm.apple.corelocation.*;
     public native UICollectionReusableView dequeueReusableCell(String identifier, NSIndexPath indexPath);
     @Method(selector = "dequeueReusableSupplementaryViewOfKind:withReuseIdentifier:forIndexPath:")
     public native UICollectionReusableView dequeueReusableSupplementaryView(UICollectionElementKind elementKind, String identifier, NSIndexPath indexPath);
-    @Method(selector = "indexPathsForSelectedItems")
-    public native NSArray<NSIndexPath> getIndexPathsForSelectedItems();
     @Method(selector = "selectItemAtIndexPath:animated:scrollPosition:")
     public native void selectItem(NSIndexPath indexPath, boolean animated, UICollectionViewScrollPosition scrollPosition);
     @Method(selector = "deselectItemAtIndexPath:animated:")
@@ -129,8 +175,6 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "cancelInteractiveTransition")
     public native void cancelInteractiveTransition();
-    @Method(selector = "numberOfSections")
-    public native @MachineSizedSInt long getNumberOfSections();
     @Method(selector = "numberOfItemsInSection:")
     public native @MachineSizedSInt long getNumberOfItemsInSection(@MachineSizedSInt long section);
     @Method(selector = "layoutAttributesForItemAtIndexPath:")
@@ -143,10 +187,6 @@ import org.robovm.apple.corelocation.*;
     public native NSIndexPath getIndexPathForCell(UICollectionViewCell cell);
     @Method(selector = "cellForItemAtIndexPath:")
     public native UICollectionViewCell getCellForItem(NSIndexPath indexPath);
-    @Method(selector = "visibleCells")
-    public native NSArray<UICollectionViewCell> getVisibleCells();
-    @Method(selector = "indexPathsForVisibleItems")
-    public native NSArray<NSIndexPath> getIndexPathsForVisibleItems();
     /**
      * @since Available in iOS 9.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewCell.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewCell.java
@@ -51,13 +51,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UICollectionViewCell() {}
+    protected UICollectionViewCell(Handle h, long handle) { super(h, handle); }
     protected UICollectionViewCell(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UICollectionViewCell(CGRect frame) {
         super(frame);
     }
-    
+    public UICollectionViewCell(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "contentView")
     public native UIView getContentView();

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UICollectionViewController() {}
+    protected UICollectionViewController(Handle h, long handle) { super(h, handle); }
     protected UICollectionViewController(SkipInit skipInit) { super(skipInit); }
     public UICollectionViewController(UICollectionViewLayout layout) { super((SkipInit) null); initObject(init(layout)); }
     public UICollectionViewController(String nibNameOrNil, NSBundle nibBundleOrNil) { super((SkipInit) null); initObject(init(nibNameOrNil, nibBundleOrNil)); }
@@ -135,6 +136,26 @@ import org.robovm.apple.corelocation.*;
     public native void performAction(UICollectionView collectionView, Selector action, NSIndexPath indexPath, NSObject sender);
     @Method(selector = "collectionView:transitionLayoutForOldLayout:newLayout:")
     public native UICollectionViewTransitionLayout getTransitionLayout(UICollectionView collectionView, UICollectionViewLayout fromLayout, UICollectionViewLayout toLayout);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "collectionView:canFocusItemAtIndexPath:")
+    public native boolean canFocusItem(UICollectionView collectionView, NSIndexPath indexPath);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "collectionView:shouldUpdateFocusInContext:")
+    public native boolean shouldUpdateFocus(UICollectionView collectionView, UICollectionViewFocusUpdateContext context);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "collectionView:didUpdateFocusInContext:withAnimationCoordinator:")
+    public native void didUpdateFocus(UICollectionView collectionView, UICollectionViewFocusUpdateContext context, UIFocusAnimationCoordinator coordinator);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "indexPathForPreferredFocusedViewInCollectionView:")
+    public native NSIndexPath getIndexPathForPreferredFocusedView(UICollectionView collectionView);
     /**
      * @since Available in iOS 9.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewDataSourcePrefetching.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewDataSourcePrefetching.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/UICollectionViewDataSourcePrefetching/*</name>*/ 
+    /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<methods>*/
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "collectionView:prefetchItemsAtIndexPaths:")
+    void prefetchItems(UICollectionView collectionView, NSArray<NSIndexPath> indexPaths);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "collectionView:cancelPrefetchingForItemsAtIndexPaths:")
+    void cancelPrefetchingForItems(UICollectionView collectionView, NSArray<NSIndexPath> indexPaths);
+    /*</methods>*/
+    /*<adapter>*/
+    /*</adapter>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewDataSourcePrefetchingAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewDataSourcePrefetchingAdapter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UICollectionViewDataSourcePrefetchingAdapter/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements UICollectionViewDataSourcePrefetching/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("collectionView:prefetchItemsAtIndexPaths:")
+    public void prefetchItems(UICollectionView collectionView, NSArray<NSIndexPath> indexPaths) {}
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("collectionView:cancelPrefetchingForItemsAtIndexPaths:")
+    public void cancelPrefetchingForItems(UICollectionView collectionView, NSArray<NSIndexPath> indexPaths) {}
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewDelegate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewDelegate.java
@@ -91,6 +91,26 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 9.0 and later.
      */
+    @Method(selector = "collectionView:canFocusItemAtIndexPath:")
+    boolean canFocusItem(UICollectionView collectionView, NSIndexPath indexPath);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "collectionView:shouldUpdateFocusInContext:")
+    boolean shouldUpdateFocus(UICollectionView collectionView, UICollectionViewFocusUpdateContext context);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "collectionView:didUpdateFocusInContext:withAnimationCoordinator:")
+    void didUpdateFocus(UICollectionView collectionView, UICollectionViewFocusUpdateContext context, UIFocusAnimationCoordinator coordinator);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "indexPathForPreferredFocusedViewInCollectionView:")
+    NSIndexPath getIndexPathForPreferredFocusedView(UICollectionView collectionView);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
     @Method(selector = "collectionView:targetIndexPathForMoveFromItemAtIndexPath:toProposedIndexPath:")
     NSIndexPath getTargetIndexPathForMoveFromItem(UICollectionView collectionView, NSIndexPath originalIndexPath, NSIndexPath proposedIndexPath);
     /**

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewDelegateAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewDelegateAdapter.java
@@ -93,6 +93,26 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 9.0 and later.
      */
+    @NotImplemented("collectionView:canFocusItemAtIndexPath:")
+    public boolean canFocusItem(UICollectionView collectionView, NSIndexPath indexPath) { return false; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("collectionView:shouldUpdateFocusInContext:")
+    public boolean shouldUpdateFocus(UICollectionView collectionView, UICollectionViewFocusUpdateContext context) { return false; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("collectionView:didUpdateFocusInContext:withAnimationCoordinator:")
+    public void didUpdateFocus(UICollectionView collectionView, UICollectionViewFocusUpdateContext context, UIFocusAnimationCoordinator coordinator) {}
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("indexPathForPreferredFocusedViewInCollectionView:")
+    public NSIndexPath getIndexPathForPreferredFocusedView(UICollectionView collectionView) { return null; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
     @NotImplemented("collectionView:targetIndexPathForMoveFromItemAtIndexPath:toProposedIndexPath:")
     public NSIndexPath getTargetIndexPathForMoveFromItem(UICollectionView collectionView, NSIndexPath originalIndexPath, NSIndexPath proposedIndexPath) { return null; }
     /**

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewFlowLayout.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewFlowLayout.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UICollectionViewFlowLayout() {}
+    protected UICollectionViewFlowLayout(Handle h, long handle) { super(h, handle); }
     protected UICollectionViewFlowLayout(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
@@ -115,6 +116,12 @@ import org.robovm.apple.corelocation.*;
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="UICollectionViewFlowLayoutAutomaticSize", optional=true)
+    public static native @ByVal CGSize getAutomaticSize();
+    
     
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewFlowLayoutInvalidationContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewFlowLayoutInvalidationContext.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UICollectionViewFlowLayoutInvalidationContext() {}
+    protected UICollectionViewFlowLayoutInvalidationContext(Handle h, long handle) { super(h, handle); }
     protected UICollectionViewFlowLayoutInvalidationContext(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewFocusUpdateContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewFocusUpdateContext.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UICollectionViewFocusUpdateContext/*</name>*/ 
+    extends /*<extends>*/UIFocusUpdateContext/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UICollectionViewFocusUpdateContextPtr extends Ptr<UICollectionViewFocusUpdateContext, UICollectionViewFocusUpdateContextPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UICollectionViewFocusUpdateContext.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UICollectionViewFocusUpdateContext() {}
+    protected UICollectionViewFocusUpdateContext(Handle h, long handle) { super(h, handle); }
+    protected UICollectionViewFocusUpdateContext(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "previouslyFocusedIndexPath")
+    public native NSIndexPath getPreviouslyFocusedIndexPath();
+    @Property(selector = "nextFocusedIndexPath")
+    public native NSIndexPath getNextFocusedIndexPath();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewLayout.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewLayout.java
@@ -51,12 +51,22 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UICollectionViewLayout() {}
+    protected UICollectionViewLayout(Handle h, long handle) { super(h, handle); }
     protected UICollectionViewLayout(SkipInit skipInit) { super(skipInit); }
     public UICollectionViewLayout(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "collectionView")
     public native UICollectionView getCollectionView();
+    @Property(selector = "layoutAttributesClass")
+    public static native Class<? extends UICollectionViewLayoutAttributes> getLayoutAttributesClass();
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @Property(selector = "invalidationContextClass")
+    public static native Class<? extends UICollectionViewLayoutInvalidationContext> getInvalidationContextClass();
+    @Property(selector = "collectionViewContentSize")
+    public native @ByVal CGSize getCollectionViewContentSize();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -107,15 +117,6 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "targetContentOffsetForProposedContentOffset:")
     public native @ByVal CGPoint getTargetContentOffset(@ByVal CGPoint proposedContentOffset);
-    @Method(selector = "collectionViewContentSize")
-    public native @ByVal CGSize getCollectionViewContentSize();
-    @Method(selector = "layoutAttributesClass")
-    public static native Class<? extends UICollectionViewLayoutAttributes> getLayoutAttributesClass();
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    @Method(selector = "invalidationContextClass")
-    public static native Class<? extends UICollectionViewLayoutInvalidationContext> getInvalidationContextClass();
     @Method(selector = "prepareForCollectionViewUpdates:")
     public native void prepareForCollectionViewUpdates(NSArray<UICollectionViewUpdateItem> updateItems);
     @Method(selector = "finalizeCollectionViewUpdates")
@@ -185,7 +186,7 @@ import org.robovm.apple.corelocation.*;
      * @since Available in iOS 9.0 and later.
      */
     @Method(selector = "invalidationContextForInteractivelyMovingItems:withTargetPosition:previousIndexPaths:previousPosition:")
-    public native UICollectionViewLayoutInvalidationContext getInvalidationContextForInteractivelyMovingItems(NSArray<?> targetIndexPaths, @ByVal CGPoint targetPosition, NSArray<NSIndexPath> previousIndexPaths, @ByVal CGPoint previousPosition);
+    public native UICollectionViewLayoutInvalidationContext getInvalidationContextForInteractivelyMovingItems(NSArray<NSIndexPath> targetIndexPaths, @ByVal CGPoint targetPosition, NSArray<NSIndexPath> previousIndexPaths, @ByVal CGPoint previousPosition);
     /**
      * @since Available in iOS 9.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewLayoutAttributes.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewLayoutAttributes.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UICollectionViewLayoutAttributes() {}
+    protected UICollectionViewLayoutAttributes(Handle h, long handle) { super(h, handle); }
     protected UICollectionViewLayoutAttributes(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewLayoutInvalidationContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewLayoutInvalidationContext.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UICollectionViewLayoutInvalidationContext() {}
+    protected UICollectionViewLayoutInvalidationContext(Handle h, long handle) { super(h, handle); }
     protected UICollectionViewLayoutInvalidationContext(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewModel.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewModel.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+import org.robovm.apple.coregraphics.CGPoint;
+import org.robovm.apple.foundation.NSIndexPath;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.objc.Selector;
+import org.robovm.objc.annotation.NotImplemented;
+import org.robovm.rt.bro.annotation.ByVal;
+import org.robovm.rt.bro.annotation.MachineSizedSInt;
+
+public class UICollectionViewModel extends UIScrollViewDelegateAdapter implements UICollectionViewDelegate, UICollectionViewDataSource {
+    @NotImplemented("collectionView:shouldHighlightItemAtIndexPath:")
+    public boolean shouldHighlightItem(UICollectionView collectionView, NSIndexPath indexPath) { return false; }
+    @NotImplemented("collectionView:didHighlightItemAtIndexPath:")
+    public void didHighlightItem(UICollectionView collectionView, NSIndexPath indexPath) {}
+    @NotImplemented("collectionView:didUnhighlightItemAtIndexPath:")
+    public void didUnhighlightItem(UICollectionView collectionView, NSIndexPath indexPath) {}
+    @NotImplemented("collectionView:shouldSelectItemAtIndexPath:")
+    public boolean shouldSelectItem(UICollectionView collectionView, NSIndexPath indexPath) { return false; }
+    @NotImplemented("collectionView:shouldDeselectItemAtIndexPath:")
+    public boolean shouldDeselectItem(UICollectionView collectionView, NSIndexPath indexPath) { return false; }
+    @NotImplemented("collectionView:didSelectItemAtIndexPath:")
+    public void didSelectItem(UICollectionView collectionView, NSIndexPath indexPath) {}
+    @NotImplemented("collectionView:didDeselectItemAtIndexPath:")
+    public void didDeselectItem(UICollectionView collectionView, NSIndexPath indexPath) {}
+    /**
+     * @since Available in iOS 8.0 and later.
+     */
+    @NotImplemented("collectionView:willDisplayCell:forItemAtIndexPath:")
+    public void willDisplayCell(UICollectionView collectionView, UICollectionViewCell cell, NSIndexPath indexPath) {}
+    /**
+     * @since Available in iOS 8.0 and later.
+     */
+    @NotImplemented("collectionView:willDisplaySupplementaryView:forElementKind:atIndexPath:")
+    public void willDisplaySupplementaryView(UICollectionView collectionView, UICollectionReusableView view, String elementKind, NSIndexPath indexPath) {}
+    @NotImplemented("collectionView:didEndDisplayingCell:forItemAtIndexPath:")
+    public void didEndDisplayingCell(UICollectionView collectionView, UICollectionViewCell cell, NSIndexPath indexPath) {}
+    @NotImplemented("collectionView:didEndDisplayingSupplementaryView:forElementOfKind:atIndexPath:")
+    public void didEndDisplayingSupplementaryView(UICollectionView collectionView, UICollectionReusableView view, String elementKind, NSIndexPath indexPath) {}
+    @NotImplemented("collectionView:shouldShowMenuForItemAtIndexPath:")
+    public boolean shouldShowMenuForItem(UICollectionView collectionView, NSIndexPath indexPath) { return false; }
+    @NotImplemented("collectionView:canPerformAction:forItemAtIndexPath:withSender:")
+    public boolean canPerformAction(UICollectionView collectionView, Selector action, NSIndexPath indexPath, NSObject sender) { return false; }
+    @NotImplemented("collectionView:performAction:forItemAtIndexPath:withSender:")
+    public void performAction(UICollectionView collectionView, Selector action, NSIndexPath indexPath, NSObject sender) {}
+    @NotImplemented("collectionView:transitionLayoutForOldLayout:newLayout:")
+    public UICollectionViewTransitionLayout getTransitionLayout(UICollectionView collectionView, UICollectionViewLayout fromLayout, UICollectionViewLayout toLayout) { return null; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("collectionView:canFocusItemAtIndexPath:")
+    public boolean canFocusItem(UICollectionView collectionView, NSIndexPath indexPath) { return false; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("collectionView:shouldUpdateFocusInContext:")
+    public boolean shouldUpdateFocus(UICollectionView collectionView, UICollectionViewFocusUpdateContext context) { return false; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("collectionView:didUpdateFocusInContext:withAnimationCoordinator:")
+    public void didUpdateFocus(UICollectionView collectionView, UICollectionViewFocusUpdateContext context, UIFocusAnimationCoordinator coordinator) {}
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("indexPathForPreferredFocusedViewInCollectionView:")
+    public NSIndexPath getIndexPathForPreferredFocusedView(UICollectionView collectionView) { return null; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("collectionView:targetIndexPathForMoveFromItemAtIndexPath:toProposedIndexPath:")
+    public NSIndexPath getTargetIndexPathForMoveFromItem(UICollectionView collectionView, NSIndexPath originalIndexPath, NSIndexPath proposedIndexPath) { return null; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("collectionView:targetContentOffsetForProposedContentOffset:")
+    public @ByVal CGPoint getTargetContentOffsetForProposedContentOffset(UICollectionView collectionView, @ByVal CGPoint proposedContentOffset) { return null; }
+
+    @NotImplemented("collectionView:numberOfItemsInSection:")
+    public @MachineSizedSInt long getNumberOfItemsInSection(UICollectionView collectionView, @MachineSizedSInt long section) { return 0; }
+    @NotImplemented("collectionView:cellForItemAtIndexPath:")
+    public UICollectionViewCell getCellForItem(UICollectionView collectionView, NSIndexPath indexPath) { return null; }
+    @NotImplemented("numberOfSectionsInCollectionView:")
+    public @MachineSizedSInt long getNumberOfSections(UICollectionView collectionView) { return 0; }
+    @NotImplemented("collectionView:viewForSupplementaryElementOfKind:atIndexPath:")
+    public UICollectionReusableView getViewForSupplementaryElement(UICollectionView collectionView, String kind, NSIndexPath indexPath) { return null; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("collectionView:canMoveItemAtIndexPath:")
+    public boolean canMoveItemAt(UICollectionView collectionView, NSIndexPath indexPath) { return false; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("collectionView:moveItemAtIndexPath:toIndexPath:")
+    public void moveItemAt(UICollectionView collectionView, NSIndexPath sourceIndexPath, NSIndexPath destinationIndexPath) {}
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewTransitionLayout.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewTransitionLayout.java
@@ -50,7 +50,7 @@ import org.robovm.apple.corelocation.*;
     /*<bind>*/static { ObjCRuntime.bind(UICollectionViewTransitionLayout.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public UICollectionViewTransitionLayout() {}
+    protected UICollectionViewTransitionLayout() {}
     protected UICollectionViewTransitionLayout(Handle h, long handle) { super(h, handle); }
     protected UICollectionViewTransitionLayout(SkipInit skipInit) { super(skipInit); }
     public UICollectionViewTransitionLayout(UICollectionViewLayout currentLayout, UICollectionViewLayout newLayout) { super((SkipInit) null); initObject(init(currentLayout, newLayout)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewTransitionLayout.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewTransitionLayout.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UICollectionViewTransitionLayout() {}
+    protected UICollectionViewTransitionLayout(Handle h, long handle) { super(h, handle); }
     protected UICollectionViewTransitionLayout(SkipInit skipInit) { super(skipInit); }
     public UICollectionViewTransitionLayout(UICollectionViewLayout currentLayout, UICollectionViewLayout newLayout) { super((SkipInit) null); initObject(init(currentLayout, newLayout)); }
     public UICollectionViewTransitionLayout(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewUpdateItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewUpdateItem.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UICollectionViewUpdateItem() {}
+    protected UICollectionViewUpdateItem(Handle h, long handle) { super(h, handle); }
     protected UICollectionViewUpdateItem(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollisionBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollisionBehavior.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UICollisionBehavior() {}
+    protected UICollisionBehavior(Handle h, long handle) { super(h, handle); }
     protected UICollisionBehavior(SkipInit skipInit) { super(skipInit); }
     public UICollisionBehavior(List<UIDynamicItem> items) { super((SkipInit) null); initObject(init(items)); }
     /*</constructors>*/
@@ -66,7 +67,7 @@ import org.robovm.apple.corelocation.*;
     @Property(selector = "setTranslatesReferenceBoundsIntoBoundary:")
     public native void setTranslatesReferenceBoundsIntoBoundary(boolean v);
     @Property(selector = "boundaryIdentifiers")
-    public native NSArray getBoundaryIdentifiers();
+    public native NSArray<?> getBoundaryIdentifiers();
     @Property(selector = "collisionDelegate")
     public native UICollisionBehaviorDelegate getCollisionDelegate();
     @Property(selector = "setCollisionDelegate:", strongRef = true)

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIColor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIColor.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIColor() {}
+    protected UIColor(Handle h, long handle) { super(h, handle); }
     protected UIColor(SkipInit skipInit) { super(skipInit); }
     public UIColor(@MachineSizedFloat double red, @MachineSizedFloat double green, @MachineSizedFloat double blue, @MachineSizedFloat double alpha) { super((SkipInit) null); initObject(init(red, green, blue, alpha)); }
     public UIColor(CGColor cgColor) { super((SkipInit) null); initObject(init(cgColor)); }
@@ -60,6 +61,36 @@ import org.robovm.apple.corelocation.*;
     public UIColor(CIColor ciColor) { super((SkipInit) null); initObject(init(ciColor)); }
     /*</constructors>*/
     /*<properties>*/
+    @Property(selector = "blackColor")
+    public static native UIColor black();
+    @Property(selector = "darkGrayColor")
+    public static native UIColor darkGray();
+    @Property(selector = "lightGrayColor")
+    public static native UIColor lightGray();
+    @Property(selector = "whiteColor")
+    public static native UIColor white();
+    @Property(selector = "grayColor")
+    public static native UIColor gray();
+    @Property(selector = "redColor")
+    public static native UIColor red();
+    @Property(selector = "greenColor")
+    public static native UIColor green();
+    @Property(selector = "blueColor")
+    public static native UIColor blue();
+    @Property(selector = "cyanColor")
+    public static native UIColor cyan();
+    @Property(selector = "yellowColor")
+    public static native UIColor yellow();
+    @Property(selector = "magentaColor")
+    public static native UIColor magenta();
+    @Property(selector = "orangeColor")
+    public static native UIColor orange();
+    @Property(selector = "purpleColor")
+    public static native UIColor purple();
+    @Property(selector = "brownColor")
+    public static native UIColor brown();
+    @Property(selector = "clearColor")
+    public static native UIColor clear();
     @Property(selector = "CGColor")
     public native CGColor getCGColor();
     /**
@@ -67,6 +98,33 @@ import org.robovm.apple.corelocation.*;
      */
     @Property(selector = "CIColor")
     public native CIColor getCIColor();
+    @Property(selector = "lightTextColor")
+    public static native UIColor lightText();
+    @Property(selector = "darkTextColor")
+    public static native UIColor darkText();
+    @Property(selector = "groupTableViewBackgroundColor")
+    public static native UIColor groupTableViewBackground();
+    /**
+     * @since Available in iOS 2.0 and later.
+     * @deprecated Deprecated in iOS 7.0.
+     */
+    @Deprecated
+    @Property(selector = "viewFlipsideBackgroundColor")
+    public static native UIColor viewFlipsideBackground();
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 7.0.
+     */
+    @Deprecated
+    @Property(selector = "scrollViewTexturedBackgroundColor")
+    public static native UIColor scrollViewTexturedBackground();
+    /**
+     * @since Available in iOS 5.0 and later.
+     * @deprecated Deprecated in iOS 7.0.
+     */
+    @Deprecated
+    @Property(selector = "underPageBackgroundColor")
+    public static native UIColor underPageBackground();
     /*</properties>*/
     /*<members>*//*</members>*/
     
@@ -156,6 +214,11 @@ import org.robovm.apple.corelocation.*;
     public static native UIColor fromHSBA(@MachineSizedFloat double hue, @MachineSizedFloat double saturation, @MachineSizedFloat double brightness, @MachineSizedFloat double alpha);
     @Method(selector = "colorWithRed:green:blue:alpha:")
     public static native UIColor fromRGBA(@MachineSizedFloat double red, @MachineSizedFloat double green, @MachineSizedFloat double blue, @MachineSizedFloat double alpha);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "colorWithDisplayP3Red:green:blue:alpha:")
+    public static native UIColor fromDisplayP3(@MachineSizedFloat double displayP3Red, @MachineSizedFloat double green, @MachineSizedFloat double blue, @MachineSizedFloat double alpha);
     @Method(selector = "colorWithCGColor:")
     public static native UIColor fromCGColor(CGColor cgColor);
     @Method(selector = "colorWithPatternImage:")
@@ -165,62 +228,5 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "colorWithCIColor:")
     public static native UIColor fromCIColor(CIColor ciColor);
-    @Method(selector = "blackColor")
-    public static native UIColor black();
-    @Method(selector = "darkGrayColor")
-    public static native UIColor darkGray();
-    @Method(selector = "lightGrayColor")
-    public static native UIColor lightGray();
-    @Method(selector = "whiteColor")
-    public static native UIColor white();
-    @Method(selector = "grayColor")
-    public static native UIColor gray();
-    @Method(selector = "redColor")
-    public static native UIColor red();
-    @Method(selector = "greenColor")
-    public static native UIColor green();
-    @Method(selector = "blueColor")
-    public static native UIColor blue();
-    @Method(selector = "cyanColor")
-    public static native UIColor cyan();
-    @Method(selector = "yellowColor")
-    public static native UIColor yellow();
-    @Method(selector = "magentaColor")
-    public static native UIColor magenta();
-    @Method(selector = "orangeColor")
-    public static native UIColor orange();
-    @Method(selector = "purpleColor")
-    public static native UIColor purple();
-    @Method(selector = "brownColor")
-    public static native UIColor brown();
-    @Method(selector = "clearColor")
-    public static native UIColor clear();
-    @Method(selector = "lightTextColor")
-    public static native UIColor lightText();
-    @Method(selector = "darkTextColor")
-    public static native UIColor darkText();
-    @Method(selector = "groupTableViewBackgroundColor")
-    public static native UIColor groupTableViewBackground();
-    /**
-     * @since Available in iOS 2.0 and later.
-     * @deprecated Deprecated in iOS 7.0.
-     */
-    @Deprecated
-    @Method(selector = "viewFlipsideBackgroundColor")
-    public static native UIColor viewFlipsideBackground();
-    /**
-     * @since Available in iOS 3.2 and later.
-     * @deprecated Deprecated in iOS 7.0.
-     */
-    @Deprecated
-    @Method(selector = "scrollViewTexturedBackgroundColor")
-    public static native UIColor scrollViewTexturedBackground();
-    /**
-     * @since Available in iOS 5.0 and later.
-     * @deprecated Deprecated in iOS 7.0.
-     */
-    @Deprecated
-    @Method(selector = "underPageBackgroundColor")
-    public static native UIColor underPageBackground();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIContentSizeCategory.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIContentSizeCategory.java
@@ -94,6 +94,10 @@ import org.robovm.apple.corelocation.*;
 
     /*<constants>*/
     /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UIContentSizeCategory Unspecified = new UIContentSizeCategory("Unspecified");
+    /**
      * @since Available in iOS 7.0 and later.
      */
     public static final UIContentSizeCategory ExtraSmall = new UIContentSizeCategory("ExtraSmall");
@@ -143,7 +147,7 @@ import org.robovm.apple.corelocation.*;
     public static final UIContentSizeCategory AccessibilityExtraExtraExtraLarge = new UIContentSizeCategory("AccessibilityExtraExtraExtraLarge");
     /*</constants>*/
     
-    private static /*<name>*/UIContentSizeCategory/*</name>*/[] values = new /*<name>*/UIContentSizeCategory/*</name>*/[] {/*<value_list>*/ExtraSmall, Small, Medium, Large, ExtraLarge, ExtraExtraLarge, ExtraExtraExtraLarge, AccessibilityMedium, AccessibilityLarge, AccessibilityExtraLarge, AccessibilityExtraExtraLarge, AccessibilityExtraExtraExtraLarge/*</value_list>*/};
+    private static /*<name>*/UIContentSizeCategory/*</name>*/[] values = new /*<name>*/UIContentSizeCategory/*</name>*/[] {/*<value_list>*/Unspecified, ExtraSmall, Small, Medium, Large, ExtraLarge, ExtraExtraLarge, ExtraExtraExtraLarge, AccessibilityMedium, AccessibilityLarge, AccessibilityExtraLarge, AccessibilityExtraExtraLarge, AccessibilityExtraExtraExtraLarge/*</value_list>*/};
     
     /*<name>*/UIContentSizeCategory/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -166,6 +170,11 @@ import org.robovm.apple.corelocation.*;
     	static { Bro.bind(Values.class); }
 
         /*<values>*/
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UIContentSizeCategoryUnspecified", optional=true)
+        public static native NSString Unspecified();
         /**
          * @since Available in iOS 7.0 and later.
          */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIControl.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIControl.java
@@ -51,14 +51,16 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIControl() {}
-    protected UIControl(long handle) { super(handle); }
+    @Deprecated protected UIControl(long handle) { super(handle); }
+    protected UIControl(Handle h, long handle) { super(h, handle); }
     protected UIControl(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UIControl(CGRect frame) {
         super(frame);
     }    
-    
+    public UIControl(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "isEnabled")
     public native boolean isEnabled();
@@ -86,6 +88,10 @@ import org.robovm.apple.corelocation.*;
     public native boolean isTracking();
     @Property(selector = "isTouchInside")
     public native boolean isTouchInside();
+    @Property(selector = "allTargets")
+    public native NSSet<?> getAllTargets();
+    @Property(selector = "allControlEvents")
+    public native UIControlEvents getAllControlEvents();
     /*</properties>*/
     /*<members>*//*</members>*/
     
@@ -134,6 +140,8 @@ import org.robovm.apple.corelocation.*;
                 ((OnEditingDidEndListener) listener).onEditingDidEnd(control);
             } else if (controlEvent == UIControlEvents.EditingDidEndOnExit) {
                 ((OnEditingDidEndOnExitListener) listener).onEditingDidEndOnExit(control);
+            } else if (controlEvent == UIControlEvents.PrimaryActionTriggered) {
+                ((OnPrimaryActionTriggeredListener) listener).onPrimaryActionTriggered(control);
             }
         }
     }
@@ -180,6 +188,9 @@ import org.robovm.apple.corelocation.*;
     public interface OnEditingDidEndOnExitListener extends Listener {
         void onEditingDidEndOnExit(UIControl control);
     }
+    public interface OnPrimaryActionTriggeredListener extends Listener {
+        void onPrimaryActionTriggered(UIControl control);
+    }
     
     public void addOnTouchDownListener(OnTouchDownListener l) {
         addListener(l, UIControlEvents.TouchDown);
@@ -223,6 +234,9 @@ import org.robovm.apple.corelocation.*;
     public void addOnEditingDidEndOnExitListener(OnEditingDidEndOnExitListener l) {
         addListener(l, UIControlEvents.EditingDidEndOnExit);
     }
+    public void addOnPrimaryActionTriggeredListener(OnPrimaryActionTriggeredListener l) {
+        addListener(l, UIControlEvents.PrimaryActionTriggered);
+    }
     
     @SuppressWarnings("unchecked")
     private List<ListenerWrapper> getListeners(boolean create) {
@@ -242,7 +256,8 @@ import org.robovm.apple.corelocation.*;
                 || listener instanceof OnEditingChangedListener 
                 || listener instanceof OnEditingDidBeginListener 
                 || listener instanceof OnEditingDidEndListener 
-                || listener instanceof OnEditingDidEndOnExitListener) {
+                || listener instanceof OnEditingDidEndOnExitListener
+                || listener instanceof OnPrimaryActionTriggeredListener) {
             selector = handleEvent;
         }
         ListenerWrapper wrapper = new ListenerWrapper(listener, controlEvent, selector);
@@ -283,10 +298,6 @@ import org.robovm.apple.corelocation.*;
     public native void addTarget(NSObject target, Selector action, UIControlEvents controlEvents);
     @Method(selector = "removeTarget:action:forControlEvents:")
     public native void removeTarget(NSObject target, Selector action, UIControlEvents controlEvents);
-    @Method(selector = "allTargets")
-    public native NSSet<?> getAllTargets();
-    @Method(selector = "allControlEvents")
-    public native UIControlEvents getAllControlEvents();
     @Method(selector = "actionsForTarget:forControlEvent:")
     public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getActions(NSObject target, UIControlEvents controlEvent);
     @Method(selector = "sendAction:to:forEvent:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIControlState.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIControlState.java
@@ -46,6 +46,10 @@ public final class /*<name>*/UIControlState/*</name>*/ extends Bits</*<name>*/UI
     public static final UIControlState Highlighted = new UIControlState(1L);
     public static final UIControlState Disabled = new UIControlState(2L);
     public static final UIControlState Selected = new UIControlState(4L);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final UIControlState Focused = new UIControlState(8L);
     public static final UIControlState Application = new UIControlState(16711680L);
     public static final UIControlState Reserved = new UIControlState(4278190080L);
     /*</values>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICubicTimingParameters.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICubicTimingParameters.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UICubicTimingParameters/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements UITimingCurveProvider/*</implements>*/ {
+
+    /*<ptr>*/public static class UICubicTimingParametersPtr extends Ptr<UICubicTimingParameters, UICubicTimingParametersPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UICubicTimingParameters.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UICubicTimingParameters() {}
+    protected UICubicTimingParameters(Handle h, long handle) { super(h, handle); }
+    protected UICubicTimingParameters(SkipInit skipInit) { super(skipInit); }
+    public UICubicTimingParameters(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    public UICubicTimingParameters(UIViewAnimationCurve curve) { super((SkipInit) null); initObject(init(curve)); }
+    public UICubicTimingParameters(@ByVal CGPoint point1, @ByVal CGPoint point2) { super((SkipInit) null); initObject(init(point1, point2)); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "animationCurve")
+    public native UIViewAnimationCurve getAnimationCurve();
+    @Property(selector = "controlPoint1")
+    public native @ByVal CGPoint getControlPoint1();
+    @Property(selector = "controlPoint2")
+    public native @ByVal CGPoint getControlPoint2();
+    @Property(selector = "timingCurveType")
+    public native UITimingCurveType getTimingCurveType();
+    @Property(selector = "cubicTimingParameters")
+    public native UICubicTimingParameters getCubicTimingParameters();
+    @Property(selector = "springTimingParameters")
+    public native UISpringTimingParameters getSpringTimingParameters();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "initWithCoder:")
+    protected native @Pointer long init(NSCoder aDecoder);
+    @Method(selector = "initWithAnimationCurve:")
+    protected native @Pointer long init(UIViewAnimationCurve curve);
+    @Method(selector = "initWithControlPoint1:controlPoint2:")
+    protected native @Pointer long init(@ByVal CGPoint point1, @ByVal CGPoint point2);
+    @Method(selector = "encodeWithCoder:")
+    public native void encode(NSCoder coder);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDataDetectorTypes.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDataDetectorTypes.java
@@ -52,6 +52,18 @@ public final class /*<name>*/UIDataDetectorTypes/*</name>*/ extends Bits</*<name
      * @since Available in iOS 4.0 and later.
      */
     public static final UIDataDetectorTypes CalendarEvent = new UIDataDetectorTypes(8L);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UIDataDetectorTypes ShipmentTrackingNumber = new UIDataDetectorTypes(16L);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UIDataDetectorTypes FlightNumber = new UIDataDetectorTypes(32L);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UIDataDetectorTypes LookupSuggestion = new UIDataDetectorTypes(64L);
     public static final UIDataDetectorTypes None = new UIDataDetectorTypes(0L);
     public static final UIDataDetectorTypes All = new UIDataDetectorTypes(Bro.IS_32BIT ? 0xffffffffL : 0xffffffffffffffffL);
     /*</values>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDatePicker.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDatePicker.java
@@ -51,13 +51,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIDatePicker() {}
+    protected UIDatePicker(Handle h, long handle) { super(h, handle); }
     protected UIDatePicker(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UIDatePicker(CGRect frame) {
         super(frame);
     }
-    
+    public UIDatePicker(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "datePickerMode")
     public native UIDatePickerMode getDatePickerMode();

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDevice.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDevice.java
@@ -94,9 +94,12 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIDevice() {}
+    protected UIDevice(Handle h, long handle) { super(h, handle); }
     protected UIDevice(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
+    @Property(selector = "currentDevice")
+    public static native UIDevice getCurrentDevice();
     @Property(selector = "name")
     public native String getName();
     @Property(selector = "model")
@@ -191,7 +194,5 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "playInputClick")
     public native void playInputClick();
-    @Method(selector = "currentDevice")
-    public static native UIDevice getCurrentDevice();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDictationPhrase.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDictationPhrase.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIDictationPhrase() {}
+    protected UIDictationPhrase(Handle h, long handle) { super(h, handle); }
     protected UIDictationPhrase(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDisplayGamut.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDisplayGamut.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UIDisplayGamut/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Unspecified(-1L),
+    SRGB(0L),
+    P3(1L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UIDisplayGamut/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UIDisplayGamut/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UIDisplayGamut/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UIDisplayGamut/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocument.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocument.java
@@ -64,6 +64,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIDocument() {}
+    protected UIDocument(Handle h, long handle) { super(h, handle); }
     protected UIDocument(SkipInit skipInit) { super(skipInit); }
     public UIDocument(NSURL url) { super((SkipInit) null); initObject(init(url)); }
     /*</constructors>*/
@@ -80,10 +81,19 @@ import org.robovm.apple.corelocation.*;
     public native void setFileModificationDate(NSDate v);
     @Property(selector = "documentState")
     public native UIDocumentState getDocumentState();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "progress")
+    public native NSProgress getProgress();
     @Property(selector = "undoManager")
     public native NSUndoManager getUndoManager();
     @Property(selector = "setUndoManager:")
     public native void setUndoManager(NSUndoManager v);
+    @Property(selector = "hasUnsavedChanges")
+    public native boolean hasUnsavedChanges();
+    @Property(selector = "savingFileType")
+    public native String getSavingFileType();
     /**
      * @since Available in iOS 8.0 and later.
      */
@@ -98,8 +108,6 @@ import org.robovm.apple.corelocation.*;
     public native NSURL getPresentedItemURL();
     @Property(selector = "presentedItemOperationQueue")
     public native NSOperationQueue getPresentedItemOperationQueue();
-    @Property(selector = "progress")
-    public native NSProgress getProgress();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -140,8 +148,6 @@ import org.robovm.apple.corelocation.*;
     public native void disableEditing();
     @Method(selector = "enableEditing")
     public native void enableEditing();
-    @Method(selector = "hasUnsavedChanges")
-    public native boolean hasUnsavedChanges();
     @Method(selector = "updateChangeCount:")
     public native void updateChangeCount(UIDocumentChangeKind change);
     @Method(selector = "changeCountTokenForSaveOperation:")
@@ -152,8 +158,6 @@ import org.robovm.apple.corelocation.*;
     public native void save(NSURL url, UIDocumentSaveOperation saveOperation, @Block VoidBooleanBlock completionHandler);
     @Method(selector = "autosaveWithCompletionHandler:")
     public native void autoSave(@Block VoidBooleanBlock completionHandler);
-    @Method(selector = "savingFileType")
-    public native String getSavingFileType();
     @Method(selector = "fileNameExtensionForType:saveOperation:")
     public native String getFileNameExtension(String typeName, UIDocumentSaveOperation saveOperation);
     public boolean writeContents(NSObject contents, NSFileAttributes additionalFileAttributes, NSURL url, UIDocumentSaveOperation saveOperation) throws NSErrorException {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocumentInteractionController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocumentInteractionController.java
@@ -51,8 +51,9 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIDocumentInteractionController() {}
+    protected UIDocumentInteractionController(Handle h, long handle) { super(h, handle); }
     protected UIDocumentInteractionController(SkipInit skipInit) { super(skipInit); }
-    public UIDocumentInteractionController(NSURL url) { super(create(url)); retain(getHandle()); }
+    public UIDocumentInteractionController(NSURL url) { super((Handle) null, create(url)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "delegate")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocumentMenuViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocumentMenuViewController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIDocumentMenuViewController() {}
+    protected UIDocumentMenuViewController(Handle h, long handle) { super(h, handle); }
     protected UIDocumentMenuViewController(SkipInit skipInit) { super(skipInit); }
     public UIDocumentMenuViewController(@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> allowedUTIs, UIDocumentPickerMode mode) { super((SkipInit) null); initObject(init(allowedUTIs, mode)); }
     public UIDocumentMenuViewController(NSURL url, UIDocumentPickerMode mode) { super((SkipInit) null); initObject(init(url, mode)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocumentPickerExtensionViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocumentPickerExtensionViewController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIDocumentPickerExtensionViewController() {}
+    protected UIDocumentPickerExtensionViewController(Handle h, long handle) { super(h, handle); }
     protected UIDocumentPickerExtensionViewController(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocumentPickerViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocumentPickerViewController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIDocumentPickerViewController() {}
+    protected UIDocumentPickerViewController(Handle h, long handle) { super(h, handle); }
     protected UIDocumentPickerViewController(SkipInit skipInit) { super(skipInit); }
     public UIDocumentPickerViewController(@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> allowedUTIs, UIDocumentPickerMode mode) { super((SkipInit) null); initObject(init(allowedUTIs, mode)); }
     public UIDocumentPickerViewController(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDynamicAnimator.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDynamicAnimator.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIDynamicAnimator() {}
+    protected UIDynamicAnimator(Handle h, long handle) { super(h, handle); }
     protected UIDynamicAnimator(SkipInit skipInit) { super(skipInit); }
     public UIDynamicAnimator(UIView view) { super((SkipInit) null); initObject(init(view)); }
     public UIDynamicAnimator(UICollectionViewLayout layout) { super((SkipInit) null); initObject(init(layout)); }
@@ -62,6 +63,8 @@ import org.robovm.apple.corelocation.*;
     public native NSArray<UIDynamicBehavior> getBehaviors();
     @Property(selector = "isRunning")
     public native boolean isRunning();
+    @Property(selector = "elapsedTime")
+    public native double getElapsedTime();
     @Property(selector = "delegate")
     public native UIDynamicAnimatorDelegate getDelegate();
     @Property(selector = "setDelegate:", strongRef = true)
@@ -81,8 +84,6 @@ import org.robovm.apple.corelocation.*;
     public native List<UIDynamicItem> getItemsInRect(@ByVal CGRect rect);
     @Method(selector = "updateItemUsingCurrentState:")
     public native void updateItemUsingCurrentState(UIDynamicItem item);
-    @Method(selector = "elapsedTime")
-    public native double getElapsedTime();
     @Method(selector = "initWithCollectionViewLayout:")
     protected native @Pointer long init(UICollectionViewLayout layout);
     @Method(selector = "layoutAttributesForCellAtIndexPath:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDynamicBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDynamicBehavior.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIDynamicBehavior() {}
+    protected UIDynamicBehavior(Handle h, long handle) { super(h, handle); }
     protected UIDynamicBehavior(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDynamicItemBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDynamicItemBehavior.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIDynamicItemBehavior() {}
+    protected UIDynamicItemBehavior(Handle h, long handle) { super(h, handle); }
     protected UIDynamicItemBehavior(SkipInit skipInit) { super(skipInit); }
     public UIDynamicItemBehavior(List<UIDynamicItem> items) { super((SkipInit) null); initObject(init(items)); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDynamicItemGroup.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDynamicItemGroup.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIDynamicItemGroup/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements UIDynamicItem/*</implements>*/ {
+
+    /*<ptr>*/public static class UIDynamicItemGroupPtr extends Ptr<UIDynamicItemGroup, UIDynamicItemGroupPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIDynamicItemGroup.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIDynamicItemGroup() {}
+    protected UIDynamicItemGroup(Handle h, long handle) { super(h, handle); }
+    protected UIDynamicItemGroup(SkipInit skipInit) { super(skipInit); }
+    public UIDynamicItemGroup(@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<UIDynamicItem> items) { super((SkipInit) null); initObject(init(items)); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "items")
+    public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<UIDynamicItem> getItems();
+    @Property(selector = "center")
+    public native @ByVal CGPoint getCenter();
+    @Property(selector = "setCenter:")
+    public native void setCenter(@ByVal CGPoint v);
+    @Property(selector = "bounds")
+    public native @ByVal CGRect getBounds();
+    @Property(selector = "transform")
+    public native @ByVal CGAffineTransform getTransform();
+    @Property(selector = "setTransform:")
+    public native void setTransform(@ByVal CGAffineTransform v);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "collisionBoundsType")
+    public native UIDynamicItemCollisionBoundsType getCollisionBoundsType();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "collisionBoundingPath")
+    public native UIBezierPath getCollisionBoundingPath();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "initWithItems:")
+    protected native @Pointer long init(@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<UIDynamicItem> items);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIEvent.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIEvent.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIEvent() {}
+    protected UIEvent(Handle h, long handle) { super(h, handle); }
     protected UIEvent(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
@@ -66,11 +67,11 @@ import org.robovm.apple.corelocation.*;
     public native UIEventSubtype getSubtype();
     @Property(selector = "timestamp")
     public native double getTimestamp();
+    @Property(selector = "allTouches")
+    public native NSSet<UITouch> getAllTouches();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
-    @Method(selector = "allTouches")
-    public native NSSet<UITouch> getAllTouches();
     @Method(selector = "touchesForWindow:")
     public native NSSet<UITouch> getTouches(UIWindow window);
     @Method(selector = "touchesForView:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIEventType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIEventType.java
@@ -44,7 +44,11 @@ public enum /*<name>*/UIEventType/*</name>*/ implements ValuedEnum {
     /*<values>*/
     Touches(0L),
     Motion(1L),
-    RemoteControl(2L);
+    RemoteControl(2L),
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    Presses(3L);
     /*</values>*/
 
     private final long n;

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFeedbackGenerator.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFeedbackGenerator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIFeedbackGenerator/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIFeedbackGeneratorPtr extends Ptr<UIFeedbackGenerator, UIFeedbackGeneratorPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIFeedbackGenerator.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIFeedbackGenerator() {}
+    protected UIFeedbackGenerator(Handle h, long handle) { super(h, handle); }
+    protected UIFeedbackGenerator(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "prepare")
+    public native void prepare();
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFieldBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFieldBehavior.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIFieldBehavior/*</name>*/ 
+    extends /*<extends>*/UIDynamicBehavior/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIFieldBehaviorPtr extends Ptr<UIFieldBehavior, UIFieldBehaviorPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIFieldBehavior.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIFieldBehavior() {}
+    protected UIFieldBehavior(Handle h, long handle) { super(h, handle); }
+    protected UIFieldBehavior(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "items")
+    public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<UIDynamicItem> getItems();
+    @Property(selector = "position")
+    public native @ByVal CGPoint getPosition();
+    @Property(selector = "setPosition:")
+    public native void setPosition(@ByVal CGPoint v);
+    @Property(selector = "region")
+    public native UIRegion getRegion();
+    @Property(selector = "setRegion:")
+    public native void setRegion(UIRegion v);
+    @Property(selector = "strength")
+    public native @MachineSizedFloat double getStrength();
+    @Property(selector = "setStrength:")
+    public native void setStrength(@MachineSizedFloat double v);
+    @Property(selector = "falloff")
+    public native @MachineSizedFloat double getFalloff();
+    @Property(selector = "setFalloff:")
+    public native void setFalloff(@MachineSizedFloat double v);
+    @Property(selector = "minimumRadius")
+    public native @MachineSizedFloat double getMinimumRadius();
+    @Property(selector = "setMinimumRadius:")
+    public native void setMinimumRadius(@MachineSizedFloat double v);
+    @Property(selector = "direction")
+    public native @ByVal CGVector getDirection();
+    @Property(selector = "setDirection:")
+    public native void setDirection(@ByVal CGVector v);
+    @Property(selector = "smoothness")
+    public native @MachineSizedFloat double getSmoothness();
+    @Property(selector = "setSmoothness:")
+    public native void setSmoothness(@MachineSizedFloat double v);
+    @Property(selector = "animationSpeed")
+    public native @MachineSizedFloat double getAnimationSpeed();
+    @Property(selector = "setAnimationSpeed:")
+    public native void setAnimationSpeed(@MachineSizedFloat double v);
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "addItem:")
+    public native void addItem(UIDynamicItem item);
+    @Method(selector = "removeItem:")
+    public native void removeItem(UIDynamicItem item);
+    @Method(selector = "dragField")
+    public static native UIFieldBehavior drag();
+    @Method(selector = "vortexField")
+    public static native UIFieldBehavior vortex();
+    @Method(selector = "radialGravityFieldWithPosition:")
+    public static native UIFieldBehavior radialGravity(@ByVal CGPoint position);
+    @Method(selector = "linearGravityFieldWithVector:")
+    public static native UIFieldBehavior linearGravity(@ByVal CGVector direction);
+    @Method(selector = "velocityFieldWithVector:")
+    public static native UIFieldBehavior velocity(@ByVal CGVector direction);
+    @Method(selector = "noiseFieldWithSmoothness:animationSpeed:")
+    public static native UIFieldBehavior noise(@MachineSizedFloat double smoothness, @MachineSizedFloat double speed);
+    @Method(selector = "turbulenceFieldWithSmoothness:animationSpeed:")
+    public static native UIFieldBehavior turbulence(@MachineSizedFloat double smoothness, @MachineSizedFloat double speed);
+    @Method(selector = "springField")
+    public static native UIFieldBehavior spring();
+    @Method(selector = "electricField")
+    public static native UIFieldBehavior electric();
+    @Method(selector = "magneticField")
+    public static native UIFieldBehavior magnetic();
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFieldBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFieldBehavior.java
@@ -50,7 +50,7 @@ import org.robovm.apple.corelocation.*;
     /*<bind>*/static { ObjCRuntime.bind(UIFieldBehavior.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public UIFieldBehavior() {}
+    protected UIFieldBehavior() {}
     protected UIFieldBehavior(Handle h, long handle) { super(h, handle); }
     protected UIFieldBehavior(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusAnimationCoordinator.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusAnimationCoordinator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIFocusAnimationCoordinator/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIFocusAnimationCoordinatorPtr extends Ptr<UIFocusAnimationCoordinator, UIFocusAnimationCoordinatorPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIFocusAnimationCoordinator.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIFocusAnimationCoordinator() {}
+    protected UIFocusAnimationCoordinator(Handle h, long handle) { super(h, handle); }
+    protected UIFocusAnimationCoordinator(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "addCoordinatedAnimations:completion:")
+    public native void addCoordinatedAnimations(@Block Runnable animations, @Block Runnable completion);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusEnvironment.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusEnvironment.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/UIFocusEnvironment/*</name>*/ 
+    /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<properties>*/
+    @Property(selector = "preferredFocusEnvironments")
+    @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<UIFocusEnvironment> getPreferredFocusEnvironments();
+    /**
+     * @since Available in iOS 9.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    @Property(selector = "preferredFocusedView")
+    UIView getPreferredFocusedView();
+    /*</properties>*/
+    /*<methods>*/
+    @Method(selector = "setNeedsFocusUpdate")
+    void setNeedsFocusUpdate();
+    @Method(selector = "updateFocusIfNeeded")
+    void updateFocusIfNeeded();
+    @Method(selector = "shouldUpdateFocusInContext:")
+    boolean shouldUpdateFocus(UIFocusUpdateContext context);
+    @Method(selector = "didUpdateFocusInContext:withAnimationCoordinator:")
+    void didUpdateFocus(UIFocusUpdateContext context, UIFocusAnimationCoordinator coordinator);
+    /*</methods>*/
+    /*<adapter>*/
+    /*</adapter>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusEnvironmentAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusEnvironmentAdapter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIFocusEnvironmentAdapter/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements UIFocusEnvironment/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*/
+    @NotImplemented("preferredFocusEnvironments")
+    public @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<UIFocusEnvironment> getPreferredFocusEnvironments() { return null; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    @NotImplemented("preferredFocusedView")
+    public UIView getPreferredFocusedView() { return null; }
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @NotImplemented("setNeedsFocusUpdate")
+    public void setNeedsFocusUpdate() {}
+    @NotImplemented("updateFocusIfNeeded")
+    public void updateFocusIfNeeded() {}
+    @NotImplemented("shouldUpdateFocusInContext:")
+    public boolean shouldUpdateFocus(UIFocusUpdateContext context) { return false; }
+    @NotImplemented("didUpdateFocusInContext:withAnimationCoordinator:")
+    public void didUpdateFocus(UIFocusUpdateContext context, UIFocusAnimationCoordinator coordinator) {}
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusGuide.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusGuide.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIFocusGuide/*</name>*/ 
+    extends /*<extends>*/UILayoutGuide/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIFocusGuidePtr extends Ptr<UIFocusGuide, UIFocusGuidePtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIFocusGuide.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIFocusGuide() {}
+    protected UIFocusGuide(Handle h, long handle) { super(h, handle); }
+    protected UIFocusGuide(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "isEnabled")
+    public native boolean isEnabled();
+    @Property(selector = "setEnabled:")
+    public native void setEnabled(boolean v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "preferredFocusEnvironments")
+    public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<UIFocusEnvironment> getPreferredFocusEnvironments();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setPreferredFocusEnvironments:")
+    public native void setPreferredFocusEnvironments(@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<UIFocusEnvironment> v);
+    /**
+     * @since Available in iOS 9.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    @Property(selector = "preferredFocusedView")
+    public native UIView getPreferredFocusedView();
+    /**
+     * @since Available in iOS 9.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    @Property(selector = "setPreferredFocusedView:", strongRef = true)
+    public native void setPreferredFocusedView(UIView v);
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusHeading.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusHeading.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(Bits.AsMachineSizedIntMarshaler.class)/*</annotations>*/
+public final class /*<name>*/UIFocusHeading/*</name>*/ extends Bits</*<name>*/UIFocusHeading/*</name>*/> {
+    /*<values>*/
+    public static final UIFocusHeading None = new UIFocusHeading(0L);
+    public static final UIFocusHeading Up = new UIFocusHeading(1L);
+    public static final UIFocusHeading Down = new UIFocusHeading(2L);
+    public static final UIFocusHeading Left = new UIFocusHeading(4L);
+    public static final UIFocusHeading Right = new UIFocusHeading(8L);
+    public static final UIFocusHeading Next = new UIFocusHeading(16L);
+    public static final UIFocusHeading Previous = new UIFocusHeading(32L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private static final /*<name>*/UIFocusHeading/*</name>*/[] values = _values(/*<name>*/UIFocusHeading/*</name>*/.class);
+
+    public /*<name>*/UIFocusHeading/*</name>*/(long value) { super(value); }
+    private /*<name>*/UIFocusHeading/*</name>*/(long value, long mask) { super(value, mask); }
+    protected /*<name>*/UIFocusHeading/*</name>*/ wrap(long value, long mask) {
+        return new /*<name>*/UIFocusHeading/*</name>*/(value, mask);
+    }
+    protected /*<name>*/UIFocusHeading/*</name>*/[] _values() {
+        return values;
+    }
+    public static /*<name>*/UIFocusHeading/*</name>*/[] values() {
+        return values.clone();
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusItem.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/UIFocusItem/*</name>*/ 
+    /*<implements>*/extends UIFocusEnvironment/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<properties>*/
+    @Property(selector = "canBecomeFocused")
+    boolean canBecomeFocused();
+    /*</properties>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+    /*<adapter>*/
+    /*</adapter>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusItemAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusItemAdapter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIFocusItemAdapter/*</name>*/ 
+    extends /*<extends>*/UIFocusEnvironmentAdapter/*</extends>*/ 
+    /*<implements>*/implements UIFocusItem/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*/
+    @NotImplemented("canBecomeFocused")
+    public boolean canBecomeFocused() { return false; }
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusUpdateContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFocusUpdateContext.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIFocusUpdateContext/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIFocusUpdateContextPtr extends Ptr<UIFocusUpdateContext, UIFocusUpdateContextPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIFocusUpdateContext.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIFocusUpdateContext() {}
+    protected UIFocusUpdateContext(Handle h, long handle) { super(h, handle); }
+    protected UIFocusUpdateContext(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "previouslyFocusedItem")
+    public native UIFocusItem getPreviouslyFocusedItem();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "nextFocusedItem")
+    public native UIFocusItem getNextFocusedItem();
+    @Property(selector = "previouslyFocusedView")
+    public native UIView getPreviouslyFocusedView();
+    @Property(selector = "nextFocusedView")
+    public native UIView getNextFocusedView();
+    @Property(selector = "focusHeading")
+    public native UIFocusHeading getFocusHeading();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFont.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFont.java
@@ -51,9 +51,12 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIFont() {}
+    protected UIFont(Handle h, long handle) { super(h, handle); }
     protected UIFont(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
+    @Property(selector = "familyNames")
+    public static native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getFamilyNames();
     @Property(selector = "familyName")
     public native String getFamilyName();
     @Property(selector = "fontName")
@@ -75,6 +78,19 @@ import org.robovm.apple.corelocation.*;
     public native @MachineSizedFloat double getLineHeight();
     @Property(selector = "leading")
     public native @MachineSizedFloat double getLeading();
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @Property(selector = "fontDescriptor")
+    public native UIFontDescriptor getFontDescriptor();
+    @Property(selector = "labelFontSize")
+    public static native @MachineSizedFloat double getLabelFontSize();
+    @Property(selector = "buttonFontSize")
+    public static native @MachineSizedFloat double getButtonFontSize();
+    @Property(selector = "smallSystemFontSize")
+    public static native @MachineSizedFloat double getSmallSystemFontSize();
+    @Property(selector = "systemFontSize")
+    public static native @MachineSizedFloat double getSystemFontSize();
     /*</properties>*/
     /*<members>*//*</members>*/
     /**
@@ -89,17 +105,15 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 7.0 and later.
      */
-    @Method(selector = "fontDescriptor")
-    public native UIFontDescriptor getFontDescriptor();
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
     @Method(selector = "preferredFontForTextStyle:")
     public static native UIFont getPreferredFont(UIFontTextStyle style);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "preferredFontForTextStyle:compatibleWithTraitCollection:")
+    public static native UIFont getPreferredFont(UIFontTextStyle style, UITraitCollection traitCollection);
     @Method(selector = "fontWithName:size:")
     public static native UIFont getFont(String fontName, @MachineSizedFloat double fontSize);
-    @Method(selector = "familyNames")
-    public static native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getFamilyNames();
     @Method(selector = "fontNamesForFamilyName:")
     public static native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getFontNamesForFamilyName(String familyName);
     @Method(selector = "systemFontOfSize:")
@@ -123,13 +137,5 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "fontWithDescriptor:size:")
     public static native UIFont getFont(UIFontDescriptor descriptor, @MachineSizedFloat double pointSize);
-    @Method(selector = "labelFontSize")
-    public static native @MachineSizedFloat double getLabelFontSize();
-    @Method(selector = "buttonFontSize")
-    public static native @MachineSizedFloat double getButtonFontSize();
-    @Method(selector = "smallSystemFontSize")
-    public static native @MachineSizedFloat double getSmallSystemFontSize();
-    @Method(selector = "systemFontSize")
-    public static native @MachineSizedFloat double getSystemFontSize();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFontDescriptor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFontDescriptor.java
@@ -51,11 +51,12 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIFontDescriptor() {}
+    protected UIFontDescriptor(Handle h, long handle) { super(h, handle); }
     protected UIFontDescriptor(SkipInit skipInit) { super(skipInit); }
     public UIFontDescriptor(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     public UIFontDescriptor(UIFontDescriptorAttributes attributes) { super((SkipInit) null); initObject(init(attributes)); }
-    public UIFontDescriptor(String fontName, @MachineSizedFloat double size) { super(create(fontName, size)); retain(getHandle()); }
-    public UIFontDescriptor(String fontName, @ByVal CGAffineTransform matrix) { super(create(fontName, matrix)); retain(getHandle()); }
+    public UIFontDescriptor(String fontName, @MachineSizedFloat double size) { super((Handle) null, create(fontName, size)); retain(getHandle()); }
+    public UIFontDescriptor(String fontName, @ByVal CGAffineTransform matrix) { super((Handle) null, create(fontName, matrix)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "postscriptName")
@@ -66,6 +67,8 @@ import org.robovm.apple.corelocation.*;
     public native @ByVal CGAffineTransform getMatrix();
     @Property(selector = "symbolicTraits")
     public native UIFontDescriptorSymbolicTraits getSymbolicTraits();
+    @Property(selector = "fontAttributes")
+    public native UIFontDescriptorAttributes getFontAttributes();
     /*</properties>*/
     /*<members>*//*</members>*/
     public NSObject getValue(String attribute) {
@@ -84,24 +87,17 @@ import org.robovm.apple.corelocation.*;
         }
         return getMatchingFontDescriptors(set);
     }
-    public static UIFontDescriptor getPreferredFontDescriptor(UIFontTextStyle style) {
-        return getPreferredFontDescriptor(style.value());
-    }
     /*<methods>*/
     @Method(selector = "initWithCoder:")
     protected native @Pointer long init(NSCoder aDecoder);
     @Method(selector = "objectForKey:")
     protected native NSObject getValue(NSString anAttribute);
-    @Method(selector = "fontAttributes")
-    public native UIFontDescriptorAttributes getFontAttributes();
     @Method(selector = "matchingFontDescriptorsWithMandatoryKeys:")
     protected native NSArray<UIFontDescriptor> getMatchingFontDescriptors(NSSet<NSString> mandatoryKeys);
     @Method(selector = "initWithFontAttributes:")
     protected native @Pointer long init(UIFontDescriptorAttributes attributes);
     @Method(selector = "fontDescriptorByAddingAttributes:")
     public native UIFontDescriptor newWithAttributes(UIFontDescriptorAttributes attributes);
-    @Method(selector = "fontDescriptorWithSymbolicTraits:")
-    public native UIFontDescriptor newWithSymbolicTraits(UIFontDescriptorSymbolicTraits symbolicTraits);
     @Method(selector = "fontDescriptorWithSize:")
     public native UIFontDescriptor newWithSize(@MachineSizedFloat double newPointSize);
     @Method(selector = "fontDescriptorWithMatrix:")
@@ -110,11 +106,18 @@ import org.robovm.apple.corelocation.*;
     public native UIFontDescriptor newWithFace(String newFace);
     @Method(selector = "fontDescriptorWithFamily:")
     public native UIFontDescriptor newWithFamily(String newFamily);
+    @Method(selector = "fontDescriptorWithSymbolicTraits:")
+    public native UIFontDescriptor newWithSymbolicTraits(UIFontDescriptorSymbolicTraits symbolicTraits);
     @Method(selector = "fontDescriptorWithName:size:")
     protected static native @Pointer long create(String fontName, @MachineSizedFloat double size);
     @Method(selector = "fontDescriptorWithName:matrix:")
     protected static native @Pointer long create(String fontName, @ByVal CGAffineTransform matrix);
     @Method(selector = "preferredFontDescriptorWithTextStyle:")
-    protected static native UIFontDescriptor getPreferredFontDescriptor(NSString style);
+    public static native UIFontDescriptor getPreferredFontDescriptor(UIFontTextStyle style);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "preferredFontDescriptorWithTextStyle:compatibleWithTraitCollection:")
+    public static native UIFontDescriptor getPreferredFontDescriptor(UIFontTextStyle style, UITraitCollection traitCollection);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIForceTouchCapability.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIForceTouchCapability.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UIForceTouchCapability/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Unknown(0L),
+    Unavailable(1L),
+    Available(2L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UIForceTouchCapability/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UIForceTouchCapability/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UIForceTouchCapability/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UIForceTouchCapability/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGestureRecognizer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGestureRecognizer.java
@@ -110,6 +110,7 @@ import org.robovm.apple.corelocation.*;
     }
     /*<constructors>*/
     public UIGestureRecognizer() {}
+    protected UIGestureRecognizer(Handle h, long handle) { super(h, handle); }
     protected UIGestureRecognizer(SkipInit skipInit) { super(skipInit); }
     public UIGestureRecognizer(NSObject target, Selector action) { super((SkipInit) null); initObject(init(target, action)); }
     /*</constructors>*/
@@ -138,6 +139,38 @@ import org.robovm.apple.corelocation.*;
     public native boolean delaysTouchesEnded();
     @Property(selector = "setDelaysTouchesEnded:")
     public native void setDelaysTouchesEnded(boolean v);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "allowedTouchTypes")
+    public native @org.robovm.rt.bro.annotation.Marshaler(UITouchType.AsListMarshaler.class) List<UITouchType> getAllowedTouchTypes();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "setAllowedTouchTypes:")
+    public native void setAllowedTouchTypes(@org.robovm.rt.bro.annotation.Marshaler(UITouchType.AsListMarshaler.class) List<UITouchType> v);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "allowedPressTypes")
+    public native @org.robovm.rt.bro.annotation.Marshaler(UIPressType.AsListMarshaler.class) List<UIPressType> getAllowedPressTypes();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "setAllowedPressTypes:")
+    public native void setAllowedPressTypes(@org.robovm.rt.bro.annotation.Marshaler(UIPressType.AsListMarshaler.class) List<UIPressType> v);
+    /**
+     * @since Available in iOS 9.2 and later.
+     */
+    @Property(selector = "requiresExclusiveTouchType")
+    public native boolean requiresExclusiveTouchType();
+    /**
+     * @since Available in iOS 9.2 and later.
+     */
+    @Property(selector = "setRequiresExclusiveTouchType:")
+    public native void setRequiresExclusiveTouchType(boolean v);
+    @Property(selector = "numberOfTouches")
+    public native @MachineSizedUInt long getNumberOfTouches();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -151,8 +184,6 @@ import org.robovm.apple.corelocation.*;
     public native void requireGestureRecognizerToFail(UIGestureRecognizer otherGestureRecognizer);
     @Method(selector = "locationInView:")
     public native @ByVal CGPoint getLocationInView(UIView view);
-    @Method(selector = "numberOfTouches")
-    public native @MachineSizedUInt long getNumberOfTouches();
     @Method(selector = "locationOfTouch:inView:")
     public native @ByVal CGPoint getLocationOfTouch(@MachineSizedUInt long touchIndex, UIView view);
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGestureRecognizerDelegate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGestureRecognizerDelegate.java
@@ -68,6 +68,8 @@ import org.robovm.apple.corelocation.*;
     boolean shouldBeRequiredToFail(UIGestureRecognizer gestureRecognizer, UIGestureRecognizer otherGestureRecognizer);
     @Method(selector = "gestureRecognizer:shouldReceiveTouch:")
     boolean shouldReceiveTouch(UIGestureRecognizer gestureRecognizer, UITouch touch);
+    @Method(selector = "gestureRecognizer:shouldReceivePress:")
+    boolean shouldReceivePress(UIGestureRecognizer gestureRecognizer, UIPress press);
     /*</methods>*/
     /*<adapter>*/
     /*</adapter>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGestureRecognizerDelegateAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGestureRecognizerDelegateAdapter.java
@@ -70,5 +70,7 @@ import org.robovm.apple.corelocation.*;
     public boolean shouldBeRequiredToFail(UIGestureRecognizer gestureRecognizer, UIGestureRecognizer otherGestureRecognizer) { return false; }
     @NotImplemented("gestureRecognizer:shouldReceiveTouch:")
     public boolean shouldReceiveTouch(UIGestureRecognizer gestureRecognizer, UITouch touch) { return false; }
+    @NotImplemented("gestureRecognizer:shouldReceivePress:")
+    public boolean shouldReceivePress(UIGestureRecognizer gestureRecognizer, UIPress press) { return false; }
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsImageRenderer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsImageRenderer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIGraphicsImageRenderer/*</name>*/ 
+    extends /*<extends>*/UIGraphicsRenderer/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIGraphicsImageRendererPtr extends Ptr<UIGraphicsImageRenderer, UIGraphicsImageRendererPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIGraphicsImageRenderer.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIGraphicsImageRenderer() {}
+    protected UIGraphicsImageRenderer(Handle h, long handle) { super(h, handle); }
+    protected UIGraphicsImageRenderer(SkipInit skipInit) { super(skipInit); }
+    public UIGraphicsImageRenderer(@ByVal CGSize size) { super((SkipInit) null); initObject(init(size)); }
+    public UIGraphicsImageRenderer(@ByVal CGSize size, UIGraphicsImageRendererFormat format) { super((SkipInit) null); initObject(init(size, format)); }
+    public UIGraphicsImageRenderer(@ByVal CGRect bounds, UIGraphicsImageRendererFormat format) { super((SkipInit) null); initObject(init(bounds, format)); }
+    /*</constructors>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "initWithSize:")
+    protected native @Pointer long init(@ByVal CGSize size);
+    @Method(selector = "initWithSize:format:")
+    protected native @Pointer long init(@ByVal CGSize size, UIGraphicsImageRendererFormat format);
+    @Method(selector = "initWithBounds:format:")
+    protected native @Pointer long init(@ByVal CGRect bounds, UIGraphicsImageRendererFormat format);
+    @Method(selector = "imageWithActions:")
+    public native UIImage toImage(@Block VoidBlock1<UIGraphicsImageRendererContext> actions);
+    @Method(selector = "PNGDataWithActions:")
+    public native NSData toPNG(@Block VoidBlock1<UIGraphicsImageRendererContext> actions);
+    @Method(selector = "JPEGDataWithCompressionQuality:actions:")
+    public native NSData toJPEG(@MachineSizedFloat double compressionQuality, @Block VoidBlock1<UIGraphicsImageRendererContext> actions);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsImageRendererContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsImageRendererContext.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIGraphicsImageRendererContext/*</name>*/ 
+    extends /*<extends>*/UIGraphicsRendererContext/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIGraphicsImageRendererContextPtr extends Ptr<UIGraphicsImageRendererContext, UIGraphicsImageRendererContextPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIGraphicsImageRendererContext.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIGraphicsImageRendererContext() {}
+    protected UIGraphicsImageRendererContext(Handle h, long handle) { super(h, handle); }
+    protected UIGraphicsImageRendererContext(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "currentImage")
+    public native UIImage getCurrentImage();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsImageRendererFormat.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsImageRendererFormat.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIGraphicsImageRendererFormat/*</name>*/ 
+    extends /*<extends>*/UIGraphicsRendererFormat/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIGraphicsImageRendererFormatPtr extends Ptr<UIGraphicsImageRendererFormat, UIGraphicsImageRendererFormatPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIGraphicsImageRendererFormat.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIGraphicsImageRendererFormat() {}
+    protected UIGraphicsImageRendererFormat(Handle h, long handle) { super(h, handle); }
+    protected UIGraphicsImageRendererFormat(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "scale")
+    public native @MachineSizedFloat double getScale();
+    @Property(selector = "setScale:")
+    public native void setScale(@MachineSizedFloat double v);
+    @Property(selector = "opaque")
+    public native boolean isOpaque();
+    @Property(selector = "setOpaque:")
+    public native void setOpaque(boolean v);
+    @Property(selector = "prefersExtendedRange")
+    public native boolean prefersExtendedRange();
+    @Property(selector = "setPrefersExtendedRange:")
+    public native void setPrefersExtendedRange(boolean v);
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsPDFRenderer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsPDFRenderer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIGraphicsPDFRenderer/*</name>*/ 
+    extends /*<extends>*/UIGraphicsRenderer/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIGraphicsPDFRendererPtr extends Ptr<UIGraphicsPDFRenderer, UIGraphicsPDFRendererPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIGraphicsPDFRenderer.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIGraphicsPDFRenderer() {}
+    protected UIGraphicsPDFRenderer(Handle h, long handle) { super(h, handle); }
+    protected UIGraphicsPDFRenderer(SkipInit skipInit) { super(skipInit); }
+    public UIGraphicsPDFRenderer(@ByVal CGRect bounds, UIGraphicsPDFRendererFormat format) { super((SkipInit) null); initObject(init(bounds, format)); }
+    /*</constructors>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "initWithBounds:format:")
+    protected native @Pointer long init(@ByVal CGRect bounds, UIGraphicsPDFRendererFormat format);
+    public boolean writePDFToURL(NSURL url, @Block VoidBlock1<UIGraphicsPDFRendererContext> actions) throws NSErrorException {
+       NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
+       boolean result = writePDFToURL(url, actions, ptr);
+       if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
+       return result;
+    }
+    @Method(selector = "writePDFToURL:withActions:error:")
+    private native boolean writePDFToURL(NSURL url, @Block VoidBlock1<UIGraphicsPDFRendererContext> actions, NSError.NSErrorPtr error);
+    @Method(selector = "PDFDataWithActions:")
+    public native NSData toPDFData(@Block VoidBlock1<UIGraphicsPDFRendererContext> actions);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsPDFRendererContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsPDFRendererContext.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIGraphicsPDFRendererContext/*</name>*/ 
+    extends /*<extends>*/UIGraphicsRendererContext/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIGraphicsPDFRendererContextPtr extends Ptr<UIGraphicsPDFRendererContext, UIGraphicsPDFRendererContextPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIGraphicsPDFRendererContext.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIGraphicsPDFRendererContext() {}
+    protected UIGraphicsPDFRendererContext(Handle h, long handle) { super(h, handle); }
+    protected UIGraphicsPDFRendererContext(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "pdfContextBounds")
+    public native @ByVal CGRect getPdfContextBounds();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "beginPage")
+    public native void beginPage();
+    @Method(selector = "beginPageWithBounds:pageInfo:")
+    public native void beginPage(@ByVal CGRect bounds, NSDictionary<?, ?> pageInfo);
+    @Method(selector = "setURL:forRect:")
+    public native void setURLForRect(NSURL url, @ByVal CGRect rect);
+    @Method(selector = "addDestinationWithName:atPoint:")
+    public native void addDestination(String name, @ByVal CGPoint point);
+    @Method(selector = "setDestinationWithName:forRect:")
+    public native void setDestination(String name, @ByVal CGRect rect);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsPDFRendererFormat.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsPDFRendererFormat.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIGraphicsPDFRendererFormat/*</name>*/ 
+    extends /*<extends>*/UIGraphicsRendererFormat/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIGraphicsPDFRendererFormatPtr extends Ptr<UIGraphicsPDFRendererFormat, UIGraphicsPDFRendererFormatPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIGraphicsPDFRendererFormat.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIGraphicsPDFRendererFormat() {}
+    protected UIGraphicsPDFRendererFormat(Handle h, long handle) { super(h, handle); }
+    protected UIGraphicsPDFRendererFormat(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "documentInfo")
+    public native NSDictionary<?, ?> getDocumentInfo();
+    @Property(selector = "setDocumentInfo:")
+    public native void setDocumentInfo(NSDictionary<?, ?> v);
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsRenderer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsRenderer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIGraphicsRenderer/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIGraphicsRendererPtr extends Ptr<UIGraphicsRenderer, UIGraphicsRendererPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIGraphicsRenderer.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIGraphicsRenderer() {}
+    protected UIGraphicsRenderer(Handle h, long handle) { super(h, handle); }
+    protected UIGraphicsRenderer(SkipInit skipInit) { super(skipInit); }
+    public UIGraphicsRenderer(@ByVal CGRect bounds) { super((SkipInit) null); initObject(init(bounds)); }
+    public UIGraphicsRenderer(@ByVal CGRect bounds, UIGraphicsRendererFormat format) { super((SkipInit) null); initObject(init(bounds, format)); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "format")
+    public native UIGraphicsRendererFormat getFormat();
+    @Property(selector = "allowsImageOutput")
+    public native boolean allowsImageOutput();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "initWithBounds:")
+    protected native @Pointer long init(@ByVal CGRect bounds);
+    @Method(selector = "initWithBounds:format:")
+    protected native @Pointer long init(@ByVal CGRect bounds, UIGraphicsRendererFormat format);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsRendererContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsRendererContext.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIGraphicsRendererContext/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIGraphicsRendererContextPtr extends Ptr<UIGraphicsRendererContext, UIGraphicsRendererContextPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIGraphicsRendererContext.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIGraphicsRendererContext() {}
+    protected UIGraphicsRendererContext(Handle h, long handle) { super(h, handle); }
+    protected UIGraphicsRendererContext(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "CGContext")
+    public native CGContext getCGContext();
+    @Property(selector = "format")
+    public native UIGraphicsRendererFormat getFormat();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "fillRect:")
+    public native void fillRect(@ByVal CGRect rect);
+    @Method(selector = "fillRect:blendMode:")
+    public native void fillRect(@ByVal CGRect rect, CGBlendMode blendMode);
+    @Method(selector = "strokeRect:")
+    public native void strokeRect(@ByVal CGRect rect);
+    @Method(selector = "strokeRect:blendMode:")
+    public native void strokeRect(@ByVal CGRect rect, CGBlendMode blendMode);
+    @Method(selector = "clipToRect:")
+    public native void clipToRect(@ByVal CGRect rect);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsRendererFormat.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsRendererFormat.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIGraphicsRendererFormat/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIGraphicsRendererFormatPtr extends Ptr<UIGraphicsRendererFormat, UIGraphicsRendererFormatPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIGraphicsRendererFormat.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIGraphicsRendererFormat() {}
+    protected UIGraphicsRendererFormat(Handle h, long handle) { super(h, handle); }
+    protected UIGraphicsRendererFormat(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "bounds")
+    public native @ByVal CGRect getBounds();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "defaultFormat")
+    public static native UIGraphicsRendererFormat getDefaultFormat();
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGravityBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGravityBehavior.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIGravityBehavior() {}
+    protected UIGravityBehavior(Handle h, long handle) { super(h, handle); }
     protected UIGravityBehavior(SkipInit skipInit) { super(skipInit); }
     public UIGravityBehavior(List<UIDynamicItem> items) { super((SkipInit) null); initObject(init(items)); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGuidedAccessRestrictionDelegate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGuidedAccessRestrictionDelegate.java
@@ -51,11 +51,10 @@ import org.robovm.apple.corelocation.*;
     /*</bind>*/
     /*<constants>*//*</constants>*/
     /*<properties>*/
-    
+    @Property(selector = "guidedAccessRestrictionIdentifiers")
+    @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getIdentifiers();
     /*</properties>*/
     /*<methods>*/
-    @Method(selector = "guidedAccessRestrictionIdentifiers")
-    @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getIdentifiers();
     @Method(selector = "guidedAccessRestrictionWithIdentifier:didChangeState:")
     void didChangeState(String restrictionIdentifier, UIGuidedAccessRestrictionState newRestrictionState);
     @Method(selector = "textForGuidedAccessRestrictionWithIdentifier:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGuidedAccessRestrictionDelegateAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGuidedAccessRestrictionDelegateAdapter.java
@@ -50,12 +50,11 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*//*</constructors>*/
     /*<properties>*/
-    
+    @NotImplemented("guidedAccessRestrictionIdentifiers")
+    public @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getIdentifiers() { return null; }
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
-    @NotImplemented("guidedAccessRestrictionIdentifiers")
-    public @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getIdentifiers() { return null; }
     @NotImplemented("guidedAccessRestrictionWithIdentifier:didChangeState:")
     public void didChangeState(String restrictionIdentifier, UIGuidedAccessRestrictionState newRestrictionState) {}
     @NotImplemented("textForGuidedAccessRestrictionWithIdentifier:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImage.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImage.java
@@ -75,6 +75,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIImage() {}
+    protected UIImage(Handle h, long handle) { super(h, handle); }
     protected UIImage(SkipInit skipInit) { super(skipInit); }
     public UIImage(NSData data) { super((SkipInit) null); initObject(init(data)); }
     /**
@@ -149,6 +150,11 @@ import org.robovm.apple.corelocation.*;
      */
     @Property(selector = "renderingMode")
     public native UIImageRenderingMode getRenderingMode();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "imageRendererFormat")
+    public native UIGraphicsImageRendererFormat getImageRendererFormat();
     /**
      * @since Available in iOS 8.0 and later.
      */
@@ -277,6 +283,10 @@ import org.robovm.apple.corelocation.*;
             saveToPhotosAlbum(null, null, 0);
         }
     }
+    
+    public static UIImage getImage(File file) {
+        return getImageWithContentsOfFile(file.getAbsolutePath());
+    }
     /*<methods>*/
     @Bridge(symbol="UIImagePNGRepresentation", optional=true)
     public native NSData toPNGData();
@@ -348,6 +358,11 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "imageFlippedForRightToLeftLayoutDirection")
     public native UIImage flipHorizontally();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "imageWithHorizontallyFlippedOrientation")
+    public native UIImage imageWithHorizontallyFlippedOrientation();
     @Method(selector = "imageNamed:")
     public static native UIImage getImage(String name);
     /**
@@ -355,6 +370,8 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "imageNamed:inBundle:compatibleWithTraitCollection:")
     public static native UIImage getImage(String name, NSBundle bundle, UITraitCollection traitCollection);
+    @Method(selector = "imageWithContentsOfFile:")
+    private static native UIImage getImageWithContentsOfFile(String path);
     /**
      * @since Available in iOS 5.0 and later.
      */
@@ -376,39 +393,4 @@ import org.robovm.apple.corelocation.*;
     @Method(selector = "animatedImageWithImages:duration:")
     public static native UIImage getAnimatedImage(NSArray<UIImage> images, double duration);
     /*</methods>*/
-    /**
-     * @Deprecated use {@link #getImage(String)} instead.
-     */
-    @Deprecated
-    public static UIImage create(String name) {
-        return UIImage.getImage(name);
-    }
-    /**
-     * @Deprecated use {@link #getAnimatedImage(String, double)} instead.
-     */
-    @Deprecated
-    public static UIImage createAnimated(String name, double duration) {
-        return UIImage.getAnimatedImage(name, duration);
-    }
-    /**
-     * @Deprecated use {@link #getAnimatedResizableImage(String, UIEdgeInsets, double)} instead.
-     */
-    @Deprecated
-    public static UIImage createAnimatedResizable(String name, @ByVal UIEdgeInsets capInsets, double duration) {
-        return UIImage.getAnimatedResizableImage(name, capInsets, duration);
-    }
-    /**
-     * @Deprecated use {@link #getAnimatedResizableImage(String, UIEdgeInsets, UIImageResizingMode, double)} instead.
-     */
-    @Deprecated
-    public static UIImage createAnimatedResizable(String name, @ByVal UIEdgeInsets capInsets, UIImageResizingMode resizingMode, double duration) {
-        return UIImage.getAnimatedResizableImage(name, capInsets, resizingMode, duration);
-    }
-    /**
-     * @Deprecated use {@link #getAnimatedImage(NSArray, double)} instead.
-     */
-    @Deprecated
-    public static UIImage createAnimated(NSArray<UIImage> images, double duration) {
-        return UIImage.getAnimatedImage(images, duration);
-    }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImageAsset.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImageAsset.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIImageAsset() {}
+    protected UIImageAsset(Handle h, long handle) { super(h, handle); }
     protected UIImageAsset(SkipInit skipInit) { super(skipInit); }
     public UIImageAsset(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImagePickerController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImagePickerController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIImagePickerController() {}
+    protected UIImagePickerController(Handle h, long handle) { super(h, handle); }
     protected UIImagePickerController(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImagePickerControllerEditingInfo.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImagePickerControllerEditingInfo.java
@@ -227,6 +227,11 @@ import org.robovm.apple.corelocation.*;
          */
         @GlobalValue(symbol="UIImagePickerControllerMediaMetadata", optional=true)
         public static native NSString MediaMetadata();
+        /**
+         * @since Available in iOS 9.1 and later.
+         */
+        @GlobalValue(symbol="UIImagePickerControllerLivePhoto", optional=true)
+        public static native NSString LivePhoto();
     }
     /*</keys>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImageView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImageView.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIImageView() {}
+    protected UIImageView(Handle h, long handle) { super(h, handle); }
     protected UIImageView(SkipInit skipInit) { super(skipInit); }
     public UIImageView(UIImage image) { super((SkipInit) null); initObject(init(image)); }
     /**
@@ -58,11 +59,12 @@ import org.robovm.apple.corelocation.*;
      */
     public UIImageView(UIImage image, UIImage highlightedImage) { super((SkipInit) null); initObject(init(image, highlightedImage)); }
     /*</constructors>*/
-    
     public UIImageView(CGRect frame) {
         super(frame);
     }
-    
+    public UIImageView(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "image")
     public native UIImage getImage();
@@ -124,6 +126,8 @@ import org.robovm.apple.corelocation.*;
      */
     @Property(selector = "setTintColor:")
     public native void setTintColor(UIColor v);
+    @Property(selector = "isAnimating")
+    public native boolean isAnimating();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -138,7 +142,5 @@ import org.robovm.apple.corelocation.*;
     public native void startAnimating();
     @Method(selector = "stopAnimating")
     public native void stopAnimating();
-    @Method(selector = "isAnimating")
-    public native boolean isAnimating();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImpactFeedbackGenerator.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImpactFeedbackGenerator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIImpactFeedbackGenerator/*</name>*/ 
+    extends /*<extends>*/UIFeedbackGenerator/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIImpactFeedbackGeneratorPtr extends Ptr<UIImpactFeedbackGenerator, UIImpactFeedbackGeneratorPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIImpactFeedbackGenerator.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIImpactFeedbackGenerator() {}
+    protected UIImpactFeedbackGenerator(Handle h, long handle) { super(h, handle); }
+    protected UIImpactFeedbackGenerator(SkipInit skipInit) { super(skipInit); }
+    public UIImpactFeedbackGenerator(UIImpactFeedbackStyle style) { super((SkipInit) null); initObject(init(style)); }
+    /*</constructors>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "initWithStyle:")
+    protected native @Pointer long init(UIImpactFeedbackStyle style);
+    @Method(selector = "impactOccurred")
+    public native void impactOccurred();
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImpactFeedbackStyle.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImpactFeedbackStyle.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UIImpactFeedbackStyle/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Light(0L),
+    Medium(1L),
+    Heavy(2L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UIImpactFeedbackStyle/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UIImpactFeedbackStyle/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UIImpactFeedbackStyle/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UIImpactFeedbackStyle/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIInputView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIInputView.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIInputView() {}
+    protected UIInputView(Handle h, long handle) { super(h, handle); }
     protected UIInputView(SkipInit skipInit) { super(skipInit); }
     public UIInputView(@ByVal CGRect frame, UIInputViewStyle inputViewStyle) { super((SkipInit) null); initObject(init(frame, inputViewStyle)); }
     public UIInputView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIInputViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIInputViewController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIInputViewController() {}
+    protected UIInputViewController(Handle h, long handle) { super(h, handle); }
     protected UIInputViewController(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
@@ -71,6 +72,11 @@ import org.robovm.apple.corelocation.*;
     public native void dismissKeyboard();
     @Method(selector = "advanceToNextInputMode")
     public native void advanceToNextInputMode();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "handleInputModeListFromView:withEvent:")
+    public native void handleInputModeList(UIView view, UIEvent event);
     @Method(selector = "requestSupplementaryLexiconWithCompletion:")
     public native void requestSupplementaryLexicon(@Block VoidBlock1<UILexicon> completionHandler);
     @Method(selector = "selectionWillChange:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIInterpolatingMotionEffect.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIInterpolatingMotionEffect.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIInterpolatingMotionEffect() {}
+    protected UIInterpolatingMotionEffect(Handle h, long handle) { super(h, handle); }
     protected UIInterpolatingMotionEffect(SkipInit skipInit) { super(skipInit); }
     public UIInterpolatingMotionEffect(String keyPath, UIInterpolatingMotionEffectType type) { super((SkipInit) null); initObject(init(keyPath, type)); }
     public UIInterpolatingMotionEffect(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIKeyCommand.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIKeyCommand.java
@@ -51,13 +51,14 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIKeyCommand() {}
+    protected UIKeyCommand(Handle h, long handle) { super(h, handle); }
     protected UIKeyCommand(SkipInit skipInit) { super(skipInit); }
     public UIKeyCommand(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
-    public UIKeyCommand(String input, UIKeyModifierFlags modifierFlags, Selector action) { super(create(input, modifierFlags, action)); retain(getHandle()); }
+    public UIKeyCommand(String input, UIKeyModifierFlags modifierFlags, Selector action) { super((Handle) null, create(input, modifierFlags, action)); retain(getHandle()); }
     /**
      * @since Available in iOS 9.0 and later.
      */
-    public UIKeyCommand(String input, UIKeyModifierFlags modifierFlags, Selector action, String discoverabilityTitle) { super(create(input, modifierFlags, action, discoverabilityTitle)); retain(getHandle()); }
+    public UIKeyCommand(String input, UIKeyModifierFlags modifierFlags, Selector action, String discoverabilityTitle) { super((Handle) null, create(input, modifierFlags, action, discoverabilityTitle)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "input")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIKeyInput.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIKeyInput.java
@@ -49,11 +49,10 @@ import org.robovm.apple.corelocation.*;
     /*</bind>*/
     /*<constants>*//*</constants>*/
     /*<properties>*/
-    
+    @Property(selector = "hasText")
+    boolean hasText();
     /*</properties>*/
     /*<methods>*/
-    @Method(selector = "hasText")
-    boolean hasText();
     @Method(selector = "insertText:")
     void insertText(String text);
     @Method(selector = "deleteBackward")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIKeyInputAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIKeyInputAdapter.java
@@ -50,12 +50,11 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*//*</constructors>*/
     /*<properties>*/
-    
+    @NotImplemented("hasText")
+    public boolean hasText() { return false; }
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
-    @NotImplemented("hasText")
-    public boolean hasText() { return false; }
     @NotImplemented("insertText:")
     public void insertText(String text) {}
     @NotImplemented("deleteBackward")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIKeyboardType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIKeyboardType.java
@@ -62,6 +62,10 @@ public enum /*<name>*/UIKeyboardType/*</name>*/ implements ValuedEnum {
      * @since Available in iOS 7.0 and later.
      */
     WebSearch(10L),
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    ASCIICapableNumberPad(11L),
     Alphabet(1L);
     /*</values>*/
 

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILabel.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILabel.java
@@ -51,13 +51,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UILabel() {}
+    protected UILabel(Handle h, long handle) { super(h, handle); }
     protected UILabel(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UILabel(CGRect frame) {
         super(frame);
     }
-    
+    public UILabel(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "text")
     public native String getText();

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILayoutGuide.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILayoutGuide.java
@@ -51,8 +51,9 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UILayoutGuide() {}
+    protected UILayoutGuide(Handle h, long handle) { super(h, handle); }
     protected UILayoutGuide(SkipInit skipInit) { super(skipInit); }
-    public UILayoutGuide(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    public UILayoutGuide(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "layoutFrame")
@@ -85,12 +86,22 @@ import org.robovm.apple.corelocation.*;
     public native NSLayoutXAxisAnchor getCenterXAnchor();
     @Property(selector = "centerYAnchor")
     public native NSLayoutYAxisAnchor getCenterYAnchor();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "hasAmbiguousLayout")
+    public native boolean hasAmbiguousLayout();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "constraintsAffectingLayoutForAxis:")
+    public native NSArray<NSLayoutConstraint> getConstraintsAffectingLayout(UILayoutConstraintAxis axis);
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILexicon.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILexicon.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UILexicon() {}
+    protected UILexicon(Handle h, long handle) { super(h, handle); }
     protected UILexicon(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILexiconEntry.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILexiconEntry.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UILexiconEntry() {}
+    protected UILexiconEntry(Handle h, long handle) { super(h, handle); }
     protected UILexiconEntry(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILocalNotification.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILocalNotification.java
@@ -39,7 +39,9 @@ import org.robovm.apple.corelocation.*;
 /*<javadoc>*/
 /**
  * @since Available in iOS 4.0 and later.
+ * @deprecated Deprecated in iOS 10.0.
  */
+@Deprecated
 /*</javadoc>*/
 /*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/UILocalNotification/*</name>*/ 
@@ -51,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UILocalNotification() {}
+    protected UILocalNotification(Handle h, long handle) { super(h, handle); }
     protected UILocalNotification(SkipInit skipInit) { super(skipInit); }
     public UILocalNotification(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
@@ -146,7 +149,9 @@ import org.robovm.apple.corelocation.*;
     /*<methods>*/
     /**
      * @since Available in iOS 4.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @GlobalValue(symbol="UILocalNotificationDefaultSoundName", optional=true)
     public static native String getDefaultSoundName();
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILocalizedIndexedCollation.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILocalizedIndexedCollation.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UILocalizedIndexedCollation() {}
+    protected UILocalizedIndexedCollation(Handle h, long handle) { super(h, handle); }
     protected UILocalizedIndexedCollation(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILongPressGestureRecognizer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILongPressGestureRecognizer.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UILongPressGestureRecognizer() {}
+    protected UILongPressGestureRecognizer(Handle h, long handle) { super(h, handle); }
     protected UILongPressGestureRecognizer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIManagedDocument.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIManagedDocument.java
@@ -51,9 +51,12 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIManagedDocument() {}
+    protected UIManagedDocument(Handle h, long handle) { super(h, handle); }
     protected UIManagedDocument(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
+    @Property(selector = "persistentStoreName")
+    public static native String getPersistentStoreName();
     @WeaklyLinked
     @Property(selector = "managedObjectContext")
     public native NSManagedObjectContext getManagedObjectContext();
@@ -109,7 +112,5 @@ import org.robovm.apple.corelocation.*;
     }
     @Method(selector = "writeAdditionalContent:toURL:originalContentsURL:error:")
     private native boolean writeAdditionalContent(NSObject content, NSURL absoluteURL, NSURL absoluteOriginalContentsURL, NSError.NSErrorPtr error);
-    @Method(selector = "persistentStoreName")
-    public static native String getPersistentStoreName();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMarkupTextPrintFormatter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMarkupTextPrintFormatter.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIMarkupTextPrintFormatter() {}
+    protected UIMarkupTextPrintFormatter(Handle h, long handle) { super(h, handle); }
     protected UIMarkupTextPrintFormatter(SkipInit skipInit) { super(skipInit); }
     public UIMarkupTextPrintFormatter(String markupText) { super((SkipInit) null); initObject(init(markupText)); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMenuController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMenuController.java
@@ -113,9 +113,12 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIMenuController() {}
+    protected UIMenuController(Handle h, long handle) { super(h, handle); }
     protected UIMenuController(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
+    @Property(selector = "sharedMenuController")
+    public static native UIMenuController getSharedMenuController();
     @Property(selector = "isMenuVisible")
     public native boolean isMenuVisible();
     @Property(selector = "setMenuVisible:")
@@ -179,7 +182,5 @@ import org.robovm.apple.corelocation.*;
     public native void setTargetRect(@ByVal CGRect targetRect, UIView targetView);
     @Method(selector = "update")
     public native void update();
-    @Method(selector = "sharedMenuController")
-    public static native UIMenuController getSharedMenuController();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMenuItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMenuItem.java
@@ -102,6 +102,7 @@ import org.robovm.apple.corelocation.*;
     }
     /*<constructors>*/
     public UIMenuItem() {}
+    protected UIMenuItem(Handle h, long handle) { super(h, handle); }
     protected UIMenuItem(SkipInit skipInit) { super(skipInit); }
     public UIMenuItem(String title, Selector action) { super((SkipInit) null); initObject(init(title, action)); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMotionEffect.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMotionEffect.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIMotionEffect() {}
+    protected UIMotionEffect(Handle h, long handle) { super(h, handle); }
     protected UIMotionEffect(SkipInit skipInit) { super(skipInit); }
     public UIMotionEffect(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMotionEffectGroup.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMotionEffectGroup.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIMotionEffectGroup() {}
+    protected UIMotionEffectGroup(Handle h, long handle) { super(h, handle); }
     protected UIMotionEffectGroup(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMutableApplicationShortcutItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMutableApplicationShortcutItem.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIMutableApplicationShortcutItem/*</name>*/ 
+    extends /*<extends>*/UIApplicationShortcutItem/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIMutableApplicationShortcutItemPtr extends Ptr<UIMutableApplicationShortcutItem, UIMutableApplicationShortcutItemPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIMutableApplicationShortcutItem.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    protected UIMutableApplicationShortcutItem(Handle h, long handle) { super(h, handle); }
+    protected UIMutableApplicationShortcutItem(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "type")
+    public native String getType();
+    @Property(selector = "setType:")
+    public native void setType(String v);
+    @Property(selector = "localizedTitle")
+    public native String getLocalizedTitle();
+    @Property(selector = "setLocalizedTitle:")
+    public native void setLocalizedTitle(String v);
+    @Property(selector = "localizedSubtitle")
+    public native String getLocalizedSubtitle();
+    @Property(selector = "setLocalizedSubtitle:")
+    public native void setLocalizedSubtitle(String v);
+    @Property(selector = "icon")
+    public native UIApplicationShortcutIcon getIcon();
+    @Property(selector = "setIcon:")
+    public native void setIcon(UIApplicationShortcutIcon v);
+    @Property(selector = "userInfo")
+    public native NSDictionary<?, ?> getUserInfo();
+    @Property(selector = "setUserInfo:")
+    public native void setUserInfo(NSDictionary<?, ?> v);
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMutableUserNotificationAction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMutableUserNotificationAction.java
@@ -39,7 +39,9 @@ import org.robovm.apple.corelocation.*;
 /*<javadoc>*/
 /**
  * @since Available in iOS 8.0 and later.
+ * @deprecated Deprecated in iOS 10.0.
  */
+@Deprecated
 /*</javadoc>*/
 /*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/UIMutableUserNotificationAction/*</name>*/ 
@@ -51,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIMutableUserNotificationAction() {}
+    protected UIMutableUserNotificationAction(Handle h, long handle) { super(h, handle); }
     protected UIMutableUserNotificationAction(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMutableUserNotificationCategory.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMutableUserNotificationCategory.java
@@ -39,7 +39,9 @@ import org.robovm.apple.corelocation.*;
 /*<javadoc>*/
 /**
  * @since Available in iOS 8.0 and later.
+ * @deprecated Deprecated in iOS 10.0.
  */
+@Deprecated
 /*</javadoc>*/
 /*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/UIMutableUserNotificationCategory/*</name>*/ 
@@ -51,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIMutableUserNotificationCategory() {}
+    protected UIMutableUserNotificationCategory(Handle h, long handle) { super(h, handle); }
     protected UIMutableUserNotificationCategory(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINavigationBar.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINavigationBar.java
@@ -53,13 +53,15 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UINavigationBar() {}
+    protected UINavigationBar(Handle h, long handle) { super(h, handle); }
     protected UINavigationBar(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UINavigationBar(CGRect frame) {
         super(frame);
     }
-    
+    public UINavigationBar(NSCoder decoder) {
+        super(decoder);
+    }
     /**
      * @since Available in iOS 5.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINavigationController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINavigationController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UINavigationController() {}
+    protected UINavigationController(Handle h, long handle) { super(h, handle); }
     protected UINavigationController(SkipInit skipInit) { super(skipInit); }
     /**
      * @since Available in iOS 5.0 and later.

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINavigationItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINavigationItem.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UINavigationItem() {}
+    protected UINavigationItem(Handle h, long handle) { super(h, handle); }
     protected UINavigationItem(SkipInit skipInit) { super(skipInit); }
     public UINavigationItem(String title) { super((SkipInit) null); initObject(init(title)); }
     public UINavigationItem(NSCoder coder) { super((SkipInit) null); initObject(init(coder)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINib.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINib.java
@@ -51,9 +51,10 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UINib() {}
+    protected UINib(Handle h, long handle) { super(h, handle); }
     protected UINib(SkipInit skipInit) { super(skipInit); }
-    public UINib(String name, NSBundle bundleOrNil) { super(create(name, bundleOrNil)); retain(getHandle()); }
-    public UINib(NSData data, NSBundle bundleOrNil) { super(create(data, bundleOrNil)); retain(getHandle()); }
+    public UINib(String name, NSBundle bundleOrNil) { super((Handle) null, create(name, bundleOrNil)); retain(getHandle()); }
+    public UINib(NSData data, NSBundle bundleOrNil) { super((Handle) null, create(data, bundleOrNil)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINotificationFeedbackGenerator.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINotificationFeedbackGenerator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UINotificationFeedbackGenerator/*</name>*/ 
+    extends /*<extends>*/UIFeedbackGenerator/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UINotificationFeedbackGeneratorPtr extends Ptr<UINotificationFeedbackGenerator, UINotificationFeedbackGeneratorPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UINotificationFeedbackGenerator.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UINotificationFeedbackGenerator() {}
+    protected UINotificationFeedbackGenerator(Handle h, long handle) { super(h, handle); }
+    protected UINotificationFeedbackGenerator(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "notificationOccurred:")
+    public native void notificationOccurred(UINotificationFeedbackType notificationType);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINotificationFeedbackType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINotificationFeedbackType.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UINotificationFeedbackType/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Success(0L),
+    Warning(1L),
+    Error(2L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UINotificationFeedbackType/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UINotificationFeedbackType/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UINotificationFeedbackType/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UINotificationFeedbackType/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPageControl.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPageControl.java
@@ -51,13 +51,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPageControl() {}
+    protected UIPageControl(Handle h, long handle) { super(h, handle); }
     protected UIPageControl(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UIPageControl(CGRect frame) {
         super(frame);
     }
-    
+    public UIPageControl(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "numberOfPages")
     public native @MachineSizedSInt long getNumberOfPages();

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPageViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPageViewController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPageViewController() {}
+    protected UIPageViewController(Handle h, long handle) { super(h, handle); }
     protected UIPageViewController(SkipInit skipInit) { super(skipInit); }
     public UIPageViewController(UIPageViewControllerTransitionStyle style, UIPageViewControllerNavigationOrientation navigationOrientation, UIPageViewControllerOptions options) { super((SkipInit) null); initObject(init(style, navigationOrientation, options)); }
     public UIPageViewController(NSCoder coder) { super((SkipInit) null); initObject(init(coder)); }
@@ -80,6 +81,15 @@ import org.robovm.apple.corelocation.*;
     public native NSArray<UIViewController> getViewControllers();
     /*</properties>*/
     /*<members>*//*</members>*/
+    private UIPageViewControllerModel model;
+    public void setModel(UIPageViewControllerModel model) {
+        this.model = model;
+        setDelegate(model);
+        setDataSource(model);
+    }
+    public UIPageViewControllerModel getModel() {
+        return model;
+    }
     /*<methods>*/
     @Method(selector = "initWithTransitionStyle:navigationOrientation:options:")
     protected native @Pointer long init(UIPageViewControllerTransitionStyle style, UIPageViewControllerNavigationOrientation navigationOrientation, UIPageViewControllerOptions options);

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPageViewControllerModel.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPageViewControllerModel.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+import org.robovm.apple.foundation.NSArray;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.objc.annotation.NotImplemented;
+import org.robovm.rt.bro.annotation.MachineSizedSInt;
+
+public class UIPageViewControllerModel extends NSObject implements UIPageViewControllerDelegate, UIPageViewControllerDataSource {
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @NotImplemented("pageViewController:willTransitionToViewControllers:")
+    public void willTransition(UIPageViewController pageViewController, NSArray<UIViewController> pendingViewControllers) {}
+    @NotImplemented("pageViewController:didFinishAnimating:previousViewControllers:transitionCompleted:")
+    public void didFinishAnimating(UIPageViewController pageViewController, boolean finished, NSArray<UIViewController> previousViewControllers, boolean completed) {}
+    @NotImplemented("pageViewController:spineLocationForInterfaceOrientation:")
+    public UIPageViewControllerSpineLocation getSpineLocation(UIPageViewController pageViewController, UIInterfaceOrientation orientation) { return null; }
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @NotImplemented("pageViewControllerSupportedInterfaceOrientations:")
+    public UIInterfaceOrientationMask getSupportedInterfaceOrientations(UIPageViewController pageViewController) { return null; }
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @NotImplemented("pageViewControllerPreferredInterfaceOrientationForPresentation:")
+    public UIInterfaceOrientation getPreferredInterfaceOrientation(UIPageViewController pageViewController) { return null; }
+    
+    @NotImplemented("pageViewController:viewControllerBeforeViewController:")
+    public UIViewController getViewControllerBefore(UIPageViewController pageViewController, UIViewController viewController) { return null; }
+    @NotImplemented("pageViewController:viewControllerAfterViewController:")
+    public UIViewController getViewControllerAfter(UIPageViewController pageViewController, UIViewController viewController) { return null; }
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @NotImplemented("presentationCountForPageViewController:")
+    public @MachineSizedSInt long getPresentationCount(UIPageViewController pageViewController) { return 0; }
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @NotImplemented("presentationIndexForPageViewController:")
+    public @MachineSizedSInt long getPresentationIndex(UIPageViewController pageViewController) { return 0; }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPanGestureRecognizer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPanGestureRecognizer.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPanGestureRecognizer() {}
+    protected UIPanGestureRecognizer(Handle h, long handle) { super(h, handle); }
     protected UIPanGestureRecognizer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPasteboard.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPasteboard.java
@@ -75,6 +75,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPasteboard() {}
+    protected UIPasteboard(Handle h, long handle) { super(h, handle); }
     protected UIPasteboard(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     public List<Map<String, NSObject>> getItems() {
@@ -92,7 +93,16 @@ import org.robovm.apple.corelocation.*;
         }
         setItems0(itemArray);
     }
+    public void setItems(List<Map<String, NSObject>> items, UIPasteboardOptions options) {
+        NSArray<NSDictionary> itemArray = new NSMutableArray<>();
+        for (Map<String, NSObject> item : items) {
+            itemArray.add(NSDictionary.fromStringMap(item));
+        }
+        setItems0(itemArray, options);
+    }
     /*<properties>*/
+    @Property(selector = "generalPasteboard")
+    public static native UIPasteboard getGeneralPasteboard();
     @Property(selector = "name")
     public native String getName();
     @Property(selector = "isPersistent")
@@ -101,6 +111,8 @@ import org.robovm.apple.corelocation.*;
     public native void setPersistent(boolean v);
     @Property(selector = "changeCount")
     public native @MachineSizedSInt long getChangeCount();
+    @Property(selector = "pasteboardTypes")
+    public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getPasteboardTypes();
     @Property(selector = "numberOfItems")
     public native @MachineSizedSInt long getNumberOfItems();
     @Property(selector = "items")
@@ -139,6 +151,26 @@ import org.robovm.apple.corelocation.*;
     public native NSArray<UIColor> getColors();
     @Property(selector = "setColors:")
     public native void setColors(NSArray<UIColor> v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "hasStrings")
+    public native boolean hasStrings();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "hasURLs")
+    public native boolean hasURLs();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "hasImages")
+    public native boolean hasImages();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "hasColors")
+    public native boolean hasColors();
     /*</properties>*/
     /*<members>*//*</members>*/
     public static UIPasteboard getFindPasteboard() {
@@ -161,6 +193,11 @@ import org.robovm.apple.corelocation.*;
         addItems(itemArray);
     }
     /*<methods>*/
+    /**
+     * @since Available in iOS 3.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
     @GlobalValue(symbol="UIPasteboardNameFind", optional=true)
     private static native String PasteboardNameFind();
     @GlobalValue(symbol="UIPasteboardChangedNotification", optional=true)
@@ -175,9 +212,12 @@ import org.robovm.apple.corelocation.*;
     public static native List<String> getImageTypeList();
     @GlobalValue(symbol="UIPasteboardTypeListColor", optional=true)
     public static native List<String> getColorTypeList();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="UIPasteboardTypeAutomatic", optional=true)
+    public static native String getAutomaticType();
     
-    @Method(selector = "pasteboardTypes")
-    public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getTypes();
     @Method(selector = "containsPasteboardTypes:")
     public native boolean contains(@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> pasteboardTypes);
     @Method(selector = "dataForPasteboardType:")
@@ -200,8 +240,11 @@ import org.robovm.apple.corelocation.*;
     public native NSArray<NSData> getData(String pasteboardType, NSIndexSet itemSet);
     @Method(selector = "addItems:")
     private native void addItems(NSArray<NSDictionary> items);
-    @Method(selector = "generalPasteboard")
-    public static native UIPasteboard getGeneralPasteboard();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "setItems:options:")
+    private native void setItems0(NSArray<NSDictionary> items, UIPasteboardOptions options);
     @Method(selector = "pasteboardWithName:create:")
     public static native UIPasteboard getPasteboard(String pasteboardName, boolean create);
     @Method(selector = "pasteboardWithUniqueName")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPasteboardOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPasteboardOptions.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit")/*</annotations>*/
+@Marshaler(/*<name>*/UIPasteboardOptions/*</name>*/.Marshaler.class)
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIPasteboardOptions/*</name>*/ 
+    extends /*<extends>*/NSDictionaryWrapper/*</extends>*/
+    /*<implements>*//*</implements>*/ {
+
+    /*<marshalers>*/
+    public static class Marshaler {
+        @MarshalsPointer
+        public static UIPasteboardOptions toObject(Class<UIPasteboardOptions> cls, long handle, long flags) {
+            NSDictionary o = (NSDictionary) NSObject.Marshaler.toObject(NSDictionary.class, handle, flags);
+            if (o == null) {
+                return null;
+            }
+            return new UIPasteboardOptions(o);
+        }
+        @MarshalsPointer
+        public static long toNative(UIPasteboardOptions o, long flags) {
+            if (o == null) {
+                return 0L;
+            }
+            return NSObject.Marshaler.toNative(o.data, flags);
+        }
+    }
+    public static class AsListMarshaler {
+        @MarshalsPointer
+        public static List<UIPasteboardOptions> toObject(Class<? extends NSObject> cls, long handle, long flags) {
+            NSArray<NSDictionary> o = (NSArray<NSDictionary>) NSObject.Marshaler.toObject(NSArray.class, handle, flags);
+            if (o == null) {
+                return null;
+            }
+            List<UIPasteboardOptions> list = new ArrayList<>();
+            for (int i = 0; i < o.size(); i++) {
+                list.add(new UIPasteboardOptions(o.get(i)));
+            }
+            return list;
+        }
+        @MarshalsPointer
+        public static long toNative(List<UIPasteboardOptions> l, long flags) {
+            if (l == null) {
+                return 0L;
+            }
+            NSArray<NSDictionary> array = new NSMutableArray<>();
+            for (UIPasteboardOptions i : l) {
+                array.add(i.getDictionary());
+            }
+            return NSObject.Marshaler.toNative(array, flags);
+        }
+    }
+    /*</marshalers>*/
+
+    /*<constructors>*/
+    UIPasteboardOptions(NSDictionary data) {
+        super(data);
+    }
+    public UIPasteboardOptions() {}
+    /*</constructors>*/
+
+    /*<methods>*/
+    public boolean has(NSString key) {
+        return data.containsKey(key);
+    }
+    public NSObject get(NSString key) {
+        if (has(key)) {
+            return data.get(key);
+        }
+        return null;
+    }
+    public UIPasteboardOptions set(NSString key, NSObject value) {
+        data.put(key, value);
+        return this;
+    }
+    
+
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public NSDate getExpirationDate() {
+        if (has(Keys.ExpirationDate())) {
+            NSDate val = (NSDate) get(Keys.ExpirationDate());
+            return val;
+        }
+        return null;
+    }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public UIPasteboardOptions setExpirationDate(NSDate expirationDate) {
+        set(Keys.ExpirationDate(), expirationDate);
+        return this;
+    }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public boolean isLocalOnly() {
+        if (has(Keys.LocalOnly())) {
+            NSNumber val = (NSNumber) get(Keys.LocalOnly());
+            return val.booleanValue();
+        }
+        return false;
+    }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public UIPasteboardOptions setLocalOnly(boolean localOnly) {
+        set(Keys.LocalOnly(), NSNumber.valueOf(localOnly));
+        return this;
+    }
+    /*</methods>*/
+    
+    /*<keys>*/
+    @Library("UIKit")
+    public static class Keys {
+        static { Bro.bind(Keys.class); }
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UIPasteboardOptionExpirationDate", optional=true)
+        public static native NSString ExpirationDate();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UIPasteboardOptionLocalOnly", optional=true)
+        public static native NSString LocalOnly();
+    }
+    /*</keys>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPercentDrivenInteractiveTransition.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPercentDrivenInteractiveTransition.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPercentDrivenInteractiveTransition() {}
+    protected UIPercentDrivenInteractiveTransition(Handle h, long handle) { super(h, handle); }
     protected UIPercentDrivenInteractiveTransition(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
@@ -66,9 +67,34 @@ import org.robovm.apple.corelocation.*;
     public native UIViewAnimationCurve getCompletionCurve();
     @Property(selector = "setCompletionCurve:")
     public native void setCompletionCurve(UIViewAnimationCurve v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "timingCurve")
+    public native UITimingCurveProvider getTimingCurve();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setTimingCurve:")
+    public native void setTimingCurve(UITimingCurveProvider v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "wantsInteractiveStart")
+    public native boolean wantsInteractiveStart();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setWantsInteractiveStart:")
+    public native void setWantsInteractiveStart(boolean v);
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "pauseInteractiveTransition")
+    public native void pauseInteractiveTransition();
     @Method(selector = "updateInteractiveTransition:")
     public native void updateInteractiveTransition(@MachineSizedFloat double percentComplete);
     @Method(selector = "cancelInteractiveTransition")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPickerView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPickerView.java
@@ -44,20 +44,22 @@ import org.robovm.apple.corelocation.*;
 /*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/UIPickerView/*</name>*/ 
     extends /*<extends>*/UIView/*</extends>*/ 
-    /*<implements>*/implements NSCoding, UITableViewDataSource/*</implements>*/ {
+    /*<implements>*/implements NSCoding/*</implements>*/ {
 
     /*<ptr>*/public static class UIPickerViewPtr extends Ptr<UIPickerView, UIPickerViewPtr> {}/*</ptr>*/
     /*<bind>*/static { ObjCRuntime.bind(UIPickerView.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPickerView() {}
+    protected UIPickerView(Handle h, long handle) { super(h, handle); }
     protected UIPickerView(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UIPickerView(CGRect frame) {
         super(frame);
     }
-    
+    public UIPickerView(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "dataSource")
     public native UIPickerViewDataSource getDataSource();
@@ -75,6 +77,15 @@ import org.robovm.apple.corelocation.*;
     public native @MachineSizedSInt long getNumberOfComponents();
     /*</properties>*/
     /*<members>*//*</members>*/
+    private UIPickerViewModel model;
+    public void setModel(UIPickerViewModel model) {
+        this.model = model;
+        setDelegate(model);
+        setDataSource(model);
+    }
+    public UIPickerViewModel getModel() {
+        return model;
+    }
     /*<methods>*/
     @Method(selector = "numberOfRowsInComponent:")
     public native @MachineSizedSInt long getNumberOfRows(@MachineSizedSInt long component);
@@ -90,27 +101,5 @@ import org.robovm.apple.corelocation.*;
     public native void selectRow(@MachineSizedSInt long row, @MachineSizedSInt long component, boolean animated);
     @Method(selector = "selectedRowInComponent:")
     public native @MachineSizedSInt long getSelectedRow(@MachineSizedSInt long component);
-    @Method(selector = "tableView:numberOfRowsInSection:")
-    public native @MachineSizedSInt long getNumberOfRowsInSection(UITableView tableView, @MachineSizedSInt long section);
-    @Method(selector = "tableView:cellForRowAtIndexPath:")
-    public native UITableViewCell getCellForRow(UITableView tableView, NSIndexPath indexPath);
-    @Method(selector = "numberOfSectionsInTableView:")
-    public native @MachineSizedSInt long getNumberOfSections(UITableView tableView);
-    @Method(selector = "tableView:titleForHeaderInSection:")
-    public native String getTitleForHeader(UITableView tableView, @MachineSizedSInt long section);
-    @Method(selector = "tableView:titleForFooterInSection:")
-    public native String getTitleForFooter(UITableView tableView, @MachineSizedSInt long section);
-    @Method(selector = "tableView:canEditRowAtIndexPath:")
-    public native boolean canEditRow(UITableView tableView, NSIndexPath indexPath);
-    @Method(selector = "tableView:canMoveRowAtIndexPath:")
-    public native boolean canMoveRow(UITableView tableView, NSIndexPath indexPath);
-    @Method(selector = "sectionIndexTitlesForTableView:")
-    public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getSectionIndexTitles(UITableView tableView);
-    @Method(selector = "tableView:sectionForSectionIndexTitle:atIndex:")
-    public native @MachineSizedSInt long getSectionForSectionIndexTitle(UITableView tableView, String title, @MachineSizedSInt long index);
-    @Method(selector = "tableView:commitEditingStyle:forRowAtIndexPath:")
-    public native void commitEditingStyleForRow(UITableView tableView, UITableViewCellEditingStyle editingStyle, NSIndexPath indexPath);
-    @Method(selector = "tableView:moveRowAtIndexPath:toIndexPath:")
-    public native void moveRow(UITableView tableView, NSIndexPath sourceIndexPath, NSIndexPath destinationIndexPath);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPickerViewModel.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPickerViewModel.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+import org.robovm.apple.foundation.NSAttributedString;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.objc.annotation.NotImplemented;
+import org.robovm.rt.bro.annotation.MachineSizedFloat;
+import org.robovm.rt.bro.annotation.MachineSizedSInt;
+
+public class UIPickerViewModel extends NSObject implements UIPickerViewDelegate, UIPickerViewDataSource {
+    @NotImplemented("pickerView:widthForComponent:")
+    public @MachineSizedFloat double getComponentWidth(UIPickerView pickerView, @MachineSizedSInt long component) { return 0; }
+    @NotImplemented("pickerView:rowHeightForComponent:")
+    public @MachineSizedFloat double getRowHeight(UIPickerView pickerView, @MachineSizedSInt long component) { return 0; }
+    @NotImplemented("pickerView:titleForRow:forComponent:")
+    public String getRowTitle(UIPickerView pickerView, @MachineSizedSInt long row, @MachineSizedSInt long component) { return null; }
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @NotImplemented("pickerView:attributedTitleForRow:forComponent:")
+    public NSAttributedString getAttributedRowTitle(UIPickerView pickerView, @MachineSizedSInt long row, @MachineSizedSInt long component) { return null; }
+    @NotImplemented("pickerView:viewForRow:forComponent:reusingView:")
+    public UIView getRowView(UIPickerView pickerView, @MachineSizedSInt long row, @MachineSizedSInt long component, UIView view) { return null; }
+    @NotImplemented("pickerView:didSelectRow:inComponent:")
+    public void didSelectRow(UIPickerView pickerView, @MachineSizedSInt long row, @MachineSizedSInt long component) {}
+    
+    @NotImplemented("numberOfComponentsInPickerView:")
+    public @MachineSizedSInt long getNumberOfComponents(UIPickerView pickerView) { return 0; }
+    @NotImplemented("pickerView:numberOfRowsInComponent:")
+    public @MachineSizedSInt long getNumberOfRows(UIPickerView pickerView, @MachineSizedSInt long component) { return 0; }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPinchGestureRecognizer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPinchGestureRecognizer.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPinchGestureRecognizer() {}
+    protected UIPinchGestureRecognizer(Handle h, long handle) { super(h, handle); }
     protected UIPinchGestureRecognizer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPopoverBackgroundView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPopoverBackgroundView.java
@@ -51,13 +51,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPopoverBackgroundView() {}
+    protected UIPopoverBackgroundView(Handle h, long handle) { super(h, handle); }
     protected UIPopoverBackgroundView(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UIPopoverBackgroundView(CGRect frame) {
         super(frame);
     }
-    
+    public UIPopoverBackgroundView(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "arrowOffset")
     public native @MachineSizedFloat double getArrowOffset();
@@ -67,13 +69,14 @@ import org.robovm.apple.corelocation.*;
     public native UIPopoverArrowDirection getArrowDirection();
     @Property(selector = "setArrowDirection:")
     public native void setArrowDirection(UIPopoverArrowDirection v);
-    /*</properties>*/
-    /*<members>*//*</members>*/
-    /*<methods>*/
     /**
      * @since Available in iOS 6.0 and later.
      */
-    @Method(selector = "wantsDefaultContentAppearance")
+    @Property(selector = "wantsDefaultContentAppearance")
     public static native boolean wantsDefaultContentAppearance();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPopoverController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPopoverController.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPopoverController() {}
+    protected UIPopoverController(Handle h, long handle) { super(h, handle); }
     protected UIPopoverController(SkipInit skipInit) { super(skipInit); }
     public UIPopoverController(UIViewController viewController) { super((SkipInit) null); initObject(init(viewController)); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPopoverPresentationController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPopoverPresentationController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPopoverPresentationController() {}
+    protected UIPopoverPresentationController(Handle h, long handle) { super(h, handle); }
     protected UIPopoverPresentationController(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPresentationController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPresentationController.java
@@ -50,7 +50,7 @@ import org.robovm.apple.corelocation.*;
     /*<bind>*/static { ObjCRuntime.bind(UIPresentationController.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public UIPresentationController() {}
+    protected UIPresentationController() {}
     protected UIPresentationController(Handle h, long handle) { super(h, handle); }
     protected UIPresentationController(SkipInit skipInit) { super(skipInit); }
     public UIPresentationController(UIViewController presentedViewController, UIViewController presentingViewController) { super((SkipInit) null); initObject(init(presentedViewController, presentingViewController)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPresentationController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPresentationController.java
@@ -44,13 +44,14 @@ import org.robovm.apple.corelocation.*;
 /*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/UIPresentationController/*</name>*/ 
     extends /*<extends>*/NSObject/*</extends>*/ 
-    /*<implements>*/implements UIAppearanceContainer, UITraitEnvironment/*</implements>*/ {
+    /*<implements>*/implements UIAppearanceContainer, UITraitEnvironment, UIFocusEnvironment/*</implements>*/ {
 
     /*<ptr>*/public static class UIPresentationControllerPtr extends Ptr<UIPresentationController, UIPresentationControllerPtr> {}/*</ptr>*/
     /*<bind>*/static { ObjCRuntime.bind(UIPresentationController.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPresentationController() {}
+    protected UIPresentationController(Handle h, long handle) { super(h, handle); }
     protected UIPresentationController(SkipInit skipInit) { super(skipInit); }
     public UIPresentationController(UIViewController presentedViewController, UIViewController presentingViewController) { super((SkipInit) null); initObject(init(presentedViewController, presentingViewController)); }
     /*</constructors>*/
@@ -67,6 +68,16 @@ import org.robovm.apple.corelocation.*;
     public native UIAdaptivePresentationControllerDelegate getDelegate();
     @Property(selector = "setDelegate:", strongRef = true)
     public native void setDelegate(UIAdaptivePresentationControllerDelegate v);
+    @Property(selector = "adaptivePresentationStyle")
+    public native UIModalPresentationStyle getAdaptivePresentationStyle();
+    @Property(selector = "presentedView")
+    public native UIView getPresentedView();
+    @Property(selector = "frameOfPresentedViewInContainerView")
+    public native @ByVal CGRect getFrameOfPresentedViewInContainerView();
+    @Property(selector = "shouldPresentInFullscreen")
+    public native boolean shouldPresentInFullscreen();
+    @Property(selector = "shouldRemovePresentersView")
+    public native boolean shouldRemovePresentersView();
     @Property(selector = "overrideTraitCollection")
     public native UITraitCollection getOverrideTraitCollection();
     @Property(selector = "setOverrideTraitCollection:")
@@ -76,13 +87,20 @@ import org.robovm.apple.corelocation.*;
      */
     @Property(selector = "traitCollection")
     public native UITraitCollection getTraitCollection();
+    @Property(selector = "preferredFocusEnvironments")
+    public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<UIFocusEnvironment> getPreferredFocusEnvironments();
+    /**
+     * @since Available in iOS 9.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    @Property(selector = "preferredFocusedView")
+    public native UIView getPreferredFocusedView();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
     @Method(selector = "initWithPresentedViewController:presentingViewController:")
     protected native @Pointer long init(UIViewController presentedViewController, UIViewController presentingViewController);
-    @Method(selector = "adaptivePresentationStyle")
-    public native UIModalPresentationStyle getAdaptivePresentationStyle();
     /**
      * @since Available in iOS 8.3 and later.
      */
@@ -92,14 +110,6 @@ import org.robovm.apple.corelocation.*;
     public native void containerViewWillLayoutSubviews();
     @Method(selector = "containerViewDidLayoutSubviews")
     public native void containerViewDidLayoutSubviews();
-    @Method(selector = "presentedView")
-    public native UIView getPresentedView();
-    @Method(selector = "frameOfPresentedViewInContainerView")
-    public native @ByVal CGRect getFrameOfPresentedViewInContainerView();
-    @Method(selector = "shouldPresentInFullscreen")
-    public native boolean shouldPresentInFullscreen();
-    @Method(selector = "shouldRemovePresentersView")
-    public native boolean shouldRemovePresentersView();
     @Method(selector = "presentationTransitionWillBegin")
     public native void presentationTransitionWillBegin();
     @Method(selector = "presentationTransitionDidEnd:")
@@ -113,5 +123,13 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "traitCollectionDidChange:")
     public native void traitCollectionDidChange(UITraitCollection previousTraitCollection);
+    @Method(selector = "setNeedsFocusUpdate")
+    public native void setNeedsFocusUpdate();
+    @Method(selector = "updateFocusIfNeeded")
+    public native void updateFocusIfNeeded();
+    @Method(selector = "shouldUpdateFocusInContext:")
+    public native boolean shouldUpdateFocus(UIFocusUpdateContext context);
+    @Method(selector = "didUpdateFocusInContext:withAnimationCoordinator:")
+    public native void didUpdateFocus(UIFocusUpdateContext context, UIFocusAnimationCoordinator coordinator);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPress.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPress.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIPress/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIPressPtr extends Ptr<UIPress, UIPressPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIPress.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIPress() {}
+    protected UIPress(Handle h, long handle) { super(h, handle); }
+    protected UIPress(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "timestamp")
+    public native double getTimestamp();
+    @Property(selector = "phase")
+    public native UIPressPhase getPhase();
+    @Property(selector = "type")
+    public native UIPressType getType();
+    @Property(selector = "window")
+    public native UIWindow getWindow();
+    @Property(selector = "responder")
+    public native UIResponder getResponder();
+    @Property(selector = "gestureRecognizers")
+    public native NSArray<UIGestureRecognizer> getGestureRecognizers();
+    @Property(selector = "force")
+    public native @MachineSizedFloat double getForce();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPressPhase.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPressPhase.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UIPressPhase/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Began(0L),
+    Changed(1L),
+    Stationary(2L),
+    Ended(3L),
+    Cancelled(4L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UIPressPhase/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UIPressPhase/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UIPressPhase/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UIPressPhase/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPressType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPressType.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UIPressType/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    UpArrow(0L),
+    DownArrow(1L),
+    LeftArrow(2L),
+    RightArrow(3L),
+    Select(4L),
+    Menu(5L),
+    PlayPause(6L);
+    /*</values>*/
+    
+    public static class AsListMarshaler {
+        @SuppressWarnings("unchecked")
+        @MarshalsPointer
+        public static List<UIPressType> toObject(Class<? extends NSObject> cls, long handle, long flags) {
+            NSArray<NSNumber> o = (NSArray<NSNumber>) NSObject.Marshaler.toObject(cls, handle, flags);
+            if (o == null) {
+                return null;
+            }
+            List<UIPressType> list = new ArrayList<>();
+            for (NSNumber n : o) {
+                list.add(UIPressType.valueOf(n.longValue()));
+            }
+            return list;
+        }
+        @MarshalsPointer
+        public static long toNative(List<UIPressType> l, long flags) {
+            if (l == null) {
+                return 0L;
+            }
+            NSArray<NSNumber> array = new NSMutableArray<>();
+            for (UIPressType i : l) {
+                array.add(NSNumber.valueOf(i.value()));
+            }
+            return NSObject.Marshaler.toNative(array, flags);
+        }
+    }
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UIPressType/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UIPressType/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UIPressType/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UIPressType/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPressesEvent.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPressesEvent.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIPressesEvent/*</name>*/ 
+    extends /*<extends>*/UIEvent/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIPressesEventPtr extends Ptr<UIPressesEvent, UIPressesEventPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIPressesEvent.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIPressesEvent() {}
+    protected UIPressesEvent(Handle h, long handle) { super(h, handle); }
+    protected UIPressesEvent(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "allPresses")
+    public native NSSet<UIPress> getAllPresses();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "pressesForGestureRecognizer:")
+    public native NSSet<UIPress> getPressesForGestureRecognizer(UIGestureRecognizer gesture);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewAction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewAction.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIPreviewAction/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements UIPreviewActionItem/*</implements>*/ {
+
+    /*<ptr>*/public static class UIPreviewActionPtr extends Ptr<UIPreviewAction, UIPreviewActionPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIPreviewAction.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIPreviewAction() {}
+    protected UIPreviewAction(Handle h, long handle) { super(h, handle); }
+    protected UIPreviewAction(SkipInit skipInit) { super(skipInit); }
+    public UIPreviewAction(String title, UIPreviewActionStyle style, @Block VoidBlock2<UIPreviewActionItem, UIViewController> handler) { super((Handle) null, create(title, style, handler)); retain(getHandle()); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "handler")
+    public native @Block VoidBlock2<UIPreviewActionItem, UIViewController> getHandler();
+    @Property(selector = "title")
+    public native String getTitle();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "actionWithTitle:style:handler:")
+    protected static native @Pointer long create(String title, UIPreviewActionStyle style, @Block VoidBlock2<UIPreviewActionItem, UIViewController> handler);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewActionGroup.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewActionGroup.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIPreviewActionGroup/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements UIPreviewActionItem/*</implements>*/ {
+
+    /*<ptr>*/public static class UIPreviewActionGroupPtr extends Ptr<UIPreviewActionGroup, UIPreviewActionGroupPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIPreviewActionGroup.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIPreviewActionGroup() {}
+    protected UIPreviewActionGroup(Handle h, long handle) { super(h, handle); }
+    protected UIPreviewActionGroup(SkipInit skipInit) { super(skipInit); }
+    public UIPreviewActionGroup(String title, UIPreviewActionStyle style, NSArray<UIPreviewAction> actions) { super((Handle) null, create(title, style, actions)); retain(getHandle()); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "title")
+    public native String getTitle();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "actionGroupWithTitle:style:actions:")
+    protected static native @Pointer long create(String title, UIPreviewActionStyle style, NSArray<UIPreviewAction> actions);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewActionItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewActionItem.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/UIPreviewActionItem/*</name>*/ 
+    /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<properties>*/
+    @Property(selector = "title")
+    String getTitle();
+    /*</properties>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+    /*<adapter>*/
+    /*</adapter>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewActionItemAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewActionItemAdapter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIPreviewActionItemAdapter/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements UIPreviewActionItem/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*/
+    @NotImplemented("title")
+    public String getTitle() { return null; }
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewActionStyle.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewActionStyle.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UIPreviewActionStyle/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Default(0L),
+    Selected(1L),
+    Destructive(2L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UIPreviewActionStyle/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UIPreviewActionStyle/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UIPreviewActionStyle/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UIPreviewActionStyle/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewInteraction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewInteraction.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIPreviewInteraction/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UIPreviewInteractionPtr extends Ptr<UIPreviewInteraction, UIPreviewInteractionPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIPreviewInteraction.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIPreviewInteraction() {}
+    protected UIPreviewInteraction(Handle h, long handle) { super(h, handle); }
+    protected UIPreviewInteraction(SkipInit skipInit) { super(skipInit); }
+    public UIPreviewInteraction(UIView view) { super((SkipInit) null); initObject(init(view)); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "view")
+    public native UIView getView();
+    @Property(selector = "delegate")
+    public native UIPreviewInteractionDelegate getDelegate();
+    @Property(selector = "setDelegate:", strongRef = true)
+    public native void setDelegate(UIPreviewInteractionDelegate v);
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "initWithView:")
+    protected native @Pointer long init(UIView view);
+    @Method(selector = "locationInCoordinateSpace:")
+    public native @ByVal CGPoint getLocationInCoordinateSpace(UICoordinateSpace coordinateSpace);
+    @Method(selector = "cancelInteraction")
+    public native void cancelInteraction();
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewInteraction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewInteraction.java
@@ -50,7 +50,7 @@ import org.robovm.apple.corelocation.*;
     /*<bind>*/static { ObjCRuntime.bind(UIPreviewInteraction.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public UIPreviewInteraction() {}
+    protected UIPreviewInteraction() {}
     protected UIPreviewInteraction(Handle h, long handle) { super(h, handle); }
     protected UIPreviewInteraction(SkipInit skipInit) { super(skipInit); }
     public UIPreviewInteraction(UIView view) { super((SkipInit) null); initObject(init(view)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewInteractionDelegate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewInteractionDelegate.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/UIPreviewInteractionDelegate/*</name>*/ 
+    /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<methods>*/
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "previewInteraction:didUpdatePreviewTransition:ended:")
+    void didUpdatePreviewTransition(UIPreviewInteraction previewInteraction, @MachineSizedFloat double transitionProgress, boolean ended);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "previewInteractionDidCancel:")
+    void didCancel(UIPreviewInteraction previewInteraction);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "previewInteractionShouldBegin:")
+    boolean shouldBegin(UIPreviewInteraction previewInteraction);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "previewInteraction:didUpdateCommitTransition:ended:")
+    void didUpdateCommitTransition(UIPreviewInteraction previewInteraction, @MachineSizedFloat double transitionProgress, boolean ended);
+    /*</methods>*/
+    /*<adapter>*/
+    /*</adapter>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewInteractionDelegateAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewInteractionDelegateAdapter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIPreviewInteractionDelegateAdapter/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements UIPreviewInteractionDelegate/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("previewInteraction:didUpdatePreviewTransition:ended:")
+    public void didUpdatePreviewTransition(UIPreviewInteraction previewInteraction, @MachineSizedFloat double transitionProgress, boolean ended) {}
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("previewInteractionDidCancel:")
+    public void didCancel(UIPreviewInteraction previewInteraction) {}
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("previewInteractionShouldBegin:")
+    public boolean shouldBegin(UIPreviewInteraction previewInteraction) { return false; }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("previewInteraction:didUpdateCommitTransition:ended:")
+    public void didUpdateCommitTransition(UIPreviewInteraction previewInteraction, @MachineSizedFloat double transitionProgress, boolean ended) {}
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrintFormatter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrintFormatter.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPrintFormatter() {}
+    protected UIPrintFormatter(Handle h, long handle) { super(h, handle); }
     protected UIPrintFormatter(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
@@ -64,8 +65,18 @@ import org.robovm.apple.corelocation.*;
     public native @MachineSizedFloat double getMaximumContentWidth();
     @Property(selector = "setMaximumContentWidth:")
     public native void setMaximumContentWidth(@MachineSizedFloat double v);
+    /**
+     * @since Available in iOS 4.2 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
     @Property(selector = "contentInsets")
     public native @ByVal UIEdgeInsets getContentInsets();
+    /**
+     * @since Available in iOS 4.2 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
     @Property(selector = "setContentInsets:")
     public native void setContentInsets(@ByVal UIEdgeInsets v);
     @Property(selector = "perPageContentInsets")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrintInfo.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrintInfo.java
@@ -51,9 +51,10 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPrintInfo() {}
+    protected UIPrintInfo(Handle h, long handle) { super(h, handle); }
     protected UIPrintInfo(SkipInit skipInit) { super(skipInit); }
     public UIPrintInfo(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
-    public UIPrintInfo(NSDictionary<?, ?> dictionary) { super(create(dictionary)); retain(getHandle()); }
+    public UIPrintInfo(NSDictionary<?, ?> dictionary) { super((Handle) null, create(dictionary)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "printerID")
@@ -76,13 +77,13 @@ import org.robovm.apple.corelocation.*;
     public native UIPrintInfoDuplex getDuplex();
     @Property(selector = "setDuplex:")
     public native void setDuplex(UIPrintInfoDuplex v);
+    @Property(selector = "dictionaryRepresentation")
+    public native NSDictionary<?, ?> toDictionary();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
     @Method(selector = "initWithCoder:")
     protected native @Pointer long init(NSCoder aDecoder);
-    @Method(selector = "dictionaryRepresentation")
-    public native NSDictionary<?, ?> toDictionary();
     @Method(selector = "printInfoWithDictionary:")
     protected static native @Pointer long create(NSDictionary<?, ?> dictionary);
     @Method(selector = "encodeWithCoder:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrintInteractionController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrintInteractionController.java
@@ -51,9 +51,16 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPrintInteractionController() {}
+    protected UIPrintInteractionController(Handle h, long handle) { super(h, handle); }
     protected UIPrintInteractionController(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
+    @Property(selector = "isPrintingAvailable")
+    public static native boolean isPrintingAvailable();
+    @Property(selector = "printableUTIs")
+    public static native @org.robovm.rt.bro.annotation.Marshaler(NSSet.AsStringSetMarshaler.class) Set<String> getPrintableUTIs();
+    @Property(selector = "sharedPrintController")
+    public static native UIPrintInteractionController getSharedPrintController();
     @Property(selector = "printInfo")
     public native UIPrintInfo getPrintInfo();
     @Property(selector = "setPrintInfo:")
@@ -62,8 +69,18 @@ import org.robovm.apple.corelocation.*;
     public native UIPrintInteractionControllerDelegate getDelegate();
     @Property(selector = "setDelegate:", strongRef = true)
     public native void setDelegate(UIPrintInteractionControllerDelegate v);
+    /**
+     * @since Available in iOS 4.2 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
     @Property(selector = "showsPageRange")
     public native boolean showsPageRange();
+    /**
+     * @since Available in iOS 4.2 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
     @Property(selector = "setShowsPageRange:")
     public native void setShowsPageRange(boolean v);
     /**
@@ -117,15 +134,9 @@ import org.robovm.apple.corelocation.*;
     public native boolean print(UIPrinter printer, @Block VoidBlock3<UIPrintInteractionController, Boolean, NSError> completion);
     @Method(selector = "dismissAnimated:")
     public native void dismiss(boolean animated);
-    @Method(selector = "isPrintingAvailable")
-    public static native boolean isPrintingAvailable();
-    @Method(selector = "printableUTIs")
-    public static native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getPrintableUTIs();
     @Method(selector = "canPrintURL:")
     public static native boolean canPrint(NSURL url);
     @Method(selector = "canPrintData:")
     public static native boolean canPrint(NSData data);
-    @Method(selector = "sharedPrintController")
-    public static native UIPrintInteractionController getSharedPrintController();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrintPageRenderer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrintPageRenderer.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPrintPageRenderer() {}
+    protected UIPrintPageRenderer(Handle h, long handle) { super(h, handle); }
     protected UIPrintPageRenderer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
@@ -66,6 +67,8 @@ import org.robovm.apple.corelocation.*;
     public native @ByVal CGRect getPaperRect();
     @Property(selector = "printableRect")
     public native @ByVal CGRect getPrintableRect();
+    @Property(selector = "numberOfPages")
+    public native @MachineSizedSInt long getNumberOfPages();
     @Property(selector = "printFormatters")
     public native NSArray<UIPrintFormatter> getPrintFormatters();
     @Property(selector = "setPrintFormatters:")
@@ -77,8 +80,6 @@ import org.robovm.apple.corelocation.*;
     public native NSArray<UIPrintFormatter> getPrintFormatters(@MachineSizedSInt long pageIndex);
     @Method(selector = "addPrintFormatter:startingAtPageAtIndex:")
     public native void addPrintFormatter(UIPrintFormatter formatter, @MachineSizedSInt long pageIndex);
-    @Method(selector = "numberOfPages")
-    public native @MachineSizedSInt long getNumberOfPages();
     @Method(selector = "prepareForDrawingPages:")
     public native void prepareForDrawingPages(@ByVal NSRange range);
     @Method(selector = "drawPageAtIndex:inRect:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrintPaper.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrintPaper.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPrintPaper() {}
+    protected UIPrintPaper(Handle h, long handle) { super(h, handle); }
     protected UIPrintPaper(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrinter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrinter.java
@@ -51,8 +51,9 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPrinter() {}
+    protected UIPrinter(Handle h, long handle) { super(h, handle); }
     protected UIPrinter(SkipInit skipInit) { super(skipInit); }
-    public UIPrinter(NSURL url) { super(create(url)); retain(getHandle()); }
+    public UIPrinter(NSURL url) { super((Handle) null, create(url)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "URL")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrinterPickerController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrinterPickerController.java
@@ -51,8 +51,9 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPrinterPickerController() {}
+    protected UIPrinterPickerController(Handle h, long handle) { super(h, handle); }
     protected UIPrinterPickerController(SkipInit skipInit) { super(skipInit); }
-    public UIPrinterPickerController(UIPrinter printer) { super(create(printer)); retain(getHandle()); }
+    public UIPrinterPickerController(UIPrinter printer) { super((Handle) null, create(printer)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "selectedPrinter")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIProgressView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIProgressView.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIProgressView() {}
+    protected UIProgressView(Handle h, long handle) { super(h, handle); }
     protected UIProgressView(SkipInit skipInit) { super(skipInit); }
     public UIProgressView(@ByVal CGRect frame) { super((SkipInit) null); initObject(init(frame)); }
     public UIProgressView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPushBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPushBehavior.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIPushBehavior() {}
+    protected UIPushBehavior(Handle h, long handle) { super(h, handle); }
     protected UIPushBehavior(SkipInit skipInit) { super(skipInit); }
     public UIPushBehavior(List<UIDynamicItem> items, UIPushBehaviorMode mode) { super((SkipInit) null); initObject(init(items, mode)); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIReferenceLibraryViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIReferenceLibraryViewController.java
@@ -50,12 +50,11 @@ import org.robovm.apple.corelocation.*;
     /*<bind>*/static { ObjCRuntime.bind(UIReferenceLibraryViewController.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public UIReferenceLibraryViewController() {}
+    protected UIReferenceLibraryViewController() {}
     protected UIReferenceLibraryViewController(Handle h, long handle) { super(h, handle); }
     protected UIReferenceLibraryViewController(SkipInit skipInit) { super(skipInit); }
     public UIReferenceLibraryViewController(String term) { super((SkipInit) null); initObject(init(term)); }
     public UIReferenceLibraryViewController(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
-    public UIReferenceLibraryViewController(String nibNameOrNil, NSBundle nibBundleOrNil) { super((SkipInit) null); initObject(init(nibNameOrNil, nibBundleOrNil)); }
     /*</constructors>*/
     /*<properties>*/
     
@@ -66,8 +65,6 @@ import org.robovm.apple.corelocation.*;
     protected native @Pointer long init(String term);
     @Method(selector = "initWithCoder:")
     protected native @Pointer long init(NSCoder aDecoder);
-    @Method(selector = "initWithNibName:bundle:")
-    protected native @Pointer long init(String nibNameOrNil, NSBundle nibBundleOrNil);
     @Method(selector = "dictionaryHasDefinitionForTerm:")
     public static native boolean dictionaryHasDefinitionForTerm(String term);
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIReferenceLibraryViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIReferenceLibraryViewController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIReferenceLibraryViewController() {}
+    protected UIReferenceLibraryViewController(Handle h, long handle) { super(h, handle); }
     protected UIReferenceLibraryViewController(SkipInit skipInit) { super(skipInit); }
     public UIReferenceLibraryViewController(String term) { super((SkipInit) null); initObject(init(term)); }
     public UIReferenceLibraryViewController(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIRefreshControl.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIRefreshControl.java
@@ -51,13 +51,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIRefreshControl() {}
+    protected UIRefreshControl(Handle h, long handle) { super(h, handle); }
     protected UIRefreshControl(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UIRefreshControl(CGRect frame) {
         super(frame);
     }
-    
+    public UIRefreshControl(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "isRefreshing")
     public native boolean isRefreshing();

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIRegion.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIRegion.java
@@ -51,13 +51,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIRegion() {}
+    protected UIRegion(Handle h, long handle) { super(h, handle); }
     protected UIRegion(SkipInit skipInit) { super(skipInit); }
     public UIRegion(@MachineSizedFloat double radius) { super((SkipInit) null); initObject(init(radius)); }
     public UIRegion(@ByVal CGSize size) { super((SkipInit) null); initObject(init(size)); }
-    public UIRegion(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    public UIRegion(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
-    
+    @Property(selector = "infiniteRegion")
+    public static native UIRegion getInfiniteRegion();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -75,11 +77,9 @@ import org.robovm.apple.corelocation.*;
     public native UIRegion intersection(UIRegion region);
     @Method(selector = "containsPoint:")
     public native boolean containsPoint(@ByVal CGPoint point);
-    @Method(selector = "infiniteRegion")
-    public static native UIRegion getInfiniteRegion();
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIRemoteNotification.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIRemoteNotification.java
@@ -59,6 +59,7 @@ import org.robovm.apple.coreimage.*;
         }
     }
     
+    private static final NSString APS = new NSString("aps");
     private static final NSString ALERT = new NSString("alert");
     private static final NSString BODY = new NSString("body");
     private static final NSString SHOW_VIEW = new NSString("show-view");
@@ -71,8 +72,9 @@ import org.robovm.apple.coreimage.*;
     static { Bro.bind(UIRemoteNotification.class); }
     
     public String getAlert() {
-        if (data.containsKey(ALERT)) {
-            NSObject val = data.get(ALERT);
+        NSDictionary<NSString, NSObject> aps = (NSDictionary<NSString, NSObject>) data.get(APS);
+        if (aps != null && aps.containsKey(ALERT)) {
+            NSObject val = aps.get(ALERT);
             if (val instanceof NSString) {
                 return val.toString();
             }
@@ -87,8 +89,9 @@ import org.robovm.apple.coreimage.*;
         return null;
     }
     public boolean isViewButtonShown() {
-        if (data.containsKey(ALERT)) {
-            NSObject val = data.get(ALERT);
+        NSDictionary<NSString, NSObject> aps = (NSDictionary<NSString, NSObject>) data.get(APS);
+        if (aps != null && aps.containsKey(ALERT)) {
+            NSObject val = aps.get(ALERT);
             if (val instanceof NSDictionary) {
                 NSDictionary<NSString, NSObject> alert = (NSDictionary<NSString, NSObject>) val;
                 if (alert.containsKey(SHOW_VIEW)) {
@@ -100,29 +103,27 @@ import org.robovm.apple.coreimage.*;
         return true;
     }
     public long getBadgeNumber() {
-        if (data.containsKey(BADGE)) {
-            NSString val = (NSString) data.get(BADGE);
+        NSDictionary<NSString, NSObject> aps = (NSDictionary<NSString, NSObject>) data.get(APS);
+        if (aps != null && aps.containsKey(BADGE)) {
+            NSString val = (NSString) aps.get(BADGE);
             return Long.valueOf(val.toString());
         }
         return -1;
     }
     public String getSound() {
-        if (data.containsKey(SOUND)) {
-            NSString val = (NSString) data.get(SOUND);
+        NSDictionary<NSString, NSObject> aps = (NSDictionary<NSString, NSObject>) data.get(APS);
+        if (aps != null && aps.containsKey(SOUND)) {
+            NSString val = (NSString) aps.get(SOUND);
             return val.toString();
         }
         return null;
     }
     
     public NSObject get(String key) {
-        return data.get(new NSString(key));
+        return data.get(key);
     }
     
     public String getString(String key) {
-        return String.valueOf(get(key));
-    }
-    
-    public NSDictionary<NSString, NSObject> getDictionary() {
-        return data;
+        return data.getString(key, null);
     }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIResponder.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIResponder.java
@@ -51,10 +51,19 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIResponder() {}
-    protected UIResponder(long handle) { super(handle); }
+    @Deprecated protected UIResponder(long handle) { super(handle); }
+    protected UIResponder(Handle h, long handle) { super(h, handle); }
     protected UIResponder(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
+    @Property(selector = "nextResponder")
+    public native UIResponder getNextResponder();
+    @Property(selector = "canBecomeFirstResponder")
+    public native boolean canBecomeFirstResponder();
+    @Property(selector = "canResignFirstResponder")
+    public native boolean canResignFirstResponder();
+    @Property(selector = "isFirstResponder")
+    public native boolean isFirstResponder();
     /**
      * @since Available in iOS 3.0 and later.
      */
@@ -201,18 +210,10 @@ import org.robovm.apple.corelocation.*;
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
-    @Method(selector = "nextResponder")
-    public native UIResponder getNextResponder();
-    @Method(selector = "canBecomeFirstResponder")
-    public native boolean canBecomeFirstResponder();
     @Method(selector = "becomeFirstResponder")
     public native boolean becomeFirstResponder();
-    @Method(selector = "canResignFirstResponder")
-    public native boolean canResignFirstResponder();
     @Method(selector = "resignFirstResponder")
     public native boolean resignFirstResponder();
-    @Method(selector = "isFirstResponder")
-    public native boolean isFirstResponder();
     @Method(selector = "touchesBegan:withEvent:")
     public native void touchesBegan(NSSet<UITouch> touches, UIEvent event);
     @Method(selector = "touchesMoved:withEvent:")
@@ -221,6 +222,31 @@ import org.robovm.apple.corelocation.*;
     public native void touchesEnded(NSSet<UITouch> touches, UIEvent event);
     @Method(selector = "touchesCancelled:withEvent:")
     public native void touchesCancelled(NSSet<UITouch> touches, UIEvent event);
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    @Method(selector = "touchesEstimatedPropertiesUpdated:")
+    public native void touchesEstimatedPropertiesUpdated(NSSet<UITouch> touches);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "pressesBegan:withEvent:")
+    public native void pressesBegan(NSSet<UIPress> presses, UIPressesEvent event);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "pressesChanged:withEvent:")
+    public native void pressesChanged(NSSet<UIPress> presses, UIPressesEvent event);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "pressesEnded:withEvent:")
+    public native void pressesEnded(NSSet<UIPress> presses, UIPressesEvent event);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "pressesCancelled:withEvent:")
+    public native void pressesCancelled(NSSet<UIPress> presses, UIPressesEvent event);
     /**
      * @since Available in iOS 3.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIRotationGestureRecognizer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIRotationGestureRecognizer.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIRotationGestureRecognizer() {}
+    protected UIRotationGestureRecognizer(Handle h, long handle) { super(h, handle); }
     protected UIRotationGestureRecognizer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIScreen.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIScreen.java
@@ -97,9 +97,17 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIScreen() {}
+    protected UIScreen(Handle h, long handle) { super(h, handle); }
     protected UIScreen(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
+    /**
+     * @since Available in iOS 3.2 and later.
+     */
+    @Property(selector = "screens")
+    public static native NSArray<UIScreen> getScreens();
+    @Property(selector = "mainScreen")
+    public static native UIScreen getMainScreen();
     @Property(selector = "bounds")
     public native @ByVal CGRect getBounds();
     /**
@@ -188,6 +196,21 @@ import org.robovm.apple.corelocation.*;
     @Property(selector = "nativeScale")
     public native @MachineSizedFloat double getNativeScale();
     /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "focusedItem")
+    public native UIFocusItem getFocusedItem();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "focusedView")
+    public native UIView getFocusedView();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "supportsFocus")
+    public native boolean supportsFocus();
+    /**
      * @since Available in iOS 2.0 and later.
      * @deprecated Deprecated in iOS 9.0.
      */
@@ -229,13 +252,6 @@ import org.robovm.apple.corelocation.*;
     @WeaklyLinked
     @Method(selector = "displayLinkWithTarget:selector:")
     public native CADisplayLink getDisplayLink(NSObject target, Selector sel);
-    /**
-     * @since Available in iOS 3.2 and later.
-     */
-    @Method(selector = "screens")
-    public static native NSArray<UIScreen> getScreens();
-    @Method(selector = "mainScreen")
-    public static native UIScreen getMainScreen();
     /**
      * @since Available in iOS 7.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIScreenEdgePanGestureRecognizer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIScreenEdgePanGestureRecognizer.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIScreenEdgePanGestureRecognizer() {}
+    protected UIScreenEdgePanGestureRecognizer(Handle h, long handle) { super(h, handle); }
     protected UIScreenEdgePanGestureRecognizer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIScreenMode.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIScreenMode.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIScreenMode() {}
+    protected UIScreenMode(Handle h, long handle) { super(h, handle); }
     protected UIScreenMode(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIScrollView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIScrollView.java
@@ -51,13 +51,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIScrollView() {}
+    protected UIScrollView(Handle h, long handle) { super(h, handle); }
     protected UIScrollView(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UIScrollView(CGRect frame) {
         super(frame);
     }
-    
+    public UIScrollView(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "contentOffset")
     public native @ByVal CGPoint getContentOffset();
@@ -189,6 +191,16 @@ import org.robovm.apple.corelocation.*;
      */
     @Property(selector = "setKeyboardDismissMode:")
     public native void setKeyboardDismissMode(UIScrollViewKeyboardDismissMode v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "refreshControl")
+    public native UIRefreshControl getRefreshControl();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setRefreshControl:")
+    public native void setRefreshControl(UIRefreshControl v);
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchBar.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchBar.java
@@ -53,6 +53,7 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UISearchBar() {}
+    protected UISearchBar(Handle h, long handle) { super(h, handle); }
     protected UISearchBar(SkipInit skipInit) { super(skipInit); }
     public UISearchBar(@ByVal CGRect frame) { super((SkipInit) null); initObject(init(frame)); }
     public UISearchBar(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
@@ -259,6 +260,16 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     public native boolean isSecureTextEntry();
     @Property(selector = "setSecureTextEntry:")
     public native void setSecureTextEntry(boolean v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "textContentType")
+    public native UITextContentType getTextContentType();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setTextContentType:")
+    public native void setTextContentType(UITextContentType v);
     /*</properties>*/
     /*<members>*//*</members>*/
     /**

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchContainerViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchContainerViewController.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UISearchContainerViewController/*</name>*/ 
+    extends /*<extends>*/UIViewController/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UISearchContainerViewControllerPtr extends Ptr<UISearchContainerViewController, UISearchContainerViewControllerPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UISearchContainerViewController.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UISearchContainerViewController() {}
+    protected UISearchContainerViewController(Handle h, long handle) { super(h, handle); }
+    protected UISearchContainerViewController(SkipInit skipInit) { super(skipInit); }
+    public UISearchContainerViewController(UISearchController searchController) { super((SkipInit) null); initObject(init(searchController)); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "searchController")
+    public native UISearchController getSearchController();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "initWithSearchController:")
+    protected native @Pointer long init(UISearchController searchController);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UISearchController() {}
+    protected UISearchController(Handle h, long handle) { super(h, handle); }
     protected UISearchController(SkipInit skipInit) { super(skipInit); }
     public UISearchController(UIViewController searchResultsController) { super((SkipInit) null); initObject(init(searchResultsController)); }
     /*</constructors>*/
@@ -71,6 +72,16 @@ import org.robovm.apple.corelocation.*;
     public native boolean dimsBackgroundDuringPresentation();
     @Property(selector = "setDimsBackgroundDuringPresentation:")
     public native void setDimsBackgroundDuringPresentation(boolean v);
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    @Property(selector = "obscuresBackgroundDuringPresentation")
+    public native boolean obscuresBackgroundDuringPresentation();
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    @Property(selector = "setObscuresBackgroundDuringPresentation:")
+    public native void setObscuresBackgroundDuringPresentation(boolean v);
     @Property(selector = "hidesNavigationBarDuringPresentation")
     public native boolean hidesNavigationBarDuringPresentation();
     @Property(selector = "setHidesNavigationBarDuringPresentation:")
@@ -101,6 +112,11 @@ import org.robovm.apple.corelocation.*;
     public native double getTransitionDuration(UIViewControllerContextTransitioning transitionContext);
     @Method(selector = "animateTransition:")
     public native void animateTransition(UIViewControllerContextTransitioning transitionContext);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "interruptibleAnimatorForTransition:")
+    public native UIViewImplicitlyAnimating getInterruptibleAnimator(UIViewControllerContextTransitioning transitionContext);
     @Method(selector = "animationEnded:")
     public native void animationEnded(boolean transitionCompleted);
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchDisplayController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchDisplayController.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UISearchDisplayController() {}
+    protected UISearchDisplayController(Handle h, long handle) { super(h, handle); }
     protected UISearchDisplayController(SkipInit skipInit) { super(skipInit); }
     public UISearchDisplayController(UISearchBar searchBar, UIViewController viewController) { super((SkipInit) null); initObject(init(searchBar, viewController)); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISegmentedControl.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISegmentedControl.java
@@ -55,14 +55,16 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     /*</constants>*/
     /*<constructors>*/
     public UISegmentedControl() {}
+    protected UISegmentedControl(Handle h, long handle) { super(h, handle); }
     protected UISegmentedControl(SkipInit skipInit) { super(skipInit); }
     public UISegmentedControl(NSArray<?> items) { super((SkipInit) null); initObject(init(items)); }
     /*</constructors>*/
-    
     public UISegmentedControl(CGRect frame) {
         super(frame);
     }
-    
+    public UISegmentedControl(NSCoder decoder) {
+        super(decoder);
+    }
     public UISegmentedControl(String... items) {
         super((SkipInit) null);
         initObject(init(NSArray.fromStrings(items)));

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISelectionFeedbackGenerator.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISelectionFeedbackGenerator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UISelectionFeedbackGenerator/*</name>*/ 
+    extends /*<extends>*/UIFeedbackGenerator/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UISelectionFeedbackGeneratorPtr extends Ptr<UISelectionFeedbackGenerator, UISelectionFeedbackGeneratorPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UISelectionFeedbackGenerator.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UISelectionFeedbackGenerator() {}
+    protected UISelectionFeedbackGenerator(Handle h, long handle) { super(h, handle); }
+    protected UISelectionFeedbackGenerator(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "selectionChanged")
+    public native void selectionChanged();
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISimpleTextPrintFormatter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISimpleTextPrintFormatter.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UISimpleTextPrintFormatter() {}
+    protected UISimpleTextPrintFormatter(Handle h, long handle) { super(h, handle); }
     protected UISimpleTextPrintFormatter(SkipInit skipInit) { super(skipInit); }
     public UISimpleTextPrintFormatter(String text) { super((SkipInit) null); initObject(init(text)); }
     /**

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISlider.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISlider.java
@@ -51,13 +51,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UISlider() {}
+    protected UISlider(Handle h, long handle) { super(h, handle); }
     protected UISlider(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UISlider(CGRect frame) {
         super(frame);
     }
-    
+    public UISlider(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "value")
     public native float getValue();

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISnapBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISnapBehavior.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UISnapBehavior() {}
+    protected UISnapBehavior(Handle h, long handle) { super(h, handle); }
     protected UISnapBehavior(SkipInit skipInit) { super(skipInit); }
     public UISnapBehavior(UIDynamicItem item, @ByVal CGPoint point) { super((SkipInit) null); initObject(init(item, point)); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISplitViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISplitViewController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UISplitViewController() {}
+    protected UISplitViewController(Handle h, long handle) { super(h, handle); }
     protected UISplitViewController(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
@@ -95,6 +96,11 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 8.0 and later.
      */
+    @Property(selector = "displayModeButtonItem")
+    public native UIBarButtonItem getDisplayModeButtonItem();
+    /**
+     * @since Available in iOS 8.0 and later.
+     */
     @Property(selector = "preferredPrimaryColumnWidthFraction")
     public native @MachineSizedFloat double getPreferredPrimaryColumnWidthFraction();
     /**
@@ -136,11 +142,6 @@ import org.robovm.apple.corelocation.*;
     @GlobalValue(symbol="UISplitViewControllerAutomaticDimension", optional=true)
     public static native @MachineSizedFloat double getAutomaticDimension();
     
-    /**
-     * @since Available in iOS 8.0 and later.
-     */
-    @Method(selector = "displayModeButtonItem")
-    public native UIBarButtonItem getDisplayModeButtonItem();
     /**
      * @since Available in iOS 8.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISpringTimingParameters.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISpringTimingParameters.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UISpringTimingParameters/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements UITimingCurveProvider/*</implements>*/ {
+
+    /*<ptr>*/public static class UISpringTimingParametersPtr extends Ptr<UISpringTimingParameters, UISpringTimingParametersPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UISpringTimingParameters.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UISpringTimingParameters() {}
+    protected UISpringTimingParameters(Handle h, long handle) { super(h, handle); }
+    protected UISpringTimingParameters(SkipInit skipInit) { super(skipInit); }
+    public UISpringTimingParameters(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    public UISpringTimingParameters(@MachineSizedFloat double ratio, @ByVal CGVector velocity) { super((SkipInit) null); initObject(init(ratio, velocity)); }
+    public UISpringTimingParameters(@MachineSizedFloat double mass, @MachineSizedFloat double stiffness, @MachineSizedFloat double damping, @ByVal CGVector velocity) { super((SkipInit) null); initObject(init(mass, stiffness, damping, velocity)); }
+    public UISpringTimingParameters(@MachineSizedFloat double ratio) { super((SkipInit) null); initObject(init(ratio)); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "initialVelocity")
+    public native @ByVal CGVector getInitialVelocity();
+    @Property(selector = "timingCurveType")
+    public native UITimingCurveType getTimingCurveType();
+    @Property(selector = "cubicTimingParameters")
+    public native UICubicTimingParameters getCubicTimingParameters();
+    @Property(selector = "springTimingParameters")
+    public native UISpringTimingParameters getSpringTimingParameters();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "initWithCoder:")
+    protected native @Pointer long init(NSCoder aDecoder);
+    @Method(selector = "initWithDampingRatio:initialVelocity:")
+    protected native @Pointer long init(@MachineSizedFloat double ratio, @ByVal CGVector velocity);
+    @Method(selector = "initWithMass:stiffness:damping:initialVelocity:")
+    protected native @Pointer long init(@MachineSizedFloat double mass, @MachineSizedFloat double stiffness, @MachineSizedFloat double damping, @ByVal CGVector velocity);
+    @Method(selector = "initWithDampingRatio:")
+    protected native @Pointer long init(@MachineSizedFloat double ratio);
+    @Method(selector = "encodeWithCoder:")
+    public native void encode(NSCoder coder);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStackView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStackView.java
@@ -51,7 +51,10 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIStackView() {}
+    protected UIStackView(Handle h, long handle) { super(h, handle); }
     protected UIStackView(SkipInit skipInit) { super(skipInit); }
+    public UIStackView(@ByVal CGRect frame) { super((SkipInit) null); initObject(init(frame)); }
+    public UIStackView(NSCoder coder) { super((SkipInit) null); initObject(init(coder)); }
     public UIStackView(NSArray<UIView> views) { super((SkipInit) null); initObject(init(views)); }
     /*</constructors>*/
     /*<properties>*/
@@ -84,6 +87,10 @@ import org.robovm.apple.corelocation.*;
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
+    @Method(selector = "initWithFrame:")
+    protected native @Pointer long init(@ByVal CGRect frame);
+    @Method(selector = "initWithCoder:")
+    protected native @Pointer long init(NSCoder coder);
     @Method(selector = "initWithArrangedSubviews:")
     protected native @Pointer long init(NSArray<UIView> views);
     @Method(selector = "addArrangedSubview:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStepper.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStepper.java
@@ -51,13 +51,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIStepper() {}
+    protected UIStepper(Handle h, long handle) { super(h, handle); }
     protected UIStepper(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UIStepper(CGRect frame) {
         super(frame);
     }
-    
+    public UIStepper(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "isContinuous")
     public native boolean isContinuous();

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStoryboard.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStoryboard.java
@@ -51,8 +51,9 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIStoryboard() {}
+    protected UIStoryboard(Handle h, long handle) { super(h, handle); }
     protected UIStoryboard(SkipInit skipInit) { super(skipInit); }
-    public UIStoryboard(String name, NSBundle storyboardBundleOrNil) { super(create(name, storyboardBundleOrNil)); retain(getHandle()); }
+    public UIStoryboard(String name, NSBundle storyboardBundleOrNil) { super((Handle) null, create(name, storyboardBundleOrNil)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStoryboardPopoverSegue.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStoryboardPopoverSegue.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIStoryboardPopoverSegue() {}
+    protected UIStoryboardPopoverSegue(Handle h, long handle) { super(h, handle); }
     protected UIStoryboardPopoverSegue(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStoryboardSegue.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStoryboardSegue.java
@@ -51,12 +51,13 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIStoryboardSegue() {}
+    protected UIStoryboardSegue(Handle h, long handle) { super(h, handle); }
     protected UIStoryboardSegue(SkipInit skipInit) { super(skipInit); }
     public UIStoryboardSegue(String identifier, UIViewController source, UIViewController destination) { super((SkipInit) null); initObject(init(identifier, source, destination)); }
     /**
      * @since Available in iOS 6.0 and later.
      */
-    public UIStoryboardSegue(String identifier, UIViewController source, UIViewController destination, @Block Runnable performHandler) { super(create(identifier, source, destination, performHandler)); retain(getHandle()); }
+    public UIStoryboardSegue(String identifier, UIViewController source, UIViewController destination, @Block Runnable performHandler) { super((Handle) null, create(identifier, source, destination, performHandler)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "identifier")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStoryboardSegue.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStoryboardSegue.java
@@ -50,7 +50,7 @@ import org.robovm.apple.corelocation.*;
     /*<bind>*/static { ObjCRuntime.bind(UIStoryboardSegue.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public UIStoryboardSegue() {}
+    protected UIStoryboardSegue() {}
     protected UIStoryboardSegue(Handle h, long handle) { super(h, handle); }
     protected UIStoryboardSegue(SkipInit skipInit) { super(skipInit); }
     public UIStoryboardSegue(String identifier, UIViewController source, UIViewController destination) { super((SkipInit) null); initObject(init(identifier, source, destination)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStoryboardUnwindSegueSource.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStoryboardUnwindSegueSource.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIStoryboardUnwindSegueSource() {}
+    protected UIStoryboardUnwindSegueSource(Handle h, long handle) { super(h, handle); }
     protected UIStoryboardUnwindSegueSource(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStoryboardUnwindSegueSource.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStoryboardUnwindSegueSource.java
@@ -50,7 +50,7 @@ import org.robovm.apple.corelocation.*;
     /*<bind>*/static { ObjCRuntime.bind(UIStoryboardUnwindSegueSource.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public UIStoryboardUnwindSegueSource() {}
+    protected UIStoryboardUnwindSegueSource() {}
     protected UIStoryboardUnwindSegueSource(Handle h, long handle) { super(h, handle); }
     protected UIStoryboardUnwindSegueSource(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISwipeGestureRecognizer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISwipeGestureRecognizer.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UISwipeGestureRecognizer() {}
+    protected UISwipeGestureRecognizer(Handle h, long handle) { super(h, handle); }
     protected UISwipeGestureRecognizer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISwitch.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISwitch.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UISwitch() {}
+    protected UISwitch(Handle h, long handle) { super(h, handle); }
     protected UISwitch(SkipInit skipInit) { super(skipInit); }
     public UISwitch(@ByVal CGRect frame) { super((SkipInit) null); initObject(init(frame)); }
     public UISwitch(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITabBar.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITabBar.java
@@ -51,13 +51,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITabBar() {}
+    protected UITabBar(Handle h, long handle) { super(h, handle); }
     protected UITabBar(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UITabBar(CGRect frame) {
         super(frame);
     }
-    
+    public UITabBar(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "delegate")
     public native UITabBarDelegate getDelegate();
@@ -71,6 +73,8 @@ import org.robovm.apple.corelocation.*;
     public native UITabBarItem getSelectedItem();
     @Property(selector = "setSelectedItem:", strongRef = true)
     public native void setSelectedItem(UITabBarItem v);
+    @Property(selector = "isCustomizing")
+    public native boolean isCustomizing();
     /**
      * @since Available in iOS 5.0 and later.
      */
@@ -91,6 +95,16 @@ import org.robovm.apple.corelocation.*;
      */
     @Property(selector = "setBarTintColor:")
     public native void setBarTintColor(UIColor v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "unselectedItemTintColor")
+    public native UIColor getUnselectedItemTintColor();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setUnselectedItemTintColor:")
+    public native void setUnselectedItemTintColor(UIColor v);
     /**
      * @since Available in iOS 5.0 and later.
      * @deprecated Deprecated in iOS 8.0.
@@ -194,7 +208,5 @@ import org.robovm.apple.corelocation.*;
     public native void beginCustomizing(NSArray<UITabBarItem> items);
     @Method(selector = "endCustomizingAnimated:")
     public native boolean endCustomizing(boolean animated);
-    @Method(selector = "isCustomizing")
-    public native boolean isCustomizing();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITabBarController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITabBarController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITabBarController() {}
+    protected UITabBarController(Handle h, long handle) { super(h, handle); }
     protected UITabBarController(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITabBarItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITabBarItem.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITabBarItem() {}
+    protected UITabBarItem(Handle h, long handle) { super(h, handle); }
     protected UITabBarItem(SkipInit skipInit) { super(skipInit); }
     public UITabBarItem(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     public UITabBarItem(String title, UIImage image, @MachineSizedSInt long tag) { super((SkipInit) null); initObject(init(title, image, tag)); }
@@ -85,6 +86,16 @@ import org.robovm.apple.corelocation.*;
      */
     @Property(selector = "setTitlePositionAdjustment:")
     public native void setTitlePositionAdjustment(@ByVal UIOffset v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "badgeColor")
+    public native UIColor getBadgeColor();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setBadgeColor:")
+    public native void setBadgeColor(UIColor v);
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -120,5 +131,15 @@ import org.robovm.apple.corelocation.*;
     @Deprecated
     @Method(selector = "finishedUnselectedImage")
     public native UIImage getFinishedUnselectedImage();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "setBadgeTextAttributes:forState:")
+    public native void setBadgeTextAttributes(NSDictionary<NSString, ?> textAttributes, UIControlState state);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "badgeTextAttributesForState:")
+    public native NSDictionary<NSString, ?> getBadgeTextAttributes(UIControlState state);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableView.java
@@ -61,15 +61,14 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITableView() {}
+    protected UITableView(Handle h, long handle) { super(h, handle); }
     protected UITableView(SkipInit skipInit) { super(skipInit); }
     public UITableView(@ByVal CGRect frame, UITableViewStyle style) { super((SkipInit) null); initObject(init(frame, style)); }
     public UITableView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
-    
     public UITableView(CGRect frame) {
         super(frame);
     }
-    
     /*<properties>*/
     @Property(selector = "style")
     public native UITableViewStyle getStyle();
@@ -81,6 +80,16 @@ import org.robovm.apple.corelocation.*;
     public native UITableViewDelegate getDelegate();
     @Property(selector = "setDelegate:", strongRef = true)
     public native void setDelegate(UITableViewDelegate v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "prefetchDataSource")
+    public native UITableViewDataSourcePrefetching getPrefetchDataSource();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setPrefetchDataSource:", strongRef = true)
+    public native void setPrefetchDataSource(UITableViewDataSourcePrefetching v);
     @Property(selector = "rowHeight")
     public native @MachineSizedFloat double getRowHeight();
     @Property(selector = "setRowHeight:")
@@ -264,8 +273,37 @@ import org.robovm.apple.corelocation.*;
     public native UIView getTableFooterView();
     @Property(selector = "setTableFooterView:")
     public native void setTableFooterView(UIView v);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "remembersLastFocusedIndexPath")
+    public native boolean remembersLastFocusedIndexPath();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "setRemembersLastFocusedIndexPath:")
+    public native void setRemembersLastFocusedIndexPath(boolean v);
     /*</properties>*/
     /*<members>*//*</members>*/
+    public void insertRow(NSIndexPath indexPath, UITableViewRowAnimation animation) {
+        insertRows(new NSArray<>(indexPath), animation);
+    }
+    public void deleteRow(NSIndexPath indexPath, UITableViewRowAnimation animation) {
+        deleteRows(new NSArray<>(indexPath), animation);
+    }
+    public void reloadRow(NSIndexPath indexPath, UITableViewRowAnimation animation) {
+        reloadRows(new NSArray<>(indexPath), animation);
+    }
+    
+    private UITableViewModel model;
+    public void setModel(UITableViewModel model) {
+        this.model = model;
+        setDelegate(model);
+        setDataSource(model);
+    }
+    public UITableViewModel getModel() {
+        return model;
+    }
     /*<methods>*/
     /**
      * @since Available in iOS 3.0 and later.

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewCell.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewCell.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITableViewCell() {}
+    protected UITableViewCell(Handle h, long handle) { super(h, handle); }
     protected UITableViewCell(SkipInit skipInit) { super(skipInit); }
     /**
      * @since Available in iOS 3.0 and later.
@@ -162,6 +163,16 @@ import org.robovm.apple.corelocation.*;
     public native void setEditing(boolean v);
     @Property(selector = "showingDeleteConfirmation")
     public native boolean isShowingDeleteConfirmation();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "focusStyle")
+    public native UITableViewCellFocusStyle getFocusStyle();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "setFocusStyle:")
+    public native void setFocusStyle(UITableViewCellFocusStyle v);
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -206,5 +217,7 @@ import org.robovm.apple.corelocation.*;
     public native boolean shouldBeRequiredToFail(UIGestureRecognizer gestureRecognizer, UIGestureRecognizer otherGestureRecognizer);
     @Method(selector = "gestureRecognizer:shouldReceiveTouch:")
     public native boolean shouldReceiveTouch(UIGestureRecognizer gestureRecognizer, UITouch touch);
+    @Method(selector = "gestureRecognizer:shouldReceivePress:")
+    public native boolean shouldReceivePress(UIGestureRecognizer gestureRecognizer, UIPress press);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewCellFocusStyle.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewCellFocusStyle.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UITableViewCellFocusStyle/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Default(0L),
+    Custom(1L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UITableViewCellFocusStyle/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UITableViewCellFocusStyle/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UITableViewCellFocusStyle/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UITableViewCellFocusStyle/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITableViewController() {}
+    protected UITableViewController(Handle h, long handle) { super(h, handle); }
     protected UITableViewController(SkipInit skipInit) { super(skipInit); }
     public UITableViewController(UITableViewStyle style) { super((SkipInit) null); initObject(init(style)); }
     public UITableViewController(String nibNameOrNil, NSBundle nibBundleOrNil) { super((SkipInit) null); initObject(init(nibNameOrNil, nibBundleOrNil)); }
@@ -210,6 +211,26 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "tableView:performAction:forRowAtIndexPath:withSender:")
     public native void performActionForRow(UITableView tableView, Selector action, NSIndexPath indexPath, NSObject sender);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "tableView:canFocusRowAtIndexPath:")
+    public native boolean canFocusRow(UITableView tableView, NSIndexPath indexPath);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "tableView:shouldUpdateFocusInContext:")
+    public native boolean shouldUpdateFocus(UITableView tableView, UITableViewFocusUpdateContext context);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "tableView:didUpdateFocusInContext:withAnimationCoordinator:")
+    public native void didUpdateFocus(UITableView tableView, UITableViewFocusUpdateContext context, UIFocusAnimationCoordinator coordinator);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "indexPathForPreferredFocusedViewInTableView:")
+    public native NSIndexPath getIndexPathForPreferredFocusedView(UITableView tableView);
     @Method(selector = "scrollViewDidScroll:")
     public native void didScroll(UIScrollView scrollView);
     /**

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewDataSourcePrefetching.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewDataSourcePrefetching.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/UITableViewDataSourcePrefetching/*</name>*/ 
+    /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<methods>*/
+    @Method(selector = "tableView:prefetchRowsAtIndexPaths:")
+    void prefetchRows(UITableView tableView, NSArray<NSIndexPath> indexPaths);
+    @Method(selector = "tableView:cancelPrefetchingForRowsAtIndexPaths:")
+    void cancelPrefetchingForRows(UITableView tableView, NSArray<NSIndexPath> indexPaths);
+    /*</methods>*/
+    /*<adapter>*/
+    /*</adapter>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewDataSourcePrefetchingAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewDataSourcePrefetchingAdapter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UITableViewDataSourcePrefetchingAdapter/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements UITableViewDataSourcePrefetching/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @NotImplemented("tableView:prefetchRowsAtIndexPaths:")
+    public void prefetchRows(UITableView tableView, NSArray<NSIndexPath> indexPaths) {}
+    @NotImplemented("tableView:cancelPrefetchingForRowsAtIndexPaths:")
+    public void cancelPrefetchingForRows(UITableView tableView, NSArray<NSIndexPath> indexPaths) {}
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewDelegate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewDelegate.java
@@ -172,6 +172,26 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "tableView:performAction:forRowAtIndexPath:withSender:")
     void performActionForRow(UITableView tableView, Selector action, NSIndexPath indexPath, NSObject sender);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "tableView:canFocusRowAtIndexPath:")
+    boolean canFocusRow(UITableView tableView, NSIndexPath indexPath);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "tableView:shouldUpdateFocusInContext:")
+    boolean shouldUpdateFocus(UITableView tableView, UITableViewFocusUpdateContext context);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "tableView:didUpdateFocusInContext:withAnimationCoordinator:")
+    void didUpdateFocus(UITableView tableView, UITableViewFocusUpdateContext context, UIFocusAnimationCoordinator coordinator);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "indexPathForPreferredFocusedViewInTableView:")
+    NSIndexPath getIndexPathForPreferredFocusedView(UITableView tableView);
     /*</methods>*/
     /*<adapter>*/
     /*</adapter>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewDelegateAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewDelegateAdapter.java
@@ -174,5 +174,25 @@ import org.robovm.apple.corelocation.*;
      */
     @NotImplemented("tableView:performAction:forRowAtIndexPath:withSender:")
     public void performActionForRow(UITableView tableView, Selector action, NSIndexPath indexPath, NSObject sender) {}
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("tableView:canFocusRowAtIndexPath:")
+    public boolean canFocusRow(UITableView tableView, NSIndexPath indexPath) { return true; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("tableView:shouldUpdateFocusInContext:")
+    public boolean shouldUpdateFocus(UITableView tableView, UITableViewFocusUpdateContext context) { return true; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("tableView:didUpdateFocusInContext:withAnimationCoordinator:")
+    public void didUpdateFocus(UITableView tableView, UITableViewFocusUpdateContext context, UIFocusAnimationCoordinator coordinator) {}
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("indexPathForPreferredFocusedViewInTableView:")
+    public NSIndexPath getIndexPathForPreferredFocusedView(UITableView tableView) { return null; }
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewFocusUpdateContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewFocusUpdateContext.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UITableViewFocusUpdateContext/*</name>*/ 
+    extends /*<extends>*/UIFocusUpdateContext/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class UITableViewFocusUpdateContextPtr extends Ptr<UITableViewFocusUpdateContext, UITableViewFocusUpdateContextPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UITableViewFocusUpdateContext.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UITableViewFocusUpdateContext() {}
+    protected UITableViewFocusUpdateContext(Handle h, long handle) { super(h, handle); }
+    protected UITableViewFocusUpdateContext(SkipInit skipInit) { super(skipInit); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "previouslyFocusedIndexPath")
+    public native NSIndexPath getPreviouslyFocusedIndexPath();
+    @Property(selector = "nextFocusedIndexPath")
+    public native NSIndexPath getNextFocusedIndexPath();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewHeaderFooterView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewHeaderFooterView.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITableViewHeaderFooterView() {}
+    protected UITableViewHeaderFooterView(Handle h, long handle) { super(h, handle); }
     protected UITableViewHeaderFooterView(SkipInit skipInit) { super(skipInit); }
     public UITableViewHeaderFooterView(String reuseIdentifier) { super((SkipInit) null); initObject(init(reuseIdentifier)); }
     public UITableViewHeaderFooterView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewModel.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewModel.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+import java.util.List;
+
+import org.robovm.apple.foundation.NSArray;
+import org.robovm.apple.foundation.NSIndexPath;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.objc.Selector;
+import org.robovm.objc.annotation.NotImplemented;
+import org.robovm.rt.bro.annotation.MachineSizedFloat;
+import org.robovm.rt.bro.annotation.MachineSizedSInt;
+
+public class UITableViewModel extends UIScrollViewDelegateAdapter implements UITableViewDelegate, UITableViewDataSource {
+    @NotImplemented("tableView:willDisplayCell:forRowAtIndexPath:")
+    public void willDisplayCell(UITableView tableView, UITableViewCell cell, NSIndexPath indexPath) {}
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @NotImplemented("tableView:willDisplayHeaderView:forSection:")
+    public void willDisplayHeaderView(UITableView tableView, UIView view, @MachineSizedSInt long section) {}
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @NotImplemented("tableView:willDisplayFooterView:forSection:")
+    public void willDisplayFooterView(UITableView tableView, UIView view, @MachineSizedSInt long section) {}
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @NotImplemented("tableView:didEndDisplayingCell:forRowAtIndexPath:")
+    public void didEndDisplayingCell(UITableView tableView, UITableViewCell cell, NSIndexPath indexPath) {}
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @NotImplemented("tableView:didEndDisplayingHeaderView:forSection:")
+    public void didEndDisplayingHeaderView(UITableView tableView, UIView view, @MachineSizedSInt long section) {}
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @NotImplemented("tableView:didEndDisplayingFooterView:forSection:")
+    public void didEndDisplayingFooterView(UITableView tableView, UIView view, @MachineSizedSInt long section) {}
+    @NotImplemented("tableView:heightForRowAtIndexPath:")
+    public @MachineSizedFloat double getHeightForRow(UITableView tableView, NSIndexPath indexPath) { return 0; }
+    @NotImplemented("tableView:heightForHeaderInSection:")
+    public @MachineSizedFloat double getHeightForHeader(UITableView tableView, @MachineSizedSInt long section) { return 0; }
+    @NotImplemented("tableView:heightForFooterInSection:")
+    public @MachineSizedFloat double getHeightForFooter(UITableView tableView, @MachineSizedSInt long section) { return 0; }
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @NotImplemented("tableView:estimatedHeightForRowAtIndexPath:")
+    public @MachineSizedFloat double getEstimatedHeightForRow(UITableView tableView, NSIndexPath indexPath) { return 0; }
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @NotImplemented("tableView:estimatedHeightForHeaderInSection:")
+    public @MachineSizedFloat double getEstimatedHeightForHeader(UITableView tableView, @MachineSizedSInt long section) { return 0; }
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @NotImplemented("tableView:estimatedHeightForFooterInSection:")
+    public @MachineSizedFloat double getEstimatedHeightForFooter(UITableView tableView, @MachineSizedSInt long section) { return 0; }
+    @NotImplemented("tableView:viewForHeaderInSection:")
+    public UIView getViewForHeader(UITableView tableView, @MachineSizedSInt long section) { return null; }
+    @NotImplemented("tableView:viewForFooterInSection:")
+    public UIView getViewForFooter(UITableView tableView, @MachineSizedSInt long section) { return null; }
+    @NotImplemented("tableView:accessoryButtonTappedForRowWithIndexPath:")
+    public void accessoryButtonTapped(UITableView tableView, NSIndexPath indexPath) {}
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @NotImplemented("tableView:shouldHighlightRowAtIndexPath:")
+    public boolean shouldHighlightRow(UITableView tableView, NSIndexPath indexPath) { return false; }
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @NotImplemented("tableView:didHighlightRowAtIndexPath:")
+    public void didHighlightRow(UITableView tableView, NSIndexPath indexPath) {}
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @NotImplemented("tableView:didUnhighlightRowAtIndexPath:")
+    public void didUnhighlightRow(UITableView tableView, NSIndexPath indexPath) {}
+    @NotImplemented("tableView:willSelectRowAtIndexPath:")
+    public NSIndexPath willSelectRow(UITableView tableView, NSIndexPath indexPath) { return null; }
+    /**
+     * @since Available in iOS 3.0 and later.
+     */
+    @NotImplemented("tableView:willDeselectRowAtIndexPath:")
+    public NSIndexPath willDeselectRow(UITableView tableView, NSIndexPath indexPath) { return null; }
+    @NotImplemented("tableView:didSelectRowAtIndexPath:")
+    public void didSelectRow(UITableView tableView, NSIndexPath indexPath) {}
+    /**
+     * @since Available in iOS 3.0 and later.
+     */
+    @NotImplemented("tableView:didDeselectRowAtIndexPath:")
+    public void didDeselectRow(UITableView tableView, NSIndexPath indexPath) {}
+    @NotImplemented("tableView:editingStyleForRowAtIndexPath:")
+    public UITableViewCellEditingStyle getEditingStyleForRow(UITableView tableView, NSIndexPath indexPath) { return null; }
+    /**
+     * @since Available in iOS 3.0 and later.
+     */
+    @NotImplemented("tableView:titleForDeleteConfirmationButtonForRowAtIndexPath:")
+    public String getTitleForDeleteConfirmationButton(UITableView tableView, NSIndexPath indexPath) { return null; }
+    /**
+     * @since Available in iOS 8.0 and later.
+     */
+    @NotImplemented("tableView:editActionsForRowAtIndexPath:")
+    public NSArray<UITableViewRowAction> getEditActionsForRow(UITableView tableView, NSIndexPath indexPath) { return null; }
+    @NotImplemented("tableView:shouldIndentWhileEditingRowAtIndexPath:")
+    public boolean shouldIndentWhileEditingRow(UITableView tableView, NSIndexPath indexPath) { return false; }
+    @NotImplemented("tableView:willBeginEditingRowAtIndexPath:")
+    public void willBeginEditingRow(UITableView tableView, NSIndexPath indexPath) {}
+    @NotImplemented("tableView:didEndEditingRowAtIndexPath:")
+    public void didEndEditingRow(UITableView tableView, NSIndexPath indexPath) {}
+    @NotImplemented("tableView:targetIndexPathForMoveFromRowAtIndexPath:toProposedIndexPath:")
+    public NSIndexPath getTargetForMove(UITableView tableView, NSIndexPath sourceIndexPath, NSIndexPath proposedDestinationIndexPath) { return null; }
+    @NotImplemented("tableView:indentationLevelForRowAtIndexPath:")
+    public @MachineSizedSInt long getIndentationLevelForRow(UITableView tableView, NSIndexPath indexPath) { return 0; }
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
+    @NotImplemented("tableView:shouldShowMenuForRowAtIndexPath:")
+    public boolean shouldShowMenuForRow(UITableView tableView, NSIndexPath indexPath) { return false; }
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
+    @NotImplemented("tableView:canPerformAction:forRowAtIndexPath:withSender:")
+    public boolean canPerformAction(UITableView tableView, Selector action, NSIndexPath indexPath, NSObject sender) { return false; }
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
+    @NotImplemented("tableView:performAction:forRowAtIndexPath:withSender:")
+    public void performActionForRow(UITableView tableView, Selector action, NSIndexPath indexPath, NSObject sender) {}
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("tableView:canFocusRowAtIndexPath:")
+    public boolean canFocusRow(UITableView tableView, NSIndexPath indexPath) { return true; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("tableView:shouldUpdateFocusInContext:")
+    public boolean shouldUpdateFocus(UITableView tableView, UITableViewFocusUpdateContext context) { return true; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("tableView:didUpdateFocusInContext:withAnimationCoordinator:")
+    public void didUpdateFocus(UITableView tableView, UITableViewFocusUpdateContext context, UIFocusAnimationCoordinator coordinator) {}
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("indexPathForPreferredFocusedViewInTableView:")
+    public NSIndexPath getIndexPathForPreferredFocusedView(UITableView tableView) { return null; }
+    
+    @NotImplemented("tableView:numberOfRowsInSection:")
+    public @MachineSizedSInt long getNumberOfRowsInSection(UITableView tableView, @MachineSizedSInt long section) { return 0; }
+    @NotImplemented("tableView:cellForRowAtIndexPath:")
+    public UITableViewCell getCellForRow(UITableView tableView, NSIndexPath indexPath) { return null; }
+    @NotImplemented("numberOfSectionsInTableView:")
+    public @MachineSizedSInt long getNumberOfSections(UITableView tableView) { return 0; }
+    @NotImplemented("tableView:titleForHeaderInSection:")
+    public String getTitleForHeader(UITableView tableView, @MachineSizedSInt long section) { return null; }
+    @NotImplemented("tableView:titleForFooterInSection:")
+    public String getTitleForFooter(UITableView tableView, @MachineSizedSInt long section) { return null; }
+    @NotImplemented("tableView:canEditRowAtIndexPath:")
+    public boolean canEditRow(UITableView tableView, NSIndexPath indexPath) { return false; }
+    @NotImplemented("tableView:canMoveRowAtIndexPath:")
+    public boolean canMoveRow(UITableView tableView, NSIndexPath indexPath) { return false; }
+    @NotImplemented("sectionIndexTitlesForTableView:")
+    public @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getSectionIndexTitles(UITableView tableView) { return null; }
+    @NotImplemented("tableView:sectionForSectionIndexTitle:atIndex:")
+    public @MachineSizedSInt long getSectionForSectionIndexTitle(UITableView tableView, String title, @MachineSizedSInt long index) { return 0; }
+    @NotImplemented("tableView:commitEditingStyle:forRowAtIndexPath:")
+    public void commitEditingStyleForRow(UITableView tableView, UITableViewCellEditingStyle editingStyle, NSIndexPath indexPath) {}
+    @NotImplemented("tableView:moveRowAtIndexPath:toIndexPath:")
+    public void moveRow(UITableView tableView, NSIndexPath sourceIndexPath, NSIndexPath destinationIndexPath) {}
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewRowAction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewRowAction.java
@@ -51,8 +51,9 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITableViewRowAction() {}
+    protected UITableViewRowAction(Handle h, long handle) { super(h, handle); }
     protected UITableViewRowAction(SkipInit skipInit) { super(skipInit); }
-    public UITableViewRowAction(UITableViewRowActionStyle style, String title, @Block VoidBlock2<UITableViewRowAction, NSIndexPath> handler) { super(create(style, title, handler)); retain(getHandle()); }
+    public UITableViewRowAction(UITableViewRowActionStyle style, String title, @Block VoidBlock2<UITableViewRowAction, NSIndexPath> handler) { super((Handle) null, create(style, title, handler)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "style")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITapGestureRecognizer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITapGestureRecognizer.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITapGestureRecognizer() {}
+    protected UITapGestureRecognizer(Handle h, long handle) { super(h, handle); }
     protected UITapGestureRecognizer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextChecker.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextChecker.java
@@ -51,10 +51,16 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITextChecker() {}
+    protected UITextChecker(Handle h, long handle) { super(h, handle); }
     protected UITextChecker(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
-    
+    @Property(selector = "ignoredWords")
+    public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getIgnoredWords();
+    @Property(selector = "setIgnoredWords:")
+    public native void setIgnoredWords(@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> v);
+    @Property(selector = "availableLanguages")
+    public static native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getAvailableLanguages();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -66,17 +72,11 @@ import org.robovm.apple.corelocation.*;
     public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getCompletionsForPartialWord(@ByVal NSRange range, String string, String language);
     @Method(selector = "ignoreWord:")
     public native void ignoreWord(String wordToIgnore);
-    @Method(selector = "ignoredWords")
-    public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getIgnoredWords();
-    @Method(selector = "setIgnoredWords:")
-    public native void setIgnoredWords(@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> words);
     @Method(selector = "learnWord:")
     public static native void learnWord(String word);
     @Method(selector = "hasLearnedWord:")
     public static native boolean hasLearnedWord(String word);
     @Method(selector = "unlearnWord:")
     public static native void unlearnWord(String word);
-    @Method(selector = "availableLanguages")
-    public static native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getAvailableLanguages();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextContentType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextContentType.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @StronglyLinked/*</annotations>*/
+@Marshaler(/*<name>*/UITextContentType/*</name>*/.Marshaler.class)
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UITextContentType/*</name>*/ 
+    extends /*<extends>*/GlobalValueEnumeration<NSString>/*</extends>*/
+    /*<implements>*//*</implements>*/ {
+
+    static { Bro.bind(/*<name>*/UITextContentType/*</name>*/.class); }
+
+    /*<marshalers>*/
+    public static class Marshaler {
+        @MarshalsPointer
+        public static UITextContentType toObject(Class<UITextContentType> cls, long handle, long flags) {
+            NSString o = (NSString) NSObject.Marshaler.toObject(NSString.class, handle, flags);
+            if (o == null) {
+                return null;
+            }
+            return UITextContentType.valueOf(o);
+        }
+        @MarshalsPointer
+        public static long toNative(UITextContentType o, long flags) {
+            if (o == null) {
+                return 0L;
+            }
+            return NSObject.Marshaler.toNative(o.value(), flags);
+        }
+    }
+    public static class AsListMarshaler {
+        @SuppressWarnings("unchecked")
+        @MarshalsPointer
+        public static List<UITextContentType> toObject(Class<? extends NSObject> cls, long handle, long flags) {
+            NSArray<NSString> o = (NSArray<NSString>) NSObject.Marshaler.toObject(NSArray.class, handle, flags);
+            if (o == null) {
+                return null;
+            }
+            List<UITextContentType> list = new ArrayList<>();
+            for (int i = 0; i < o.size(); i++) {
+                list.add(UITextContentType.valueOf(o.get(i)));
+            }
+            return list;
+        }
+        @MarshalsPointer
+        public static long toNative(List<UITextContentType> l, long flags) {
+            if (l == null) {
+                return 0L;
+            }
+            NSArray<NSString> array = new NSMutableArray<>();
+            for (UITextContentType o : l) {
+                array.add(o.value());
+            }
+            return NSObject.Marshaler.toNative(array, flags);
+        }
+    }
+    /*</marshalers>*/
+
+    /*<constants>*/
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType Name = new UITextContentType("Name");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType NamePrefix = new UITextContentType("NamePrefix");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType GivenName = new UITextContentType("GivenName");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType MiddleName = new UITextContentType("MiddleName");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType FamilyName = new UITextContentType("FamilyName");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType NameSuffix = new UITextContentType("NameSuffix");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType Nickname = new UITextContentType("Nickname");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType JobTitle = new UITextContentType("JobTitle");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType OrganizationName = new UITextContentType("OrganizationName");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType Location = new UITextContentType("Location");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType FullStreetAddress = new UITextContentType("FullStreetAddress");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType StreetAddressLine1 = new UITextContentType("StreetAddressLine1");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType StreetAddressLine2 = new UITextContentType("StreetAddressLine2");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType AddressCity = new UITextContentType("AddressCity");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType AddressState = new UITextContentType("AddressState");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType AddressCityAndState = new UITextContentType("AddressCityAndState");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType Sublocality = new UITextContentType("Sublocality");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType CountryName = new UITextContentType("CountryName");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType PostalCode = new UITextContentType("PostalCode");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType TelephoneNumber = new UITextContentType("TelephoneNumber");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType EmailAddress = new UITextContentType("EmailAddress");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType URL = new UITextContentType("URL");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final UITextContentType CreditCardNumber = new UITextContentType("CreditCardNumber");
+    /*</constants>*/
+    
+    private static /*<name>*/UITextContentType/*</name>*/[] values = new /*<name>*/UITextContentType/*</name>*/[] {/*<value_list>*/Name, NamePrefix, GivenName, MiddleName, FamilyName, NameSuffix, Nickname, JobTitle, OrganizationName, Location, FullStreetAddress, StreetAddressLine1, StreetAddressLine2, AddressCity, AddressState, AddressCityAndState, Sublocality, CountryName, PostalCode, TelephoneNumber, EmailAddress, URL, CreditCardNumber/*</value_list>*/};
+    
+    /*<name>*/UITextContentType/*</name>*/ (String getterName) {
+        super(Values.class, getterName);
+    }
+    
+    public static /*<name>*/UITextContentType/*</name>*/ valueOf(/*<type>*/NSString/*</type>*/ value) {
+        for (/*<name>*/UITextContentType/*</name>*/ v : values) {
+            if (v.value().equals(value)) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + value + " found in " 
+            + /*<name>*/UITextContentType/*</name>*/.class.getName());
+    }
+    
+    /*<methods>*//*</methods>*/
+    
+    /*<annotations>*/@Library("UIKit") @StronglyLinked/*</annotations>*/
+    public static class Values {
+    	static { Bro.bind(Values.class); }
+
+        /*<values>*/
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeName", optional=true)
+        public static native NSString Name();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeNamePrefix", optional=true)
+        public static native NSString NamePrefix();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeGivenName", optional=true)
+        public static native NSString GivenName();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeMiddleName", optional=true)
+        public static native NSString MiddleName();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeFamilyName", optional=true)
+        public static native NSString FamilyName();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeNameSuffix", optional=true)
+        public static native NSString NameSuffix();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeNickname", optional=true)
+        public static native NSString Nickname();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeJobTitle", optional=true)
+        public static native NSString JobTitle();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeOrganizationName", optional=true)
+        public static native NSString OrganizationName();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeLocation", optional=true)
+        public static native NSString Location();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeFullStreetAddress", optional=true)
+        public static native NSString FullStreetAddress();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeStreetAddressLine1", optional=true)
+        public static native NSString StreetAddressLine1();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeStreetAddressLine2", optional=true)
+        public static native NSString StreetAddressLine2();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeAddressCity", optional=true)
+        public static native NSString AddressCity();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeAddressState", optional=true)
+        public static native NSString AddressState();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeAddressCityAndState", optional=true)
+        public static native NSString AddressCityAndState();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeSublocality", optional=true)
+        public static native NSString Sublocality();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeCountryName", optional=true)
+        public static native NSString CountryName();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypePostalCode", optional=true)
+        public static native NSString PostalCode();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeTelephoneNumber", optional=true)
+        public static native NSString TelephoneNumber();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeEmailAddress", optional=true)
+        public static native NSString EmailAddress();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeURL", optional=true)
+        public static native NSString URL();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="UITextContentTypeCreditCardNumber", optional=true)
+        public static native NSString CreditCardNumber();
+        /*</values>*/
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextDocumentProxy.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextDocumentProxy.java
@@ -53,6 +53,11 @@ import org.robovm.apple.corelocation.*;
     String getDocumentContextBeforeInput();
     @Property(selector = "documentContextAfterInput")
     String getDocumentContextAfterInput();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "documentInputMode")
+    UITextInputMode getDocumentInputMode();
     /*</properties>*/
     /*<methods>*/
     @Method(selector = "adjustTextPositionByCharacterOffset:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextDocumentProxyAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextDocumentProxyAdapter.java
@@ -54,6 +54,11 @@ import org.robovm.apple.corelocation.*;
     public String getDocumentContextBeforeInput() { return null; }
     @NotImplemented("documentContextAfterInput")
     public String getDocumentContextAfterInput() { return null; }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("documentInputMode")
+    public UITextInputMode getDocumentInputMode() { return null; }
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextField.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextField.java
@@ -79,13 +79,15 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITextField() {}
+    protected UITextField(Handle h, long handle) { super(h, handle); }
     protected UITextField(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UITextField(CGRect frame) {
         super(frame);
     }
-    
+    public UITextField(NSCoder decoder) {
+        super(decoder);
+    }
     /**
      * @since Available in iOS 7.0 and later.
      */
@@ -367,6 +369,10 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     public native UITextStorageDirection getSelectionAffinity();
     @Property(selector = "setSelectionAffinity:")
     public native void setSelectionAffinity(UITextStorageDirection v);
+    @Property(selector = "insertDictationResultPlaceholder")
+    public native NSObject getInsertDictationResultPlaceholder();
+    @Property(selector = "hasText")
+    public native boolean hasText();
     @Property(selector = "autocapitalizationType")
     public native UITextAutocapitalizationType getAutocapitalizationType();
     @Property(selector = "setAutocapitalizationType:")
@@ -405,6 +411,16 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     public native boolean isSecureTextEntry();
     @Property(selector = "setSecureTextEntry:")
     public native void setSecureTextEntry(boolean v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "textContentType")
+    public native UITextContentType getTextContentType();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setTextContentType:")
+    public native void setTextContentType(UITextContentType v);
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -414,6 +430,11 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     public static native NSString DidEndEditingNotification();
     @GlobalValue(symbol="UITextFieldTextDidChangeNotification", optional=true)
     public static native NSString DidChangeNotification();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="UITextFieldDidEndEditingReasonKey", optional=true)
+    protected static native NSString DidEndEditingReasonKey();
     
     @Method(selector = "borderRectForBounds:")
     public native @ByVal CGRect getBorderRect(@ByVal CGRect bounds);
@@ -491,8 +512,6 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     public native void dictationRecordingDidEnd();
     @Method(selector = "dictationRecognitionFailed")
     public native void dictationRecognitionFailed();
-    @Method(selector = "insertDictationResultPlaceholder")
-    public native NSObject getInsertDictationResultPlaceholder();
     @Method(selector = "frameForDictationResultPlaceholder:")
     public native @ByVal CGRect getDictationResultPlaceholderFrame(NSObject placeholder);
     @Method(selector = "removeDictationResultPlaceholder:willInsertResult:")
@@ -512,8 +531,6 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
      */
     @Method(selector = "endFloatingCursor")
     public native void endFloatingCursor();
-    @Method(selector = "hasText")
-    public native boolean hasText();
     @Method(selector = "insertText:")
     public native void insertText(String text);
     @Method(selector = "deleteBackward")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextFieldDelegate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextFieldDelegate.java
@@ -60,6 +60,11 @@ import org.robovm.apple.corelocation.*;
     boolean shouldEndEditing(UITextField textField);
     @Method(selector = "textFieldDidEndEditing:")
     void didEndEditing(UITextField textField);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "textFieldDidEndEditing:reason:")
+    void didEndEditing(UITextField textField, UITextFieldDidEndEditingReason reason);
     @Method(selector = "textField:shouldChangeCharactersInRange:replacementString:")
     boolean shouldChangeCharacters(UITextField textField, @ByVal NSRange range, String string);
     @Method(selector = "textFieldShouldClear:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextFieldDelegateAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextFieldDelegateAdapter.java
@@ -62,6 +62,11 @@ import org.robovm.apple.corelocation.*;
     public boolean shouldEndEditing(UITextField textField) { return true; }
     @NotImplemented("textFieldDidEndEditing:")
     public void didEndEditing(UITextField textField) {}
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("textFieldDidEndEditing:reason:")
+    public void didEndEditing(UITextField textField, UITextFieldDidEndEditingReason reason) {}
     @NotImplemented("textField:shouldChangeCharactersInRange:replacementString:")
     public boolean shouldChangeCharacters(UITextField textField, @ByVal NSRange range, String string) { return true; }
     @NotImplemented("textFieldShouldClear:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextFieldDidEndEditingReason.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextFieldDidEndEditingReason.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UITextFieldDidEndEditingReason/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Committed(0L),
+    Cancelled(1L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UITextFieldDidEndEditingReason/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UITextFieldDidEndEditingReason/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UITextFieldDidEndEditingReason/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UITextFieldDidEndEditingReason/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextFieldDidEndEditingReason.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextFieldDidEndEditingReason.java
@@ -44,8 +44,7 @@ import org.robovm.apple.corelocation.*;
 /*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
 public enum /*<name>*/UITextFieldDidEndEditingReason/*</name>*/ implements ValuedEnum {
     /*<values>*/
-    Committed(0L),
-    Cancelled(1L);
+    Committed(0L);
     /*</values>*/
 
     /*<bind>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInput.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInput.java
@@ -74,6 +74,8 @@ import org.robovm.apple.corelocation.*;
     UITextStorageDirection getSelectionAffinity();
     @Property(selector = "setSelectionAffinity:")
     void setSelectionAffinity(UITextStorageDirection v);
+    @Property(selector = "insertDictationResultPlaceholder")
+    NSObject getInsertDictationResultPlaceholder();
     /*</properties>*/
     /*<methods>*/
     @Method(selector = "textInRange:")
@@ -134,8 +136,6 @@ import org.robovm.apple.corelocation.*;
     void dictationRecordingDidEnd();
     @Method(selector = "dictationRecognitionFailed")
     void dictationRecognitionFailed();
-    @Method(selector = "insertDictationResultPlaceholder")
-    NSObject getInsertDictationResultPlaceholder();
     @Method(selector = "frameForDictationResultPlaceholder:")
     @ByVal CGRect getDictationResultPlaceholderFrame(NSObject placeholder);
     @Method(selector = "removeDictationResultPlaceholder:willInsertResult:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputAdapter.java
@@ -76,6 +76,8 @@ import org.robovm.apple.corelocation.*;
     public UITextStorageDirection getSelectionAffinity() { return null; }
     @NotImplemented("setSelectionAffinity:")
     public void setSelectionAffinity(UITextStorageDirection v) {}
+    @NotImplemented("insertDictationResultPlaceholder")
+    public NSObject getInsertDictationResultPlaceholder() { return null; }
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -137,8 +139,6 @@ import org.robovm.apple.corelocation.*;
     public void dictationRecordingDidEnd() {}
     @NotImplemented("dictationRecognitionFailed")
     public void dictationRecognitionFailed() {}
-    @NotImplemented("insertDictationResultPlaceholder")
-    public NSObject getInsertDictationResultPlaceholder() { return null; }
     @NotImplemented("frameForDictationResultPlaceholder:")
     public @ByVal CGRect getDictationResultPlaceholderFrame(NSObject placeholder) { return null; }
     @NotImplemented("removeDictationResultPlaceholder:willInsertResult:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputAssistantItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputAssistantItem.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITextInputAssistantItem() {}
+    protected UITextInputAssistantItem(Handle h, long handle) { super(h, handle); }
     protected UITextInputAssistantItem(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputMode.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputMode.java
@@ -64,11 +64,14 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITextInputMode() {}
+    protected UITextInputMode(Handle h, long handle) { super(h, handle); }
     protected UITextInputMode(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "primaryLanguage")
     public native String getPrimaryLanguage();
+    @Property(selector = "activeInputModes")
+    public static native NSArray<UITextInputMode> getActiveInputModes();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -85,7 +88,5 @@ import org.robovm.apple.corelocation.*;
     @Deprecated
     @Method(selector = "currentInputMode")
     public static native UITextInputMode getCurrentInputMode();
-    @Method(selector = "activeInputModes")
-    public static native NSArray<UITextInputMode> getActiveInputModes();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputStringTokenizer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputStringTokenizer.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITextInputStringTokenizer() {}
+    protected UITextInputStringTokenizer(Handle h, long handle) { super(h, handle); }
     protected UITextInputStringTokenizer(SkipInit skipInit) { super(skipInit); }
     public UITextInputStringTokenizer(UITextInput textInput) { super((SkipInit) null); initObject(init(textInput)); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputTraits.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputTraits.java
@@ -87,6 +87,16 @@ import org.robovm.apple.corelocation.*;
     boolean isSecureTextEntry();
     @Property(selector = "setSecureTextEntry:")
     void setSecureTextEntry(boolean v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "textContentType")
+    UITextContentType getTextContentType();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setTextContentType:")
+    void setTextContentType(UITextContentType v);
     /*</properties>*/
     /*<methods>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputTraitsAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputTraitsAdapter.java
@@ -88,6 +88,16 @@ import org.robovm.apple.corelocation.*;
     public boolean isSecureTextEntry() { return false; }
     @NotImplemented("setSecureTextEntry:")
     public void setSecureTextEntry(boolean v) {}
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("textContentType")
+    public UITextContentType getTextContentType() { return null; }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("setTextContentType:")
+    public void setTextContentType(UITextContentType v) {}
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextItemInteraction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextItemInteraction.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UITextItemInteraction/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    InvokeDefaultAction(0L),
+    PresentActions(1L),
+    Preview(2L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UITextItemInteraction/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UITextItemInteraction/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UITextItemInteraction/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UITextItemInteraction/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextPosition.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextPosition.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITextPosition() {}
+    protected UITextPosition(Handle h, long handle) { super(h, handle); }
     protected UITextPosition(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextRange.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextRange.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITextRange() {}
+    protected UITextRange(Handle h, long handle) { super(h, handle); }
     protected UITextRange(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextSelectionRect.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextSelectionRect.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITextSelectionRect() {}
+    protected UITextSelectionRect(Handle h, long handle) { super(h, handle); }
     protected UITextSelectionRect(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextView.java
@@ -79,6 +79,7 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITextView() {}
+    protected UITextView(Handle h, long handle) { super(h, handle); }
     protected UITextView(SkipInit skipInit) { super(skipInit); }
     /**
      * @since Available in iOS 7.0 and later.
@@ -367,6 +368,10 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     public native UITextStorageDirection getSelectionAffinity();
     @Property(selector = "setSelectionAffinity:")
     public native void setSelectionAffinity(UITextStorageDirection v);
+    @Property(selector = "insertDictationResultPlaceholder")
+    public native NSObject getInsertDictationResultPlaceholder();
+    @Property(selector = "hasText")
+    public native boolean hasText();
     @Property(selector = "autocapitalizationType")
     public native UITextAutocapitalizationType getAutocapitalizationType();
     @Property(selector = "setAutocapitalizationType:")
@@ -405,6 +410,16 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     public native boolean isSecureTextEntry();
     @Property(selector = "setSecureTextEntry:")
     public native void setSecureTextEntry(boolean v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "textContentType")
+    public native UITextContentType getTextContentType();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setTextContentType:")
+    public native void setTextContentType(UITextContentType v);
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -482,8 +497,6 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     public native void dictationRecordingDidEnd();
     @Method(selector = "dictationRecognitionFailed")
     public native void dictationRecognitionFailed();
-    @Method(selector = "insertDictationResultPlaceholder")
-    public native NSObject getInsertDictationResultPlaceholder();
     @Method(selector = "frameForDictationResultPlaceholder:")
     public native @ByVal CGRect getDictationResultPlaceholderFrame(NSObject placeholder);
     @Method(selector = "removeDictationResultPlaceholder:willInsertResult:")
@@ -503,8 +516,6 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
      */
     @Method(selector = "endFloatingCursor")
     public native void endFloatingCursor();
-    @Method(selector = "hasText")
-    public native boolean hasText();
     @Method(selector = "insertText:")
     public native void insertText(String text);
     @Method(selector = "deleteBackward")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextViewDelegate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextViewDelegate.java
@@ -67,13 +67,27 @@ import org.robovm.apple.corelocation.*;
     @Method(selector = "textViewDidChangeSelection:")
     void didChangeSelection(UITextView textView);
     /**
-     * @since Available in iOS 7.0 and later.
+     * @since Available in iOS 10.0 and later.
      */
+    @Method(selector = "textView:shouldInteractWithURL:inRange:interaction:")
+    boolean shouldInteractWithURL(UITextView textView, NSURL URL, @ByVal NSRange characterRange, UITextItemInteraction interaction);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "textView:shouldInteractWithTextAttachment:inRange:interaction:")
+    boolean shouldInteractWithTextAttachment(UITextView textView, NSTextAttachment textAttachment, @ByVal NSRange characterRange, UITextItemInteraction interaction);
+    /**
+     * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
     @Method(selector = "textView:shouldInteractWithURL:inRange:")
     boolean shouldInteractWithURL(UITextView textView, NSURL URL, @ByVal NSRange characterRange);
     /**
      * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @Method(selector = "textView:shouldInteractWithTextAttachment:inRange:")
     boolean shouldInteractWithTextAttachment(UITextView textView, NSTextAttachment textAttachment, @ByVal NSRange characterRange);
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextViewDelegateAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextViewDelegateAdapter.java
@@ -69,13 +69,27 @@ import org.robovm.apple.corelocation.*;
     @NotImplemented("textViewDidChangeSelection:")
     public void didChangeSelection(UITextView textView) {}
     /**
-     * @since Available in iOS 7.0 and later.
+     * @since Available in iOS 10.0 and later.
      */
+    @NotImplemented("textView:shouldInteractWithURL:inRange:interaction:")
+    public boolean shouldInteractWithURL(UITextView textView, NSURL URL, @ByVal NSRange characterRange, UITextItemInteraction interaction) { return false; }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("textView:shouldInteractWithTextAttachment:inRange:interaction:")
+    public boolean shouldInteractWithTextAttachment(UITextView textView, NSTextAttachment textAttachment, @ByVal NSRange characterRange, UITextItemInteraction interaction) { return false; }
+    /**
+     * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
     @NotImplemented("textView:shouldInteractWithURL:inRange:")
     public boolean shouldInteractWithURL(UITextView textView, NSURL URL, @ByVal NSRange characterRange) { return false; }
     /**
      * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @NotImplemented("textView:shouldInteractWithTextAttachment:inRange:")
     public boolean shouldInteractWithTextAttachment(UITextView textView, NSTextAttachment textAttachment, @ByVal NSRange characterRange) { return false; }
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITimingCurveProvider.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITimingCurveProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/UITimingCurveProvider/*</name>*/ 
+    /*<implements>*/extends NSCoding/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<properties>*/
+    @Property(selector = "timingCurveType")
+    UITimingCurveType getTimingCurveType();
+    @Property(selector = "cubicTimingParameters")
+    UICubicTimingParameters getCubicTimingParameters();
+    @Property(selector = "springTimingParameters")
+    UISpringTimingParameters getSpringTimingParameters();
+    /*</properties>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+    /*<adapter>*/
+    /*</adapter>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITimingCurveProviderAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITimingCurveProviderAdapter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UITimingCurveProviderAdapter/*</name>*/ 
+    extends /*<extends>*/NSCodingAdapter/*</extends>*/ 
+    /*<implements>*/implements UITimingCurveProvider/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*/
+    @NotImplemented("timingCurveType")
+    public UITimingCurveType getTimingCurveType() { return null; }
+    @NotImplemented("cubicTimingParameters")
+    public UICubicTimingParameters getCubicTimingParameters() { return null; }
+    @NotImplemented("springTimingParameters")
+    public UISpringTimingParameters getSpringTimingParameters() { return null; }
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITimingCurveType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITimingCurveType.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UITimingCurveType/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Builtin(0L),
+    Cubic(1L),
+    Spring(2L),
+    Composed(3L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UITimingCurveType/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UITimingCurveType/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UITimingCurveType/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UITimingCurveType/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIToolbar.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIToolbar.java
@@ -51,13 +51,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIToolbar() {}
+    protected UIToolbar(Handle h, long handle) { super(h, handle); }
     protected UIToolbar(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UIToolbar(CGRect frame) {
         super(frame);
     }
-    
+    public UIToolbar(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "barStyle")
     public native UIBarStyle getBarStyle();

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITouch.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITouch.java
@@ -53,6 +53,7 @@ import org.robovm.apple.spritekit.SKNode;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITouch() {}
+    protected UITouch(Handle h, long handle) { super(h, handle); }
     protected UITouch(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
@@ -62,6 +63,11 @@ import org.robovm.apple.spritekit.SKNode;
     public native UITouchPhase getPhase();
     @Property(selector = "tapCount")
     public native @MachineSizedUInt long getTapCount();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "type")
+    public native UITouchType getType();
     /**
      * @since Available in iOS 8.0 and later.
      */
@@ -81,6 +87,36 @@ import org.robovm.apple.spritekit.SKNode;
      */
     @Property(selector = "gestureRecognizers")
     public native NSArray<UIGestureRecognizer> getGestureRecognizers();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "force")
+    public native @MachineSizedFloat double getForce();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "maximumPossibleForce")
+    public native @MachineSizedFloat double getMaximumPossibleForce();
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    @Property(selector = "altitudeAngle")
+    public native @MachineSizedFloat double getAltitudeAngle();
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    @Property(selector = "estimationUpdateIndex")
+    public native NSNumber getEstimationUpdateIndex();
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    @Property(selector = "estimatedProperties")
+    public native UITouchProperties getEstimatedProperties();
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    @Property(selector = "estimatedPropertiesExpectingUpdates")
+    public native UITouchProperties getEstimatedPropertiesExpectingUpdates();
     /*</properties>*/
     /*<members>*//*</members>*/
     
@@ -99,5 +135,25 @@ import org.robovm.apple.spritekit.SKNode;
     public native @ByVal CGPoint getLocationInView(UIView view);
     @Method(selector = "previousLocationInView:")
     public native @ByVal CGPoint getPreviousLocationInView(UIView view);
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    @Method(selector = "preciseLocationInView:")
+    public native @ByVal CGPoint getPreciseLocationInView(UIView view);
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    @Method(selector = "precisePreviousLocationInView:")
+    public native @ByVal CGPoint getPrecisePreviousLocationInView(UIView view);
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    @Method(selector = "azimuthAngleInView:")
+    public native @MachineSizedFloat double getAzimuthAngleInView(UIView view);
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    @Method(selector = "azimuthUnitVectorInView:")
+    public native @ByVal CGVector getAzimuthUnitVectorInView(UIView view);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITouchProperties.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITouchProperties.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.1 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(Bits.AsMachineSizedIntMarshaler.class)/*</annotations>*/
+public final class /*<name>*/UITouchProperties/*</name>*/ extends Bits</*<name>*/UITouchProperties/*</name>*/> {
+    /*<values>*/
+    public static final UITouchProperties None = new UITouchProperties(0L);
+    public static final UITouchProperties Force = new UITouchProperties(1L);
+    public static final UITouchProperties Azimuth = new UITouchProperties(2L);
+    public static final UITouchProperties Altitude = new UITouchProperties(4L);
+    public static final UITouchProperties Location = new UITouchProperties(8L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private static final /*<name>*/UITouchProperties/*</name>*/[] values = _values(/*<name>*/UITouchProperties/*</name>*/.class);
+
+    public /*<name>*/UITouchProperties/*</name>*/(long value) { super(value); }
+    private /*<name>*/UITouchProperties/*</name>*/(long value, long mask) { super(value, mask); }
+    protected /*<name>*/UITouchProperties/*</name>*/ wrap(long value, long mask) {
+        return new /*<name>*/UITouchProperties/*</name>*/(value, mask);
+    }
+    protected /*<name>*/UITouchProperties/*</name>*/[] _values() {
+        return values;
+    }
+    public static /*<name>*/UITouchProperties/*</name>*/[] values() {
+        return values.clone();
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITouchType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITouchType.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UITouchType/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Direct(0L),
+    Indirect(1L),
+    /**
+     * @since Available in iOS 9.1 and later.
+     */
+    Stylus(2L);
+    /*</values>*/
+    
+    public static class AsListMarshaler {
+        @SuppressWarnings("unchecked")
+        @MarshalsPointer
+        public static List<UITouchType> toObject(Class<? extends NSObject> cls, long handle, long flags) {
+            NSArray<NSNumber> o = (NSArray<NSNumber>) NSObject.Marshaler.toObject(cls, handle, flags);
+            if (o == null) {
+                return null;
+            }
+            List<UITouchType> list = new ArrayList<>();
+            for (NSNumber n : o) {
+                list.add(UITouchType.valueOf(n.longValue()));
+            }
+            return list;
+        }
+        @MarshalsPointer
+        public static long toNative(List<UITouchType> l, long flags) {
+            if (l == null) {
+                return 0L;
+            }
+            NSArray<NSNumber> array = new NSMutableArray<>();
+            for (UITouchType i : l) {
+                array.add(NSNumber.valueOf(i.value()));
+            }
+            return NSObject.Marshaler.toNative(array, flags);
+        }
+    }
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UITouchType/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UITouchType/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UITouchType/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UITouchType/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITraitCollection.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITraitCollection.java
@@ -51,18 +51,64 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UITraitCollection() {}
+    protected UITraitCollection(Handle h, long handle) { super(h, handle); }
     protected UITraitCollection(SkipInit skipInit) { super(skipInit); }
     public UITraitCollection(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public UITraitCollection(UIUserInterfaceStyle userInterfaceStyle) { super((Handle) null, create(userInterfaceStyle)); retain(getHandle()); }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public UITraitCollection(UITraitEnvironmentLayoutDirection layoutDirection) { super((Handle) null, create(layoutDirection)); retain(getHandle()); }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public UITraitCollection(UIForceTouchCapability capability) { super((Handle) null, create(capability)); retain(getHandle()); }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public UITraitCollection(UIContentSizeCategory preferredContentSizeCategory) { super((Handle) null, create(preferredContentSizeCategory)); retain(getHandle()); }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public UITraitCollection(UIDisplayGamut displayGamut) { super((Handle) null, create(displayGamut)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "userInterfaceIdiom")
     public native UIUserInterfaceIdiom getUserInterfaceIdiom();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "userInterfaceStyle")
+    public native UIUserInterfaceStyle getUserInterfaceStyle();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "layoutDirection")
+    public native UITraitEnvironmentLayoutDirection getLayoutDirection();
     @Property(selector = "displayScale")
     public native @MachineSizedFloat double getDisplayScale();
     @Property(selector = "horizontalSizeClass")
     public native UIUserInterfaceSizeClass getHorizontalSizeClass();
     @Property(selector = "verticalSizeClass")
     public native UIUserInterfaceSizeClass getVerticalSizeClass();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "forceTouchCapability")
+    public native UIForceTouchCapability getForceTouchCapability();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "preferredContentSizeCategory")
+    public native String getPreferredContentSizeCategory();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "displayGamut")
+    public native UIDisplayGamut getDisplayGamut();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -74,11 +120,36 @@ import org.robovm.apple.corelocation.*;
     public static native UITraitCollection createWithTraits(NSArray<UITraitCollection> traitCollections);
     @Method(selector = "traitCollectionWithUserInterfaceIdiom:")
     public static native UITraitCollection createWithUserInterfaceIdiom(UIUserInterfaceIdiom idiom);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "traitCollectionWithUserInterfaceStyle:")
+    protected static native @Pointer long create(UIUserInterfaceStyle userInterfaceStyle);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "traitCollectionWithLayoutDirection:")
+    protected static native @Pointer long create(UITraitEnvironmentLayoutDirection layoutDirection);
     @Method(selector = "traitCollectionWithDisplayScale:")
     public static native UITraitCollection createWithDisplayScale(@MachineSizedFloat double scale);
     @Method(selector = "traitCollectionWithHorizontalSizeClass:")
     public static native UITraitCollection createWithHorizontalSizeClass(UIUserInterfaceSizeClass horizontalSizeClass);
     @Method(selector = "traitCollectionWithVerticalSizeClass:")
     public static native UITraitCollection createWithVerticalSizeClass(UIUserInterfaceSizeClass verticalSizeClass);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "traitCollectionWithForceTouchCapability:")
+    protected static native @Pointer long create(UIForceTouchCapability capability);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "traitCollectionWithPreferredContentSizeCategory:")
+    protected static native @Pointer long create(UIContentSizeCategory preferredContentSizeCategory);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "traitCollectionWithDisplayGamut:")
+    protected static native @Pointer long create(UIDisplayGamut displayGamut);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITraitEnvironmentLayoutDirection.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITraitEnvironmentLayoutDirection.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UITraitEnvironmentLayoutDirection/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Unspecified(-1L),
+    LeftToRight(0L),
+    RightToLeft(1L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UITraitEnvironmentLayoutDirection/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UITraitEnvironmentLayoutDirection/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UITraitEnvironmentLayoutDirection/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UITraitEnvironmentLayoutDirection/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserInterfaceIdiom.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserInterfaceIdiom.java
@@ -50,7 +50,15 @@ public enum /*<name>*/UIUserInterfaceIdiom/*</name>*/ implements ValuedEnum {
     /**
      * @since Available in iOS 3.2 and later.
      */
-    Pad(1L);
+    Pad(1L),
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    TV(2L),
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    CarPlay(3L);
     /*</values>*/
 
     private final long n;

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserInterfaceStyle.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserInterfaceStyle.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UIUserInterfaceStyle/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Unspecified(0L),
+    Light(1L),
+    Dark(2L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UIUserInterfaceStyle/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UIUserInterfaceStyle/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UIUserInterfaceStyle/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UIUserInterfaceStyle/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationAction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationAction.java
@@ -39,7 +39,9 @@ import org.robovm.apple.corelocation.*;
 /*<javadoc>*/
 /**
  * @since Available in iOS 8.0 and later.
+ * @deprecated Deprecated in iOS 10.0.
  */
+@Deprecated
 /*</javadoc>*/
 /*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/UIUserNotificationAction/*</name>*/ 
@@ -51,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIUserNotificationAction() {}
+    protected UIUserNotificationAction(Handle h, long handle) { super(h, handle); }
     protected UIUserNotificationAction(SkipInit skipInit) { super(skipInit); }
     public UIUserNotificationAction(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
@@ -76,6 +79,33 @@ import org.robovm.apple.corelocation.*;
     @Property(selector = "isDestructive")
     public native boolean isDestructive();
     /*</properties>*/
+    public void setIdentifier(String v) {
+        throw new UnsupportedOperationException("UIUserNotificationAction is immutable");
+    }
+
+    public void setTitle(String v) {
+        throw new UnsupportedOperationException("UIUserNotificationAction is immutable");
+    }
+
+    public void setBehavior(UIUserNotificationActionBehavior v) {
+        throw new UnsupportedOperationException("UIUserNotificationAction is immutable");
+    }
+
+    public void setParameters(NSDictionary<?, ?> v) {
+        throw new UnsupportedOperationException("UIUserNotificationAction is immutable");
+    }
+
+    public void setActivationMode(UIUserNotificationActivationMode v) {
+        throw new UnsupportedOperationException("UIUserNotificationAction is immutable");
+    }
+
+    public void setAuthenticationRequired(boolean v) {
+        throw new UnsupportedOperationException("UIUserNotificationAction is immutable");
+    }
+
+    public void setDestructive(boolean v) {
+        throw new UnsupportedOperationException("UIUserNotificationAction is immutable");
+    }
     /*<members>*//*</members>*/
     /*<methods>*/
     @Method(selector = "initWithCoder:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationActionBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationActionBehavior.java
@@ -39,7 +39,9 @@ import org.robovm.apple.corelocation.*;
 /*<javadoc>*/
 /**
  * @since Available in iOS 9.0 and later.
+ * @deprecated Deprecated in iOS 10.0.
  */
+@Deprecated
 /*</javadoc>*/
 /*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedUIntMarshaler.class)/*</annotations>*/
 public enum /*<name>*/UIUserNotificationActionBehavior/*</name>*/ implements ValuedEnum {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationActionContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationActionContext.java
@@ -39,7 +39,9 @@ import org.robovm.apple.corelocation.*;
 /*<javadoc>*/
 /**
  * @since Available in iOS 8.0 and later.
+ * @deprecated Deprecated in iOS 10.0.
  */
+@Deprecated
 /*</javadoc>*/
 /*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedUIntMarshaler.class)/*</annotations>*/
 public enum /*<name>*/UIUserNotificationActionContext/*</name>*/ implements ValuedEnum {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationActivationMode.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationActivationMode.java
@@ -39,7 +39,9 @@ import org.robovm.apple.corelocation.*;
 /*<javadoc>*/
 /**
  * @since Available in iOS 8.0 and later.
+ * @deprecated Deprecated in iOS 10.0.
  */
+@Deprecated
 /*</javadoc>*/
 /*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedUIntMarshaler.class)/*</annotations>*/
 public enum /*<name>*/UIUserNotificationActivationMode/*</name>*/ implements ValuedEnum {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationCategory.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationCategory.java
@@ -39,7 +39,9 @@ import org.robovm.apple.corelocation.*;
 /*<javadoc>*/
 /**
  * @since Available in iOS 8.0 and later.
+ * @deprecated Deprecated in iOS 10.0.
  */
+@Deprecated
 /*</javadoc>*/
 /*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/UIUserNotificationCategory/*</name>*/ 
@@ -51,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIUserNotificationCategory() {}
+    protected UIUserNotificationCategory(Handle h, long handle) { super(h, handle); }
     protected UIUserNotificationCategory(SkipInit skipInit) { super(skipInit); }
     public UIUserNotificationCategory(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
@@ -58,6 +61,13 @@ import org.robovm.apple.corelocation.*;
     @Property(selector = "identifier")
     public native String getIdentifier();
     /*</properties>*/
+    public void setIdentifier(String v) {
+        throw new UnsupportedOperationException("UIUserNotificationCategory is immutable");
+    }
+
+    public void setActions(NSArray<UIUserNotificationAction> actions, UIUserNotificationActionContext context) {
+        throw new UnsupportedOperationException("UIUserNotificationCategory is immutable");
+    }
     /*<members>*//*</members>*/
     /*<methods>*/
     @Method(selector = "initWithCoder:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationSettings.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationSettings.java
@@ -39,7 +39,9 @@ import org.robovm.apple.corelocation.*;
 /*<javadoc>*/
 /**
  * @since Available in iOS 8.0 and later.
+ * @deprecated Deprecated in iOS 10.0.
  */
+@Deprecated
 /*</javadoc>*/
 /*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/UIUserNotificationSettings/*</name>*/ 
@@ -51,8 +53,9 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIUserNotificationSettings() {}
+    protected UIUserNotificationSettings(Handle h, long handle) { super(h, handle); }
     protected UIUserNotificationSettings(SkipInit skipInit) { super(skipInit); }
-    public UIUserNotificationSettings(UIUserNotificationType types, NSSet<UIUserNotificationCategory> categories) { super(create(types, categories)); retain(getHandle()); }
+    public UIUserNotificationSettings(UIUserNotificationType types, NSSet<UIUserNotificationCategory> categories) { super((Handle) null, create(types, categories)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "types")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationType.java
@@ -39,7 +39,9 @@ import org.robovm.apple.corelocation.*;
 /*<javadoc>*/
 /**
  * @since Available in iOS 8.0 and later.
+ * @deprecated Deprecated in iOS 10.0.
  */
+@Deprecated
 /*</javadoc>*/
 /*<annotations>*/@Marshaler(Bits.AsMachineSizedIntMarshaler.class)/*</annotations>*/
 public final class /*<name>*/UIUserNotificationType/*</name>*/ extends Bits</*<name>*/UIUserNotificationType/*</name>*/> {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIVibrancyEffect.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIVibrancyEffect.java
@@ -52,8 +52,9 @@ import org.robovm.rt.annotation.WeaklyLinked;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIVibrancyEffect() {}
+    protected UIVibrancyEffect(Handle h, long handle) { super(h, handle); }
     protected UIVibrancyEffect(SkipInit skipInit) { super(skipInit); }
-    public UIVibrancyEffect(UIBlurEffect blurEffect) { super(create(blurEffect)); retain(getHandle()); }
+    public UIVibrancyEffect(UIBlurEffect blurEffect) { super((Handle) null, create(blurEffect)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIVideoEditorController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIVideoEditorController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIVideoEditorController() {}
+    protected UIVideoEditorController(Handle h, long handle) { super(h, handle); }
     protected UIVideoEditorController(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIView.java
@@ -44,19 +44,23 @@ import org.robovm.apple.corelocation.*;
 /*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/UIView/*</name>*/ 
     extends /*<extends>*/UIResponder/*</extends>*/ 
-    /*<implements>*/implements NSCoding, UIAppearanceContainer, UIDynamicItem, UITraitEnvironment, UICoordinateSpace, UIAccessibilityIdentification/*</implements>*/ {
+    /*<implements>*/implements NSCoding, UIAppearanceContainer, UIDynamicItem, UITraitEnvironment, UICoordinateSpace, UIFocusItem, CALayerDelegate, UIAccessibilityIdentification/*</implements>*/ {
 
     /*<ptr>*/public static class UIViewPtr extends Ptr<UIView, UIViewPtr> {}/*</ptr>*/
     /*<bind>*/static { ObjCRuntime.bind(UIView.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIView() {}
-    protected UIView(long handle) { super(handle); }
+    @Deprecated protected UIView(long handle) { super(handle); }
+    protected UIView(Handle h, long handle) { super(h, handle); }
     protected UIView(SkipInit skipInit) { super(skipInit); }
     public UIView(@ByVal CGRect frame) { super((SkipInit) null); initObject(init(frame)); }
     public UIView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/
+    @WeaklyLinked
+    @Property(selector = "layerClass")
+    public static native Class<? extends CALayer> getLayerClass();
     @Property(selector = "isUserInteractionEnabled")
     public native boolean isUserInteractionEnabled();
     @Property(selector = "setUserInteractionEnabled:")
@@ -71,6 +75,16 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 9.0 and later.
      */
+    @Property(selector = "canBecomeFocused")
+    public native boolean canBecomeFocused();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "isFocused")
+    public native boolean isFocused();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
     @Property(selector = "semanticContentAttribute")
     public native UISemanticContentAttribute getSemanticContentAttribute();
     /**
@@ -78,6 +92,11 @@ import org.robovm.apple.corelocation.*;
      */
     @Property(selector = "setSemanticContentAttribute:")
     public native void setSemanticContentAttribute(UISemanticContentAttribute v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "effectiveUserInterfaceLayoutDirection")
+    public native UIUserInterfaceLayoutDirection getEffectiveUserInterfaceLayoutDirection();
     @Property(selector = "frame")
     public native @ByVal CGRect getFrame();
     @Property(selector = "setFrame:")
@@ -214,6 +233,13 @@ import org.robovm.apple.corelocation.*;
      */
     @Property(selector = "setTintAdjustmentMode:")
     public native void setTintAdjustmentMode(UIViewTintAdjustmentMode v);
+    @Property(selector = "areAnimationsEnabled")
+    public static native boolean areAnimationsEnabled();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "inheritedAnimationDuration")
+    public static native double getInheritedAnimationDuration();
     /**
      * @since Available in iOS 3.2 and later.
      */
@@ -250,6 +276,16 @@ import org.robovm.apple.corelocation.*;
     @Property(selector = "setTranslatesAutoresizingMaskIntoConstraints:")
     public native void setTranslatesAutoresizingMaskIntoConstraints(boolean v);
     /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @Property(selector = "requiresConstraintBasedLayout")
+    public static native boolean requiresConstraintBasedLayout();
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @Property(selector = "alignmentRectInsets")
+    public native @ByVal UIEdgeInsets getAlignmentRectInsets();
+    /**
      * @since Available in iOS 9.0 and later.
      */
     @Property(selector = "viewForFirstBaselineLayout")
@@ -259,6 +295,11 @@ import org.robovm.apple.corelocation.*;
      */
     @Property(selector = "viewForLastBaselineLayout")
     public native UIView getViewForLastBaselineLayout();
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @Property(selector = "intrinsicContentSize")
+    public native @ByVal CGSize getIntrinsicContentSize();
     /**
      * @since Available in iOS 9.0 and later.
      */
@@ -327,6 +368,11 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 6.0 and later.
      */
+    @Property(selector = "hasAmbiguousLayout")
+    public native boolean hasAmbiguousLayout();
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     @Property(selector = "restorationIdentifier")
     public native String getRestorationIdentifier();
     /**
@@ -349,6 +395,15 @@ import org.robovm.apple.corelocation.*;
      */
     @Property(selector = "traitCollection")
     public native UITraitCollection getTraitCollection();
+    @Property(selector = "preferredFocusEnvironments")
+    public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<UIFocusEnvironment> getPreferredFocusEnvironments();
+    /**
+     * @since Available in iOS 9.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    @Property(selector = "preferredFocusedView")
+    public native UIView getPreferredFocusedView();
     /**
      * @since Available in iOS 5.0 and later.
      */
@@ -372,14 +427,16 @@ import org.robovm.apple.corelocation.*;
     protected native @Pointer long init(@ByVal CGRect frame);
     @Method(selector = "initWithCoder:")
     protected native @Pointer long init(NSCoder aDecoder);
-    @WeaklyLinked
-    @Method(selector = "layerClass")
-    public static native Class<? extends CALayer> getLayerClass();
     /**
      * @since Available in iOS 9.0 and later.
      */
     @Method(selector = "userInterfaceLayoutDirectionForSemanticContentAttribute:")
-    public static native UIUserInterfaceLayoutDirection getUserInterfaceLayoutDirectionForSemanticContentAttribute(UISemanticContentAttribute attribute);
+    public static native UIUserInterfaceLayoutDirection getUserInterfaceLayoutDirection(UISemanticContentAttribute attribute);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "userInterfaceLayoutDirectionForSemanticContentAttribute:relativeToLayoutDirection:")
+    public static native UIUserInterfaceLayoutDirection getUserInterfaceLayoutDirection(UISemanticContentAttribute semanticContentAttribute, UIUserInterfaceLayoutDirection layoutDirection);
     @Method(selector = "hitTest:withEvent:")
     public native UIView hitTest(@ByVal CGPoint point, UIEvent event);
     @Method(selector = "pointInside:withEvent:")
@@ -478,18 +535,11 @@ import org.robovm.apple.corelocation.*;
     public static native void setAnimationTransition(UIViewAnimationTransition transition, UIView view, boolean cache);
     @Method(selector = "setAnimationsEnabled:")
     public static native void setAnimationsEnabled(boolean enabled);
-    @Method(selector = "areAnimationsEnabled")
-    public static native boolean areAnimationsEnabled();
     /**
      * @since Available in iOS 7.0 and later.
      */
     @Method(selector = "performWithoutAnimation:")
     public static native void performWithoutAnimation(@Block Runnable actionsWithoutAnimation);
-    /**
-     * @since Available in iOS 9.0 and later.
-     */
-    @Method(selector = "inheritedAnimationDuration")
-    public static native double getInheritedAnimationDuration();
     /**
      * @since Available in iOS 4.0 and later.
      */
@@ -603,11 +653,6 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 6.0 and later.
      */
-    @Method(selector = "requiresConstraintBasedLayout")
-    public static native boolean requiresConstraintBasedLayout();
-    /**
-     * @since Available in iOS 6.0 and later.
-     */
     @Method(selector = "alignmentRectForFrame:")
     public native @ByVal CGRect getAlignmentRectForFrame(@ByVal CGRect frame);
     /**
@@ -617,21 +662,11 @@ import org.robovm.apple.corelocation.*;
     public native @ByVal CGRect getFrameForAlignmentRect(@ByVal CGRect alignmentRect);
     /**
      * @since Available in iOS 6.0 and later.
-     */
-    @Method(selector = "alignmentRectInsets")
-    public native @ByVal UIEdgeInsets getAlignmentRectInsets();
-    /**
-     * @since Available in iOS 6.0 and later.
      * @deprecated Deprecated in iOS 9.0.
      */
     @Deprecated
     @Method(selector = "viewForBaselineLayout")
     public native UIView getViewForBaselineLayout();
-    /**
-     * @since Available in iOS 6.0 and later.
-     */
-    @Method(selector = "intrinsicContentSize")
-    public native @ByVal CGSize getIntrinsicContentSize();
     /**
      * @since Available in iOS 6.0 and later.
      */
@@ -682,11 +717,6 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "constraintsAffectingLayoutForAxis:")
     public native NSArray<NSLayoutConstraint> getConstraintsAffectingLayout(UILayoutConstraintAxis axis);
-    /**
-     * @since Available in iOS 6.0 and later.
-     */
-    @Method(selector = "hasAmbiguousLayout")
-    public native boolean hasAmbiguousLayout();
     /**
      * @since Available in iOS 6.0 and later.
      */
@@ -750,5 +780,26 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "convertRect:fromCoordinateSpace:")
     public native @ByVal CGRect convertRectFromCoordinateSpace(@ByVal CGRect rect, UICoordinateSpace coordinateSpace);
+    @Method(selector = "setNeedsFocusUpdate")
+    public native void setNeedsFocusUpdate();
+    @Method(selector = "updateFocusIfNeeded")
+    public native void updateFocusIfNeeded();
+    @Method(selector = "shouldUpdateFocusInContext:")
+    public native boolean shouldUpdateFocus(UIFocusUpdateContext context);
+    @Method(selector = "didUpdateFocusInContext:withAnimationCoordinator:")
+    public native void didUpdateFocus(UIFocusUpdateContext context, UIFocusAnimationCoordinator coordinator);
+    @Method(selector = "displayLayer:")
+    public native void displayLayer(CALayer layer);
+    @Method(selector = "drawLayer:inContext:")
+    public native void drawLayer(CALayer layer, CGContext ctx);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "layerWillDraw:")
+    public native void willDrawLayer(CALayer layer);
+    @Method(selector = "layoutSublayersOfLayer:")
+    public native void layoutSublayers(CALayer layer);
+    @Method(selector = "actionForLayer:forKey:")
+    public native CAAction getAction(CALayer layer, String event);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewAnimating.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewAnimating.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/UIViewAnimating/*</name>*/ 
+    /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<properties>*/
+    @Property(selector = "state")
+    UIViewAnimatingState getState();
+    @Property(selector = "isRunning")
+    boolean isRunning();
+    @Property(selector = "isReversed")
+    boolean isReversed();
+    @Property(selector = "setReversed:")
+    void setReversed(boolean v);
+    @Property(selector = "fractionComplete")
+    @MachineSizedFloat double getFractionComplete();
+    @Property(selector = "setFractionComplete:")
+    void setFractionComplete(@MachineSizedFloat double v);
+    /*</properties>*/
+    /*<methods>*/
+    @Method(selector = "startAnimation")
+    void startAnimation();
+    @Method(selector = "startAnimationAfterDelay:")
+    void startAnimation(double delay);
+    @Method(selector = "pauseAnimation")
+    void pauseAnimation();
+    @Method(selector = "stopAnimation:")
+    void stopAnimation(boolean withoutFinishing);
+    @Method(selector = "finishAnimationAtPosition:")
+    void finishAnimation(UIViewAnimatingPosition finalPosition);
+    /*</methods>*/
+    /*<adapter>*/
+    /*</adapter>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewAnimatingAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewAnimatingAdapter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIViewAnimatingAdapter/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements UIViewAnimating/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*/
+    @NotImplemented("state")
+    public UIViewAnimatingState getState() { return null; }
+    @NotImplemented("isRunning")
+    public boolean isRunning() { return false; }
+    @NotImplemented("isReversed")
+    public boolean isReversed() { return false; }
+    @NotImplemented("setReversed:")
+    public void setReversed(boolean v) {}
+    @NotImplemented("fractionComplete")
+    public @MachineSizedFloat double getFractionComplete() { return 0; }
+    @NotImplemented("setFractionComplete:")
+    public void setFractionComplete(@MachineSizedFloat double v) {}
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @NotImplemented("startAnimation")
+    public void startAnimation() {}
+    @NotImplemented("startAnimationAfterDelay:")
+    public void startAnimation(double delay) {}
+    @NotImplemented("pauseAnimation")
+    public void pauseAnimation() {}
+    @NotImplemented("stopAnimation:")
+    public void stopAnimation(boolean withoutFinishing) {}
+    @NotImplemented("finishAnimationAtPosition:")
+    public void finishAnimation(UIViewAnimatingPosition finalPosition) {}
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewAnimatingPosition.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewAnimatingPosition.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UIViewAnimatingPosition/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    End(0L),
+    Start(1L),
+    Current(2L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UIViewAnimatingPosition/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UIViewAnimatingPosition/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UIViewAnimatingPosition/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UIViewAnimatingPosition/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewAnimatingState.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewAnimatingState.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/UIViewAnimatingState/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Inactive(0L),
+    Active(1L),
+    Stopped(2L);
+    /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/UIViewAnimatingState/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/UIViewAnimatingState/*</name>*/ valueOf(long n) {
+        for (/*<name>*/UIViewAnimatingState/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/UIViewAnimatingState/*</name>*/.class.getName());
+    }
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewController.java
@@ -46,7 +46,7 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
 /*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/UIViewController/*</name>*/ 
     extends /*<extends>*/UIResponder/*</extends>*/ 
-    /*<implements>*/implements NSCoding, UIAppearanceContainer, UITraitEnvironment, UIStateRestoring, NSExtensionRequestHandling/*</implements>*/ {
+    /*<implements>*/implements NSCoding, UIAppearanceContainer, UITraitEnvironment, UIFocusEnvironment, UIStateRestoring, NSExtensionRequestHandling/*</implements>*/ {
 
     public static class Notifications {
         /**
@@ -67,7 +67,8 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIViewController() {}
-    protected UIViewController(long handle) { super(handle); }
+    @Deprecated protected UIViewController(long handle) { super(handle); }
+    protected UIViewController(Handle h, long handle) { super(h, handle); }
     protected UIViewController(SkipInit skipInit) { super(skipInit); }
     public UIViewController(String nibNameOrNil, NSBundle nibBundleOrNil) { super((SkipInit) null); initObject(init(nibNameOrNil, nibBundleOrNil)); }
     public UIViewController(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
@@ -82,6 +83,11 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
      */
     @Property(selector = "viewIfLoaded")
     public native UIView getViewIfLoaded();
+    /**
+     * @since Available in iOS 3.0 and later.
+     */
+    @Property(selector = "isViewLoaded")
+    public native boolean isViewLoaded();
     @Property(selector = "nibName")
     public native String getNibName();
     @Property(selector = "nibBundle")
@@ -128,6 +134,36 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
     @Property(selector = "setProvidesPresentationContextTransitionStyle:")
     public native void setProvidesPresentationContextTransitionStyle(boolean v);
     /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "restoresFocusAfterTransition")
+    public native boolean isRestoresFocusAfterTransition();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setRestoresFocusAfterTransition:")
+    public native void setRestoresFocusAfterTransition(boolean v);
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
+    @Property(selector = "isBeingPresented")
+    public native boolean isBeingPresented();
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
+    @Property(selector = "isBeingDismissed")
+    public native boolean isBeingDismissed();
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
+    @Property(selector = "isMovingToParentViewController")
+    public native boolean isMovingToParentViewController();
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
+    @Property(selector = "isMovingFromParentViewController")
+    public native boolean isMovingFromParentViewController();
+    /**
      * @since Available in iOS 3.0 and later.
      */
     @Property(selector = "modalTransitionStyle")
@@ -157,6 +193,16 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
      */
     @Property(selector = "setModalPresentationCapturesStatusBarAppearance:")
     public native void setModalPresentationCapturesStatusBarAppearance(boolean v);
+    /**
+     * @since Available in iOS 4.3 and later.
+     */
+    @Property(selector = "disablesAutomaticKeyboardDismissal")
+    public native boolean disablesAutomaticKeyboardDismissal();
+    /**
+     * @since Available in iOS 4.3 and later.
+     */
+    @Property(selector = "setDisablesAutomaticKeyboardDismissal:")
+    public native void setDisablesAutomaticKeyboardDismissal(boolean v);
     /**
      * @since Available in iOS 3.0 and later.
      * @deprecated Deprecated in iOS 7.0.
@@ -212,6 +258,36 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
     @Property(selector = "setPreferredContentSize:")
     public native void setPreferredContentSize(@ByVal CGSize v);
     /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @Property(selector = "preferredStatusBarStyle")
+    public native UIStatusBarStyle getPreferredStatusBarStyle();
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @Property(selector = "prefersStatusBarHidden")
+    public native boolean prefersStatusBarHidden();
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @Property(selector = "preferredStatusBarUpdateAnimation")
+    public native UIStatusBarAnimation getPreferredStatusBarUpdateAnimation();
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @Property(selector = "shouldAutorotate")
+    public native boolean shouldAutorotate();
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @Property(selector = "supportedInterfaceOrientations")
+    public native UIInterfaceOrientationMask getSupportedInterfaceOrientations();
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @Property(selector = "preferredInterfaceOrientationForPresentation")
+    public native UIInterfaceOrientation getPreferredInterfaceOrientationForPresentation();
+    /**
      * @since Available in iOS 2.0 and later.
      * @deprecated Deprecated in iOS 8.0.
      */
@@ -222,6 +298,8 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
     public native boolean isEditing();
     @Property(selector = "setEditing:")
     public native void setEditing(boolean v);
+    @Property(selector = "editButtonItem")
+    public native UIBarButtonItem getEditButtonItem();
     /**
      * @since Available in iOS 3.0 and later.
      * @deprecated Deprecated in iOS 8.0.
@@ -234,6 +312,21 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
      */
     @Property(selector = "childViewControllers")
     public native NSArray<UIViewController> getChildViewControllers();
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @Property(selector = "childViewControllerForStatusBarStyle")
+    public native UIViewController getChildViewControllerForStatusBarStyle();
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @Property(selector = "childViewControllerForStatusBarHidden")
+    public native UIViewController getChildViewControllerForStatusBarHidden();
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @Property(selector = "shouldAutomaticallyForwardAppearanceMethods")
+    public native boolean shouldAutomaticallyForwardAppearanceMethods();
     /**
      * @since Available in iOS 6.0 and later.
      */
@@ -289,6 +382,11 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
      */
     @Property(selector = "popoverPresentationController")
     public native UIPopoverPresentationController getPopoverPresentationController();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "previewActionItems")
+    public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<UIPreviewActionItem> getPreviewActionItems();
     @Property(selector = "navigationItem")
     public native UINavigationItem getNavigationItem();
     @Property(selector = "hidesBottomBarWhenPushed")
@@ -331,6 +429,11 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
     @Deprecated
     @Property(selector = "setContentSizeForViewInPopover:")
     public native void setContentSizeForViewInPopover(@ByVal CGSize v);
+    /**
+     * @since Available in iOS 7.0 and later.
+     */
+    @Property(selector = "transitionCoordinator")
+    public native UIViewControllerTransitionCoordinator getTransitionCoordinator();
     @Property(selector = "splitViewController")
     public native UISplitViewController getSplitViewController();
     @Property(selector = "tabBarItem")
@@ -344,6 +447,15 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
      */
     @Property(selector = "traitCollection")
     public native UITraitCollection getTraitCollection();
+    @Property(selector = "preferredFocusEnvironments")
+    public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<UIFocusEnvironment> getPreferredFocusEnvironments();
+    /**
+     * @since Available in iOS 9.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    @Property(selector = "preferredFocusedView")
+    public native UIView getPreferredFocusedView();
     @Property(selector = "restorationParent")
     public native UIStateRestoring getRestorationParent();
     @Property(selector = "objectRestorationClass")
@@ -454,11 +566,6 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
     @Method(selector = "viewDidLoad")
     public native void viewDidLoad();
     /**
-     * @since Available in iOS 3.0 and later.
-     */
-    @Method(selector = "isViewLoaded")
-    public native boolean isViewLoaded();
-    /**
      * @since Available in iOS 5.0 and later.
      */
     @Method(selector = "performSegueWithIdentifier:sender:")
@@ -530,26 +637,6 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
     /**
      * @since Available in iOS 5.0 and later.
      */
-    @Method(selector = "isBeingPresented")
-    public native boolean isBeingPresented();
-    /**
-     * @since Available in iOS 5.0 and later.
-     */
-    @Method(selector = "isBeingDismissed")
-    public native boolean isBeingDismissed();
-    /**
-     * @since Available in iOS 5.0 and later.
-     */
-    @Method(selector = "isMovingToParentViewController")
-    public native boolean isMovingToParentViewController();
-    /**
-     * @since Available in iOS 5.0 and later.
-     */
-    @Method(selector = "isMovingFromParentViewController")
-    public native boolean isMovingFromParentViewController();
-    /**
-     * @since Available in iOS 5.0 and later.
-     */
     @Method(selector = "presentViewController:animated:completion:")
     public native void presentViewController(UIViewController viewControllerToPresent, boolean animated, @Block Runnable completion);
     /**
@@ -557,26 +644,6 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
      */
     @Method(selector = "dismissViewControllerAnimated:completion:")
     public native void dismissViewController(boolean animated, @Block Runnable completion);
-    /**
-     * @since Available in iOS 4.3 and later.
-     */
-    @Method(selector = "disablesAutomaticKeyboardDismissal")
-    public native boolean disablesAutomaticKeyboardDismissal();
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    @Method(selector = "preferredStatusBarStyle")
-    public native UIStatusBarStyle getPreferredStatusBarStyle();
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    @Method(selector = "prefersStatusBarHidden")
-    public native boolean prefersStatusBarHidden();
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    @Method(selector = "preferredStatusBarUpdateAnimation")
-    public native UIStatusBarAnimation getPreferredStatusBarUpdateAnimation();
     /**
      * @since Available in iOS 7.0 and later.
      */
@@ -597,21 +664,6 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
      */
     @Method(selector = "showDetailViewController:sender:")
     public native void showDetailViewController(UIViewController vc, NSObject sender);
-    /**
-     * @since Available in iOS 6.0 and later.
-     */
-    @Method(selector = "shouldAutorotate")
-    public native boolean shouldAutorotate();
-    /**
-     * @since Available in iOS 6.0 and later.
-     */
-    @Method(selector = "supportedInterfaceOrientations")
-    public native UIInterfaceOrientationMask getSupportedInterfaceOrientations();
-    /**
-     * @since Available in iOS 6.0 and later.
-     */
-    @Method(selector = "preferredInterfaceOrientationForPresentation")
-    public native UIInterfaceOrientation getPreferredInterfaceOrientation();
     /**
      * @since Available in iOS 2.0 and later.
      * @deprecated Deprecated in iOS 8.0.
@@ -654,8 +706,6 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
     public static native void attemptRotationToDeviceOrientation();
     @Method(selector = "setEditing:animated:")
     public native void setEditing(boolean editing, boolean animated);
-    @Method(selector = "editButtonItem")
-    public native UIBarButtonItem getEditButtonItem();
     /**
      * @since Available in iOS 5.0 and later.
      */
@@ -682,16 +732,6 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
     @Method(selector = "endAppearanceTransition")
     public native void endAppearanceTransition();
     /**
-     * @since Available in iOS 7.0 and later.
-     */
-    @Method(selector = "childViewControllerForStatusBarStyle")
-    public native UIViewController getChildViewControllerForStatusBarStyle();
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    @Method(selector = "childViewControllerForStatusBarHidden")
-    public native UIViewController getChildViewControllerForStatusBarHidden();
-    /**
      * @since Available in iOS 8.0 and later.
      */
     @Method(selector = "setOverrideTraitCollection:forChildViewController:")
@@ -708,11 +748,6 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
     @Deprecated
     @Method(selector = "shouldAutomaticallyForwardRotationMethods")
     public native boolean shouldAutomaticallyForwardRotationMethods();
-    /**
-     * @since Available in iOS 6.0 and later.
-     */
-    @Method(selector = "shouldAutomaticallyForwardAppearanceMethods")
-    public native boolean shouldAutomaticallyForwardAppearanceMethods();
     /**
      * @since Available in iOS 5.0 and later.
      */
@@ -754,15 +789,20 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
     @Method(selector = "removeKeyCommand:")
     public native void removeKeyCommand(UIKeyCommand keyCommand);
     /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "registerForPreviewingWithDelegate:sourceView:")
+    public native UIViewControllerPreviewing registerForPreviewing(UIViewControllerPreviewingDelegate delegate, UIView sourceView);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "unregisterForPreviewingWithContext:")
+    public native void unregisterForPreviewing(UIViewControllerPreviewing previewing);
+    /**
      * @since Available in iOS 3.0 and later.
      */
     @Method(selector = "setToolbarItems:animated:")
     public native void setToolbarItems(NSArray<UIBarButtonItem> toolbarItems, boolean animated);
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    @Method(selector = "transitionCoordinator")
-    public native UIViewControllerTransitionCoordinator getTransitionCoordinator();
     /**
      * @since Available in iOS 8.0 and later.
      */
@@ -780,6 +820,14 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
      */
     @Method(selector = "traitCollectionDidChange:")
     public native void traitCollectionDidChange(UITraitCollection previousTraitCollection);
+    @Method(selector = "setNeedsFocusUpdate")
+    public native void setNeedsFocusUpdate();
+    @Method(selector = "updateFocusIfNeeded")
+    public native void updateFocusIfNeeded();
+    @Method(selector = "shouldUpdateFocusInContext:")
+    public native boolean shouldUpdateFocus(UIFocusUpdateContext context);
+    @Method(selector = "didUpdateFocusInContext:withAnimationCoordinator:")
+    public native void didUpdateFocus(UIFocusUpdateContext context, UIFocusAnimationCoordinator coordinator);
     @Method(selector = "beginRequestWithExtensionContext:")
     public native void beginRequest(NSExtensionContext context);
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerAnimatedTransitioning.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerAnimatedTransitioning.java
@@ -56,6 +56,11 @@ import org.robovm.apple.corelocation.*;
     double getTransitionDuration(UIViewControllerContextTransitioning transitionContext);
     @Method(selector = "animateTransition:")
     void animateTransition(UIViewControllerContextTransitioning transitionContext);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "interruptibleAnimatorForTransition:")
+    UIViewImplicitlyAnimating getInterruptibleAnimator(UIViewControllerContextTransitioning transitionContext);
     @Method(selector = "animationEnded:")
     void animationEnded(boolean transitionCompleted);
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerAnimatedTransitioningAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerAnimatedTransitioningAdapter.java
@@ -58,6 +58,11 @@ import org.robovm.apple.corelocation.*;
     public double getTransitionDuration(UIViewControllerContextTransitioning transitionContext) { return 0; }
     @NotImplemented("animateTransition:")
     public void animateTransition(UIViewControllerContextTransitioning transitionContext) {}
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("interruptibleAnimatorForTransition:")
+    public UIViewImplicitlyAnimating getInterruptibleAnimator(UIViewControllerContextTransitioning transitionContext) { return null; }
     @NotImplemented("animationEnded:")
     public void animationEnded(boolean transitionCompleted) {}
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerContextTransitioning.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerContextTransitioning.java
@@ -49,25 +49,34 @@ import org.robovm.apple.corelocation.*;
     /*</bind>*/
     /*<constants>*//*</constants>*/
     /*<properties>*/
-    
+    @Property(selector = "containerView")
+    UIView getContainerView();
+    @Property(selector = "isAnimated")
+    boolean isAnimated();
+    @Property(selector = "isInteractive")
+    boolean isInteractive();
+    @Property(selector = "transitionWasCancelled")
+    boolean isTransitionWasCancelled();
+    @Property(selector = "presentationStyle")
+    UIModalPresentationStyle getPresentationStyle();
+    /**
+     * @since Available in iOS 8.0 and later.
+     */
+    @Property(selector = "targetTransform")
+    @ByVal CGAffineTransform getTargetTransform();
     /*</properties>*/
     /*<methods>*/
-    @Method(selector = "containerView")
-    UIView getContainerView();
-    @Method(selector = "isAnimated")
-    boolean isAnimated();
-    @Method(selector = "isInteractive")
-    boolean isInteractive();
-    @Method(selector = "transitionWasCancelled")
-    boolean transitionWasCancelled();
-    @Method(selector = "presentationStyle")
-    UIModalPresentationStyle getPresentationStyle();
     @Method(selector = "updateInteractiveTransition:")
     void updateInteractiveTransition(@MachineSizedFloat double percentComplete);
     @Method(selector = "finishInteractiveTransition")
     void finishInteractiveTransition();
     @Method(selector = "cancelInteractiveTransition")
     void cancelInteractiveTransition();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "pauseInteractiveTransition")
+    void pauseInteractiveTransition();
     @Method(selector = "completeTransition:")
     void completeTransition(boolean didComplete);
     @Method(selector = "viewControllerForKey:")
@@ -77,11 +86,6 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "viewForKey:")
     UIView getView(UITransitionContextViewType key);
-    /**
-     * @since Available in iOS 8.0 and later.
-     */
-    @Method(selector = "targetTransform")
-    @ByVal CGAffineTransform getTargetTransform();
     @Method(selector = "initialFrameForViewController:")
     @ByVal CGRect getInitialFrame(UIViewController vc);
     @Method(selector = "finalFrameForViewController:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerContextTransitioningAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerContextTransitioningAdapter.java
@@ -50,10 +50,6 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*//*</constructors>*/
     /*<properties>*/
-    
-    /*</properties>*/
-    /*<members>*//*</members>*/
-    /*<methods>*/
     @NotImplemented("containerView")
     public UIView getContainerView() { return null; }
     @NotImplemented("isAnimated")
@@ -61,15 +57,28 @@ import org.robovm.apple.corelocation.*;
     @NotImplemented("isInteractive")
     public boolean isInteractive() { return false; }
     @NotImplemented("transitionWasCancelled")
-    public boolean transitionWasCancelled() { return false; }
+    public boolean isTransitionWasCancelled() { return false; }
     @NotImplemented("presentationStyle")
     public UIModalPresentationStyle getPresentationStyle() { return null; }
+    /**
+     * @since Available in iOS 8.0 and later.
+     */
+    @NotImplemented("targetTransform")
+    public @ByVal CGAffineTransform getTargetTransform() { return null; }
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
     @NotImplemented("updateInteractiveTransition:")
     public void updateInteractiveTransition(@MachineSizedFloat double percentComplete) {}
     @NotImplemented("finishInteractiveTransition")
     public void finishInteractiveTransition() {}
     @NotImplemented("cancelInteractiveTransition")
     public void cancelInteractiveTransition() {}
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("pauseInteractiveTransition")
+    public void pauseInteractiveTransition() {}
     @NotImplemented("completeTransition:")
     public void completeTransition(boolean didComplete) {}
     @NotImplemented("viewControllerForKey:")
@@ -79,11 +88,6 @@ import org.robovm.apple.corelocation.*;
      */
     @NotImplemented("viewForKey:")
     public UIView getView(UITransitionContextViewType key) { return null; }
-    /**
-     * @since Available in iOS 8.0 and later.
-     */
-    @NotImplemented("targetTransform")
-    public @ByVal CGAffineTransform getTargetTransform() { return null; }
     @NotImplemented("initialFrameForViewController:")
     public @ByVal CGRect getInitialFrame(UIViewController vc) { return null; }
     @NotImplemented("finalFrameForViewController:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerInteractiveTransitioning.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerInteractiveTransitioning.java
@@ -49,15 +49,19 @@ import org.robovm.apple.corelocation.*;
     /*</bind>*/
     /*<constants>*//*</constants>*/
     /*<properties>*/
-    
+    @Property(selector = "completionSpeed")
+    @MachineSizedFloat double getCompletionSpeed();
+    @Property(selector = "completionCurve")
+    UIViewAnimationCurve getCompletionCurve();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "wantsInteractiveStart")
+    boolean wantsInteractiveStart();
     /*</properties>*/
     /*<methods>*/
     @Method(selector = "startInteractiveTransition:")
     void startInteractiveTransition(UIViewControllerContextTransitioning transitionContext);
-    @Method(selector = "completionSpeed")
-    @MachineSizedFloat double getCompletionSpeed();
-    @Method(selector = "completionCurve")
-    UIViewAnimationCurve getCompletionCurve();
     /*</methods>*/
     /*<adapter>*/
     /*</adapter>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerInteractiveTransitioningAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerInteractiveTransitioningAdapter.java
@@ -50,15 +50,19 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*//*</constructors>*/
     /*<properties>*/
-    
+    @NotImplemented("completionSpeed")
+    public @MachineSizedFloat double getCompletionSpeed() { return 0; }
+    @NotImplemented("completionCurve")
+    public UIViewAnimationCurve getCompletionCurve() { return null; }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("wantsInteractiveStart")
+    public boolean wantsInteractiveStart() { return false; }
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
     @NotImplemented("startInteractiveTransition:")
     public void startInteractiveTransition(UIViewControllerContextTransitioning transitionContext) {}
-    @NotImplemented("completionSpeed")
-    public @MachineSizedFloat double getCompletionSpeed() { return 0; }
-    @NotImplemented("completionCurve")
-    public UIViewAnimationCurve getCompletionCurve() { return null; }
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerPreviewing.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerPreviewing.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/UIViewControllerPreviewing/*</name>*/ 
+    /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<properties>*/
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "previewingGestureRecognizerForFailureRelationship")
+    UIGestureRecognizer getPreviewingGestureRecognizerForFailureRelationship();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "delegate")
+    UIViewControllerPreviewingDelegate getDelegate();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "sourceView")
+    UIView getSourceView();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "sourceRect")
+    @ByVal CGRect getSourceRect();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "setSourceRect:")
+    void setSourceRect(@ByVal CGRect v);
+    /*</properties>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+    /*<adapter>*/
+    /*</adapter>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerPreviewingAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerPreviewingAdapter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIViewControllerPreviewingAdapter/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements UIViewControllerPreviewing/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*/
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("previewingGestureRecognizerForFailureRelationship")
+    public UIGestureRecognizer getPreviewingGestureRecognizerForFailureRelationship() { return null; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("delegate")
+    public UIViewControllerPreviewingDelegate getDelegate() { return null; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("sourceView")
+    public UIView getSourceView() { return null; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("sourceRect")
+    public @ByVal CGRect getSourceRect() { return null; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("setSourceRect:")
+    public void setSourceRect(@ByVal CGRect v) {}
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerPreviewingDelegate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerPreviewingDelegate.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 9.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/UIViewControllerPreviewingDelegate/*</name>*/ 
+    /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<methods>*/
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "previewingContext:viewControllerForLocation:")
+    UIViewController getViewControllerForLocation(UIViewControllerPreviewing previewingContext, @ByVal CGPoint location);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "previewingContext:commitViewController:")
+    void commitViewController(UIViewControllerPreviewing previewingContext, UIViewController viewControllerToCommit);
+    /*</methods>*/
+    /*<adapter>*/
+    /*</adapter>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerPreviewingDelegateAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerPreviewingDelegateAdapter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIViewControllerPreviewingDelegateAdapter/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements UIViewControllerPreviewingDelegate/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("previewingContext:viewControllerForLocation:")
+    public UIViewController getViewControllerForLocation(UIViewControllerPreviewing previewingContext, @ByVal CGPoint location) { return null; }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @NotImplemented("previewingContext:commitViewController:")
+    public void commitViewController(UIViewControllerPreviewing previewingContext, UIViewController viewControllerToCommit) {}
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerTransitionCoordinator.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerTransitionCoordinator.java
@@ -56,8 +56,18 @@ import org.robovm.apple.corelocation.*;
     boolean animateAlongsideTransition(@Block VoidBlock1<UIViewControllerTransitionCoordinatorContext> animation, @Block VoidBlock1<UIViewControllerTransitionCoordinatorContext> completion);
     @Method(selector = "animateAlongsideTransitionInView:animation:completion:")
     boolean animateAlongsideTransition(UIView view, @Block VoidBlock1<UIViewControllerTransitionCoordinatorContext> animation, @Block VoidBlock1<UIViewControllerTransitionCoordinatorContext> completion);
+    /**
+     * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
     @Method(selector = "notifyWhenInteractionEndsUsingBlock:")
     void notifyWhenInteractionEnds(@Block VoidBlock1<UIViewControllerTransitionCoordinatorContext> handler);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "notifyWhenInteractionChangesUsingBlock:")
+    void notifyWhenInteractionChanges(@Block VoidBlock1<UIViewControllerTransitionCoordinatorContext> handler);
     /*</methods>*/
     /*<adapter>*/
     /*</adapter>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerTransitionCoordinatorAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerTransitionCoordinatorAdapter.java
@@ -58,7 +58,17 @@ import org.robovm.apple.corelocation.*;
     public boolean animateAlongsideTransition(@Block VoidBlock1<UIViewControllerTransitionCoordinatorContext> animation, @Block VoidBlock1<UIViewControllerTransitionCoordinatorContext> completion) { return false; }
     @NotImplemented("animateAlongsideTransitionInView:animation:completion:")
     public boolean animateAlongsideTransition(UIView view, @Block VoidBlock1<UIViewControllerTransitionCoordinatorContext> animation, @Block VoidBlock1<UIViewControllerTransitionCoordinatorContext> completion) { return false; }
+    /**
+     * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
     @NotImplemented("notifyWhenInteractionEndsUsingBlock:")
     public void notifyWhenInteractionEnds(@Block VoidBlock1<UIViewControllerTransitionCoordinatorContext> handler) {}
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("notifyWhenInteractionChangesUsingBlock:")
+    public void notifyWhenInteractionChanges(@Block VoidBlock1<UIViewControllerTransitionCoordinatorContext> handler) {}
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerTransitionCoordinatorContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerTransitionCoordinatorContext.java
@@ -49,27 +49,38 @@ import org.robovm.apple.corelocation.*;
     /*</bind>*/
     /*<constants>*//*</constants>*/
     /*<properties>*/
-    
+    @Property(selector = "isAnimated")
+    boolean isAnimated();
+    @Property(selector = "presentationStyle")
+    UIModalPresentationStyle getPresentationStyle();
+    @Property(selector = "initiallyInteractive")
+    boolean isInitiallyInteractive();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "isInterruptible")
+    boolean isInterruptible();
+    @Property(selector = "isInteractive")
+    boolean isInteractive();
+    @Property(selector = "isCancelled")
+    boolean isCancelled();
+    @Property(selector = "transitionDuration")
+    double getTransitionDuration();
+    @Property(selector = "percentComplete")
+    @MachineSizedFloat double getPercentComplete();
+    @Property(selector = "completionVelocity")
+    @MachineSizedFloat double getCompletionVelocity();
+    @Property(selector = "completionCurve")
+    UIViewAnimationCurve getCompletionCurve();
+    @Property(selector = "containerView")
+    UIView getContainerView();
+    /**
+     * @since Available in iOS 8.0 and later.
+     */
+    @Property(selector = "targetTransform")
+    @ByVal CGAffineTransform getTargetTransform();
     /*</properties>*/
     /*<methods>*/
-    @Method(selector = "isAnimated")
-    boolean isAnimated();
-    @Method(selector = "presentationStyle")
-    UIModalPresentationStyle getPresentationStyle();
-    @Method(selector = "initiallyInteractive")
-    boolean isInitiallyInteractive();
-    @Method(selector = "isInteractive")
-    boolean isInteractive();
-    @Method(selector = "isCancelled")
-    boolean isCancelled();
-    @Method(selector = "transitionDuration")
-    double getTransitionDuration();
-    @Method(selector = "percentComplete")
-    @MachineSizedFloat double getPercentComplete();
-    @Method(selector = "completionVelocity")
-    @MachineSizedFloat double getCompletionVelocity();
-    @Method(selector = "completionCurve")
-    UIViewAnimationCurve getCompletionCurve();
     @Method(selector = "viewControllerForKey:")
     UIViewController getViewController(String key);
     /**
@@ -77,13 +88,6 @@ import org.robovm.apple.corelocation.*;
      */
     @Method(selector = "viewForKey:")
     UIView getView(String key);
-    @Method(selector = "containerView")
-    UIView getContainerView();
-    /**
-     * @since Available in iOS 8.0 and later.
-     */
-    @Method(selector = "targetTransform")
-    @ByVal CGAffineTransform getTargetTransform();
     /*</methods>*/
     /*<adapter>*/
     /*</adapter>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerTransitionCoordinatorContextAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewControllerTransitionCoordinatorContextAdapter.java
@@ -50,16 +50,17 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*//*</constructors>*/
     /*<properties>*/
-    
-    /*</properties>*/
-    /*<members>*//*</members>*/
-    /*<methods>*/
     @NotImplemented("isAnimated")
     public boolean isAnimated() { return false; }
     @NotImplemented("presentationStyle")
     public UIModalPresentationStyle getPresentationStyle() { return null; }
     @NotImplemented("initiallyInteractive")
     public boolean isInitiallyInteractive() { return false; }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("isInterruptible")
+    public boolean isInterruptible() { return false; }
     @NotImplemented("isInteractive")
     public boolean isInteractive() { return false; }
     @NotImplemented("isCancelled")
@@ -72,13 +73,6 @@ import org.robovm.apple.corelocation.*;
     public @MachineSizedFloat double getCompletionVelocity() { return 0; }
     @NotImplemented("completionCurve")
     public UIViewAnimationCurve getCompletionCurve() { return null; }
-    @NotImplemented("viewControllerForKey:")
-    public UIViewController getViewController(String key) { return null; }
-    /**
-     * @since Available in iOS 8.0 and later.
-     */
-    @NotImplemented("viewForKey:")
-    public UIView getView(String key) { return null; }
     @NotImplemented("containerView")
     public UIView getContainerView() { return null; }
     /**
@@ -86,5 +80,15 @@ import org.robovm.apple.corelocation.*;
      */
     @NotImplemented("targetTransform")
     public @ByVal CGAffineTransform getTargetTransform() { return null; }
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @NotImplemented("viewControllerForKey:")
+    public UIViewController getViewController(String key) { return null; }
+    /**
+     * @since Available in iOS 8.0 and later.
+     */
+    @NotImplemented("viewForKey:")
+    public UIView getView(String key) { return null; }
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewImplicitlyAnimating.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewImplicitlyAnimating.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/UIViewImplicitlyAnimating/*</name>*/ 
+    /*<implements>*/extends UIViewAnimating/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<methods>*/
+    @Method(selector = "addAnimations:delayFactor:")
+    void addAnimations(@Block Runnable animation, @MachineSizedFloat double delayFactor);
+    @Method(selector = "addAnimations:")
+    void addAnimations(@Block Runnable animation);
+    @Method(selector = "addCompletion:")
+    void addCompletion(@Block VoidBlock1<UIViewAnimatingPosition> completion);
+    @Method(selector = "continueAnimationWithTimingParameters:durationFactor:")
+    void continueAnimation(UITimingCurveProvider parameters, @MachineSizedFloat double durationFactor);
+    /*</methods>*/
+    /*<adapter>*/
+    /*</adapter>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewImplicitlyAnimatingAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewImplicitlyAnimatingAdapter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIViewImplicitlyAnimatingAdapter/*</name>*/ 
+    extends /*<extends>*/UIViewAnimatingAdapter/*</extends>*/ 
+    /*<implements>*/implements UIViewImplicitlyAnimating/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*/
+    
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @NotImplemented("addAnimations:delayFactor:")
+    public void addAnimations(@Block Runnable animation, @MachineSizedFloat double delayFactor) {}
+    @NotImplemented("addAnimations:")
+    public void addAnimations(@Block Runnable animation) {}
+    @NotImplemented("addCompletion:")
+    public void addCompletion(@Block VoidBlock1<UIViewAnimatingPosition> completion) {}
+    @NotImplemented("continueAnimationWithTimingParameters:durationFactor:")
+    public void continueAnimation(UITimingCurveProvider parameters, @MachineSizedFloat double durationFactor) {}
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewPrintFormatter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewPrintFormatter.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIViewPrintFormatter() {}
+    protected UIViewPrintFormatter(Handle h, long handle) { super(h, handle); }
     protected UIViewPrintFormatter(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewPropertyAnimator.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewPropertyAnimator.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.uikit;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.coreanimation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.coredata.*;
+import org.robovm.apple.coreimage.*;
+import org.robovm.apple.coretext.*;
+import org.robovm.apple.corelocation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("UIKit") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/UIViewPropertyAnimator/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements UIViewImplicitlyAnimating/*</implements>*/ {
+
+    /*<ptr>*/public static class UIViewPropertyAnimatorPtr extends Ptr<UIViewPropertyAnimator, UIViewPropertyAnimatorPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(UIViewPropertyAnimator.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public UIViewPropertyAnimator() {}
+    protected UIViewPropertyAnimator(Handle h, long handle) { super(h, handle); }
+    protected UIViewPropertyAnimator(SkipInit skipInit) { super(skipInit); }
+    public UIViewPropertyAnimator(double duration, UITimingCurveProvider parameters) { super((SkipInit) null); initObject(init(duration, parameters)); }
+    public UIViewPropertyAnimator(double duration, UIViewAnimationCurve curve, @Block Runnable animations) { super((SkipInit) null); initObject(init(duration, curve, animations)); }
+    public UIViewPropertyAnimator(double duration, @ByVal CGPoint point1, @ByVal CGPoint point2, @Block Runnable animations) { super((SkipInit) null); initObject(init(duration, point1, point2, animations)); }
+    public UIViewPropertyAnimator(double duration, @MachineSizedFloat double ratio, @Block Runnable animations) { super((SkipInit) null); initObject(init(duration, ratio, animations)); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "timingParameters")
+    public native UITimingCurveProvider getTimingParameters();
+    @Property(selector = "duration")
+    public native double getDuration();
+    @Property(selector = "delay")
+    public native double getDelay();
+    @Property(selector = "isUserInteractionEnabled")
+    public native boolean isUserInteractionEnabled();
+    @Property(selector = "setUserInteractionEnabled:")
+    public native void setUserInteractionEnabled(boolean v);
+    @Property(selector = "isManualHitTestingEnabled")
+    public native boolean isManualHitTestingEnabled();
+    @Property(selector = "setManualHitTestingEnabled:")
+    public native void setManualHitTestingEnabled(boolean v);
+    @Property(selector = "isInterruptible")
+    public native boolean isInterruptible();
+    @Property(selector = "setInterruptible:")
+    public native void setInterruptible(boolean v);
+    @Property(selector = "state")
+    public native UIViewAnimatingState getState();
+    @Property(selector = "isRunning")
+    public native boolean isRunning();
+    @Property(selector = "isReversed")
+    public native boolean isReversed();
+    @Property(selector = "setReversed:")
+    public native void setReversed(boolean v);
+    @Property(selector = "fractionComplete")
+    public native @MachineSizedFloat double getFractionComplete();
+    @Property(selector = "setFractionComplete:")
+    public native void setFractionComplete(@MachineSizedFloat double v);
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "initWithDuration:timingParameters:")
+    protected native @Pointer long init(double duration, UITimingCurveProvider parameters);
+    @Method(selector = "initWithDuration:curve:animations:")
+    protected native @Pointer long init(double duration, UIViewAnimationCurve curve, @Block Runnable animations);
+    @Method(selector = "initWithDuration:controlPoint1:controlPoint2:animations:")
+    protected native @Pointer long init(double duration, @ByVal CGPoint point1, @ByVal CGPoint point2, @Block Runnable animations);
+    @Method(selector = "initWithDuration:dampingRatio:animations:")
+    protected native @Pointer long init(double duration, @MachineSizedFloat double ratio, @Block Runnable animations);
+    @Method(selector = "addAnimations:delayFactor:")
+    public native void addAnimations(@Block Runnable animation, @MachineSizedFloat double delayFactor);
+    @Method(selector = "addAnimations:")
+    public native void addAnimations(@Block Runnable animation);
+    @Method(selector = "addCompletion:")
+    public native void addCompletion(@Block VoidBlock1<UIViewAnimatingPosition> completion);
+    @Method(selector = "continueAnimationWithTimingParameters:durationFactor:")
+    public native void continueAnimation(UITimingCurveProvider parameters, @MachineSizedFloat double durationFactor);
+    @Method(selector = "runningPropertyAnimatorWithDuration:delay:options:animations:completion:")
+    public static native UIViewPropertyAnimator getRunningPropertyAnimator(double duration, double delay, UIViewAnimationOptions options, @Block Runnable animations, @Block VoidBlock1<UIViewAnimatingPosition> completion);
+    @Method(selector = "startAnimation")
+    public native void startAnimation();
+    @Method(selector = "startAnimationAfterDelay:")
+    public native void startAnimation(double delay);
+    @Method(selector = "pauseAnimation")
+    public native void pauseAnimation();
+    @Method(selector = "stopAnimation:")
+    public native void stopAnimation(boolean withoutFinishing);
+    @Method(selector = "finishAnimationAtPosition:")
+    public native void finishAnimation(UIViewAnimatingPosition finalPosition);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIVisualEffect.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIVisualEffect.java
@@ -51,7 +51,8 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIVisualEffect() {}
-    protected UIVisualEffect(long handle) { super(handle); }
+    @Deprecated protected UIVisualEffect(long handle) { super(handle); }
+    protected UIVisualEffect(Handle h, long handle) { super(h, handle); }
     protected UIVisualEffect(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIVisualEffectView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIVisualEffectView.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIVisualEffectView() {}
+    protected UIVisualEffectView(Handle h, long handle) { super(h, handle); }
     protected UIVisualEffectView(SkipInit skipInit) { super(skipInit); }
     public UIVisualEffectView(UIVisualEffect effect) { super((SkipInit) null); initObject(init(effect)); }
     public UIVisualEffectView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIWebView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIWebView.java
@@ -51,13 +51,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIWebView() {}
+    protected UIWebView(Handle h, long handle) { super(h, handle); }
     protected UIWebView(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UIWebView(CGRect frame) {
         super(frame);
     }
-    
+    public UIWebView(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     @Property(selector = "delegate")
     public native UIWebViewDelegate getDelegate();
@@ -195,6 +197,16 @@ import org.robovm.apple.corelocation.*;
      */
     @Property(selector = "setAllowsPictureInPictureMediaPlayback:")
     public native void setAllowsPictureInPictureMediaPlayback(boolean v);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "allowsLinkPreview")
+    public native boolean allowsLinkPreview();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "setAllowsLinkPreview:")
+    public native void setAllowsLinkPreview(boolean v);
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIWindow.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIWindow.java
@@ -139,13 +139,15 @@ import org.robovm.apple.corelocation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public UIWindow() {}
+    protected UIWindow(Handle h, long handle) { super(h, handle); }
     protected UIWindow(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
-    
     public UIWindow(CGRect frame) {
         super(frame);
     }
-    
+    public UIWindow(NSCoder decoder) {
+        super(decoder);
+    }
     /*<properties>*/
     /**
      * @since Available in iOS 3.2 and later.


### PR DESCRIPTION
This PR updates the UIKit classes with the latest iOS 10 additions. 
The diff is very huge. If you are interested in the changes, take a look at the diff for `uikit.yaml`.

Big part of the diff makes the new handle constructor that has been added to all classes and the methods that have been transformed to properties.
I have also regenerated the Social framework because a UIKit class depended on new methods in Social.

There are 3 instances that I have marked with `TODO` in the yaml file. These are classes/methods that require some new classes from the CloudKit framework that we have not yet updated.