### PR TITLE
Include Maven plugin so that it gets released.

### DIFF
--- a/plugins/maven/robovm-maven-plugin/pom.xml
+++ b/plugins/maven/robovm-maven-plugin/pom.xml
@@ -16,7 +16,7 @@
 
   <groupId>com.mobidevelop.robovm</groupId>
   <artifactId>robovm-maven-parent</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.3.1-SNAPSHOT</version>
   <name>RoboVM Maven</name>
   <packaging>pom</packaging>
 
@@ -37,7 +37,7 @@
   <scm>
     <url>https://github.com/mobidevelop/robovm</url>
     <connection>scm:git:git://github.com/mobidevelop/robovm.git</connection>
-    <developerConnection>scm:git:git@github.com:mobidevelop/robovm.git</developerConnection>    
+    <developerConnection>scm:git:git@github.com:mobidevelop/robovm.git</developerConnection>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <scm>
     <url>https://github.com/mobidevelop/robovm</url>
     <connection>scm:git:https://github.com/mobidevelop/robovm.git</connection>
-    <developerConnection>scm:git:https://github.com/mobidevelop/robovm.git</developerConnection>    
+    <developerConnection>scm:git:https://github.com/mobidevelop/robovm.git</developerConnection>
   </scm>
 
   <properties>
@@ -38,6 +38,7 @@
     <module>compiler</module>
     <module>dist</module>
     <module>plugins/templates</module>
+    <module>plugins/maven/robovm-maven-plugin</module>
   </modules>
 
 </project>


### PR DESCRIPTION
So I went to all that trouble to get the Maven plugin in shape for inclusion in the next release, and then failed to actually reference it from the top-level POM, so it didn't go out with 2.3.0.

This includes the Maven plugin in the top-level POM so that the next Maven release will include it.

I also noted that the `plugins/maven/junit` module and `plugins/maven/maven-resolve` module are not actually needed by the Maven plugin and are only for certain kinds of testing that apparently no one is using and no one is likely to need to support, so I'll file another PR getting rid of them. No point in letting that code sit around and rot.
