### PR TITLE
Fixes for build and compiler errors

### DIFF
--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/photos/PHAssetResourceRequestOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/photos/PHAssetResourceRequestOptions.java
@@ -57,9 +57,9 @@ import org.robovm.apple.avfoundation.*;
     @Property(selector = "setNetworkAccessAllowed:")
     public native void setNetworkAccessAllowed(boolean v);
     @Property(selector = "progressHandler")
-    public native VoidBlock1<Double> getProgressHandler();
+    public native @Block VoidBlock1<Double> getProgressHandler();
     @Property(selector = "setProgressHandler:")
-    public native void setProgressHandler(VoidBlock1<Double> v);
+    public native void setProgressHandler(@Block VoidBlock1<Double> v);
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/

--- a/plugins/maven/maven-resolver/src/test/java/org/robovm/maven/resolver/RoboVMResolverTest.java
+++ b/plugins/maven/maven-resolver/src/test/java/org/robovm/maven/resolver/RoboVMResolverTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 public class RoboVMResolverTest {
 
     File m2Repo = new File(System.getProperty("user.home"), ".m2/repository");
-    File distAlpha2Dir = new File(m2Repo, "com/mobidevelop/robovm/robovm-dist/2.2.0-SNAPSHOT/unpacked/robovm-2.2.0-SNAPSHOT");
+    File distAlpha2Dir = new File(m2Repo, "com/mobidevelop/robovm/robovm-dist/2.2.1-SNAPSHOT/unpacked/robovm-2.2.1-SNAPSHOT");
 
     @Before
     public void setup() throws Exception {
@@ -41,7 +41,7 @@ public class RoboVMResolverTest {
     @Test
     public void testResolveAndUnpackRoboVMDistArtifact() throws Exception {
         RoboVMResolver resolver = new RoboVMResolver();
-        File dir = resolver.resolveAndUnpackRoboVMDistArtifact("2.2.0-SNAPSHOT");
+        File dir = resolver.resolveAndUnpackRoboVMDistArtifact("2.2.1-SNAPSHOT");
         assertEquals(distAlpha2Dir, dir);
         assertTrue(new File(dir, "bin/ios-sim").canExecute());
 


### PR DESCRIPTION
Build fails when attempting to run tests for robovm-maven-resolver as the
2.2.0-SNAPSHOT cannot be found in Sonatype Nexus Snapshots. Updating to use the 2.2.1-SNAPSHOT one instead.

Also, when compiling the following error was thrown for the PHAssetResourceRequestOptions class:

```
Compiling org.robovm.apple.photos.PHAssetResourceRequestOptions (ios x86 release)
java.lang.IllegalArgumentException: No @Marshaler found for return type of @Bridge method <org.robovm.apple.photos.PHAssetResourceRequestOptions: org.robovm.objc.block.VoidBlock1 $m$progressHandler(org.robovm.apple.photos.PHAssetResourceRequestOptions,org.robovm.objc.Selector)>
```

Adding the `@Block` annotation to the two `VoidBlock1` instances appears to correct it.