### PR TITLE
Issue 894 fix + partial ios10 binding

### DIFF
--- a/compiler/cocoatouch/src/main/bro-gen/coreanimation.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/coreanimation.yaml
@@ -426,6 +426,9 @@ values:
     kCA(OnOrderIn|OnOrderOut|Transition):
         class: CAActionIdentifier
         name: '#{g[0]}'
+    kCAContentsFormat(.*):
+        class: CALayerContentsFormat
+        name: '#{g[0]}'
 
     # CAMediaTiming
     kCAFillMode(.*):

--- a/compiler/cocoatouch/src/main/bro-gen/coreaudio.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/coreaudio.yaml
@@ -177,7 +177,11 @@ functions:
         class: CoreAudio
         name: 'Function__#{g[0]}'
 
-values:   
+values:
+    kAudioStreamAnyRate:
+        class: AudioStreamBasicDescription
+        name: 'AnyRate'
+
     # Make sure we don't miss any values if new ones are introduced in a later version
     (Audio.*):
         class: CoreAudio

--- a/compiler/cocoatouch/src/main/bro-gen/corebluetooth.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/corebluetooth.yaml
@@ -19,7 +19,8 @@ enums:
     CBPeripheralManagerAuthorizationStatus: {}
     CBPeripheralManagerState: {}
     CBPeripheralManagerConnectionLatency: {}
-        
+    CBManagerState: {}
+
 classes:
     CBError:
         extends: NSError
@@ -31,6 +32,7 @@ classes:
     CBATTRequest: {} # DONE
     CBAttribute: {} # DONE
     CBCentral: {} # DONE
+    CBManager: {} # DONE
     CBCentralManager: # DONE
         methods:
             '-initWithDelegate:queue:':

--- a/compiler/cocoatouch/src/main/bro-gen/coredata.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/coredata.yaml
@@ -5,7 +5,9 @@ framework: CoreData
 clang_args: ['-x', 'objective-c']
 headers:
     - /System/Library/Frameworks/CoreData.framework/Headers/CoreData.h
-typedefs: {}
+typedefs:
+    'void (^)(NSPersistentStoreDescription * _Nonnull, NSError * _Nullable)': '@Block VoidBlock2<NSPersistentStoreDescription, NSError>'
+
 enums:
     NSAttributeType: {first: NSUndefinedAttributeType, suffix: AttributeType, type: MachineUInt}
     NSCoreDataErrorCode: {first: NSManagedObjectValidationError, suffix: Error}
@@ -246,6 +248,10 @@ classes:
                 name: init
             '+fetchRequestWithEntityName:':
                 exclude: true
+            '-execute:':
+                name: execute
+                throws: NSErrorException
+
     NSFetchRequestExpression: # DONE
         methods:
             '+expressionForFetch:context:countOnly:':
@@ -307,6 +313,8 @@ classes:
     NSManagedObject: # DONE
         methods:
             '-initWithEntity:insertIntoManagedObjectContext:':
+                name: init
+            '-initWithContext:':
                 name: init
             '-hasFaultForRelationshipNamed:':
                 name: hasFaultForRelationship
@@ -417,6 +425,9 @@ classes:
                 parameters:
                     contexts:
                         type: NSArray<NSManagedObjectContext>
+            '-setQueryGenerationFromToken:error:':
+                throws: NSErrorException
+                trim_after_first_colon: true
     NSManagedObjectID: # DONE
         methods:
             '-URIRepresentation':
@@ -608,6 +619,8 @@ classes:
         properties:
             'persistentStores':
                 type: NSArray<NSPersistentStore>
+            'registeredStoreTypes':
+                type: 'NSDictionary<NSString, NSPersistentStore>'
         methods:
             '-initWithManagedObjectModel:':
                 name: init
@@ -623,6 +636,8 @@ classes:
                 parameters:
                     options:
                         type: NSPersistentStoreOptions
+            '-addPersistentStoreWithDescription:completionHandler:':
+                trim_after_first_colon: true
             '-removePersistentStore:error:':
                 trim_after_first_colon: true
                 throws: NSErrorException
@@ -662,9 +677,6 @@ classes:
                 trim_after_first_colon: true
             '-performBlockAndWait:':
                 trim_after_first_colon: true
-            '+registeredStoreTypes':
-                property: true
-                return_type: 'NSDictionary<NSString, NSPersistentStore>'
             '+registerStoreClass:forStoreType:':
                 name: registerStoreClassForType
                 parameters:
@@ -707,6 +719,7 @@ classes:
                 type: List<String>
                 marshaler: NSArray.AsStringListMarshaler
     NSPersistentStoreResult: {} # DONE
+    NSPersistentStoreDescription: {} # DONE
     NSPropertyDescription: # DONE
         properties:
             'validationPredicates':
@@ -724,6 +737,7 @@ classes:
                         type: List<String>
                         marshaler: NSArray.AsStringListMarshaler
     NSPropertyMapping: {} # DONE
+    NSQueryGenerationToken: {} # DONE
     NSRelationshipDescription: {} # DONE
     NSSaveChangesRequest: # DONE
         properties:
@@ -759,6 +773,9 @@ protocols:
         properties:
             'objects':
                 type: NSArray<NSManagedObject>
+    NSFetchRequestResult:
+        protocols: [NSObjectProtocol]
+        skip_adapter: true
 
 functions:
     # Make sure we don't miss any functions if new ones are introduced in a later version
@@ -820,6 +837,10 @@ values:
         class: NSManagedObjectContext
         name: '#{g[0]}'
         type: NSString
+    NSManagedObjectContext(.*Key):
+        class: NSManagedObjectContext
+        name: '#{g[0]}'
+        type: NSString
     NS(.*Objects)Key:
         dictionary: NSManagedObjectContextNotification
         name: '#{g[0]}'
@@ -843,7 +864,7 @@ values:
     # NSMergePolicy
     NS(.*MergePolicy):
         class: NSMergePolicy
-        name: 'get#{g[0]}'
+        name: 'get#{g[0]}Const'
         readonly: true
         type: NSMergePolicy
 

--- a/compiler/cocoatouch/src/main/bro-gen/corefoundation.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/corefoundation.yaml
@@ -1974,6 +1974,9 @@ constants:
     kCFCoreFoundation(Version.*):
         class: CoreFoundationVersionNumber
         name: '#{g[0]}'
+    kCFISO8601DateFormatWith(.*):
+        class: CFISO8601DateFormatOptions
+        name: '#{g[0]}'
 
     kCFStringEncodingInvalidId:
         exclude: true

--- a/compiler/cocoatouch/src/main/bro-gen/coregraphics.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/coregraphics.yaml
@@ -38,6 +38,7 @@ enums:
     CGRectEdge: {prefix: CGRect, suffix: Edge, type: MachineUInt}
     CGTextDrawingMode: {}
     CGTextEncoding: {}
+    CGColorConversionInfoTransformType: {}
 
 classes:
     CoreGraphics:
@@ -118,7 +119,9 @@ functions:
     CGAffineTransform(.*):
         class: CGAffineTransform
         name: '#{g[0]}'
-
+    CGColorConversionInfoCreate(.*):
+        class: CGColorConversionInfo
+        name: 'create#{g[0]}'
     # CGBitmapContext
     CGBitmapContext(CreateImage):
         class: CGBitmapContext
@@ -137,6 +140,8 @@ functions:
         parameters:
             data:
                 type: IntPtr
+            bitmapInfo:
+                type: CGBitmapInfo
             releaseInfo:
                 type: '@Pointer long'
     CGBitmapContext(Create):
@@ -148,6 +153,8 @@ functions:
         parameters:
             data:
                 type: IntPtr
+            bitmapInfo:
+                type: CGBitmapInfo
     CGBitmapContext(GetData):
         class: CGBitmapContext
         name: '#{g[0]}'
@@ -1009,6 +1016,16 @@ values:
         class: CGSize
         name: '#{g[0]}'
 
+    # CGColorSpace
+    kCGColorSpace(.*):
+        class: CGColorSpace
+        name: '#{g[0]}'
+
+    # CGColorConversionInfo
+    kCGColorConversion(.*):
+        class: CGColorConversionInfo
+        name: '#{g[0]}'
+
     # Make sure we don't miss any values if new ones are introduced in a later CoreGraphics
     (k?CG.*):
         class: CoreGraphics
@@ -1027,6 +1044,11 @@ constants:
         name: '#{g[0]}'
     kCG(GlyphMax):
         class: CGFont
+        name: '#{g[0]}'
+
+    # CGImage
+    kCGImage(.*):
+        class: CGImage
         name: '#{g[0]}'
 
     # Make sure we don't miss any constants if new ones are introduced in a later CoreGraphics

--- a/compiler/cocoatouch/src/main/bro-gen/coreimage.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/coreimage.yaml
@@ -1,5 +1,5 @@
 package: org.robovm.apple.coreimage
-include: [foundation.yaml, corefoundation.yaml, coregraphics.yaml, opengles.yaml, corevideo.yaml, imageio.yaml, uikit.yaml]
+include: [foundation.yaml, corefoundation.yaml, coregraphics.yaml, opengles.yaml, corevideo.yaml, imageio.yaml, uikit.yaml, metal.yaml]
 library: CoreImage
 framework: CoreImage
 clang_args: ['-x', 'objective-c']
@@ -10,19 +10,24 @@ enums:
 
 classes:
     CIColor: # DONE
+        properties:
+            'components':
+                visibility: protected
         methods:
             '-initWithCGColor:':
                 exclude: true
+            '-initWithRed:green:blue:alpha:':
+                exclude: true # as conflicts with constructors in ios9+
+            '-initWithRed:green:blue:':
+                exclude: true # as conflicts with constructors in ios9+
             '-init.*':
                 name: init
             '+color.*':
-                name: init
+                name: create # as conflicts with constructors in ios9+
                 visibility: protected
                 return_type: '@Pointer long'
             '-(alpha|blue|colorSpace|green|numberOfComponents|red|stringRepresentation)':
                 property: true
-            '-components':
-                visibility: protected
     CIColorKernel: # DONE
         methods:
             '-applyWithExtent:arguments:':
@@ -30,15 +35,28 @@ classes:
                 parameters:
                     args:
                         type: NSArray<?>
+            '+kernelWithString:':
+                exclude: true # present in parent protocol
+
     CIContext: # DONE
         methods:
-            '+context.*':
+            '-init.*':
                 name: init
+                visibility: protected
+                parameters:
+                    options:
+                        name: options
+                        type: CIContextOptions
+            '+context.*':
+                name: create
                 visibility: protected
                 return_type: '@Pointer long'
                 annotations: ['@WeaklyLinked']
                 parameters:
                     dict:
+                        name: options
+                        type: CIContextOptions
+                    options:
                         name: options
                         type: CIContextOptions
             '-(inputImageMaximumSize|outputImageMaximumSize)':
@@ -56,6 +74,14 @@ classes:
                 name: createCGLayer
                 return_marshaler: CFType.NoRetainMarshaler
                 annotations: ['@WeaklyLinked']
+            '-TIFFRepresentationOfImage:format:colorSpace:options:':
+                name: tiffRepresentationOfImage
+            '-JPEGRepresentationOfImage:colorSpace:options:':
+                name: jpegRepresentationOfImage
+            '-writeTIFFRepresentationOfImage:toURL:format:colorSpace:options:error:':
+                trim_after_first_colon: true
+            '-writeJPEGRepresentationOfImage:toURL:colorSpace:options:error:':
+                trim_after_first_colon: true
     CIDetector: # DONE
         methods:
             '+detectorOfType:context:options:':
@@ -89,11 +115,13 @@ classes:
                 name: deserializeFromXMP
                 return_type: NSArray<CIFilter>
                 throws: NSErrorException
-            '+filterWithName:withInputParameters:':
+            '+filterWith.*':
                 name: create
                 parameters:
                     params:
                         type: CIFilterInputParameters
+                    params:
+                        options: CIFilterInputParameters
             '+filterNames.*':
                 name: getFilterNames
                 return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
@@ -110,6 +138,17 @@ classes:
             '-(inputKeys|outputKeys)':
                 property: true
                 return_type: '@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String>'
+            '+registerFilterName:constructor:classAttributes:':
+                name: register
+            '+localizedNameForFilterName:':
+                trim_after_first_colon: true
+            '+localizedNameForCategory:':
+                trim_after_first_colon: true
+            '+localizedDescriptionForFilterName:':
+                trim_after_first_colon: true
+            '+localizedReferenceDocumentationForFilterName:':
+                trim_after_first_colon: true
+
     CIImage: # DONE
         methods:
             '-initWithCVPixelBuffer:.*':
@@ -121,6 +160,8 @@ classes:
                     d:
                         type: CIImageOptions
                     dict:
+                        type: CIImageOptions
+                    options:
                         type: CIImageOptions
             '+imageWith.*':
                 exclude: true
@@ -199,8 +240,14 @@ classes:
                         type: '@Block("@ByVal (,@ByVal)") Block2<Integer, CGRect, CGRect>'
                     args:
                         type: NSArray<?>
+            '+kernelWithString:':
+                exclude: true # present in parent protocol
 
 protocols:
+    CIFilterConstructor:
+        protocols: [NSObjectProtocol]
+        skip_adapter: true
+
 
 functions:
     # Make sure we don't miss any functions if new ones are introduced in a later version
@@ -275,6 +322,18 @@ values:
         dictionary: CIFilterInputParameters
         name: '#{g[0]}'
         type: NSString
+    kCISupportedDecoderVersionsKey:
+        dictionary: CIFilterInputParameters
+        name: 'SupportedDecoderVersions'
+    kCIInputLinearSpaceFilter:
+        dictionary: CIFilterInputParameters
+        name: 'LinearSpaceFilter'
+    kCIOutputNativeSizeKey:
+        dictionary: CIFilterInputParameters
+        name: 'NativeSize'
+    kCIActiveKeys:
+        dictionary: CIFilterInputParameters
+        name: 'ActiveKeys'
     kCI(OutputImage)Key:
         dictionary: CIFilterInputParameters
         name: '#{g[0]}'
@@ -372,6 +431,24 @@ values:
                 annotations: ['@WeaklyLinked']
                 type: CGImageProperties
                 hint: GlobalValueDictionaryWrapper<NSString>
+
+    # CIUIParameterSet
+    kCIUIParameterSet:
+        name: 'Set'
+        class: CIUIParameterSet
+    kCIUISet(.*):
+        name: '#{g[0]}'
+        class: CIUIParameterSet
+
+    #CIFeatureType
+    CIFeatureType(.*):
+        name: '#{g[0]}'
+        class: CIFeatureType
+
+    #CISamplerType
+    kCISampler(.*):
+        name: '#{g[0]}'
+        class: CISamplerType
 
     # Make sure we don't miss any values if new ones are introduced in a later version
     (k?CI.*):

--- a/compiler/cocoatouch/src/main/bro-gen/coremedia.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/coremedia.yaml
@@ -1318,8 +1318,34 @@ values:
         dictionary: CMVideoFormatDescriptionExtension
         name: '#{g[0]}'
         type: CFString
-    kCMFormatDescriptionColorPrimaries_P22:
-        exclude: true
+    kCMFormatDescriptionChromaLocation_(.*):
+        class: CMVideoFormatDescription
+        name: 'ChromaLocation#{g[0]}'
+        type: CFString
+    kCMSampleBufferLensStabilizationInfo_(.*):
+        class: CMVideoFormatDescription
+        name: 'LensStabilizationInfo#{g[0]}'
+        type: CFString
+    kCMFormatDescription(YCbCrMatrix_.*):
+        class: CMVideoFormatDescription
+        name: '#{g[0]}'
+        type: CFString
+    kCMFormatDescription(TransferFunction_.*):
+        class: CMVideoFormatDescription
+        name: '#{g[0]}'
+        type: CFString
+    kCMFormatDescription(ColorPrimaries_.*):
+        class: CMVideoFormatDescription
+        name: '#{g[0]}'
+        type: CFString
+    kCMSampleBufferLensStabilizationInfo_(.*):
+        class: CMVideoFormatDescription
+        name: 'LensStabilizationInfo#{g[0]}'
+        type: CFString
+    kCMFormatDescriptionFieldDetail_(.*):
+        class: CMVideoFormatDescription
+        name: 'FieldDetail#{g[0]}'
+        type: CFString
 
     # Make sure we don't miss any values if new ones are introduced in a later version
     (k?CM.*):

--- a/compiler/cocoatouch/src/main/bro-gen/coremidi.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/coremidi.yaml
@@ -16,6 +16,8 @@ typedefs:
     MIDISetupRef: MIDISetup
     MIDIThruConnectionRef: MIDIThruConnection
     MIDIDriverRef: MIDIDriver
+    MIDIReadBlock: '@Block VoidBlock2<MIDIPacketList, Long>'
+    MIDINotifyBlock: '@Block VoidBlock1<MIDINotification>'
 private_typedefs:
     '__CFString *': String
     '__CFString **': NSString.NSStringPtr
@@ -185,6 +187,11 @@ functions:
         parameters:
             notifyRefCon:
                 type: "@Pointer long"
+    MIDIClientCreateWithBlock:
+        class: MIDIClient
+        name: "create"
+        visibility: protected
+        return_type: MIDIError
     MIDIClient(.*):
         class: MIDIClient
         name: "#{g[0]}"
@@ -213,6 +220,11 @@ functions:
         parameters:
             refCon:
                 type: "@Pointer long"
+    MIDIInputPortCreateWithBlock:
+        class: MIDIPort
+        name: "createInputPort"
+        visibility: protected
+        return_type: MIDIError
     MIDIOutputPortCreate:
         class: MIDIPort
         name: "createOutputPort"
@@ -301,6 +313,11 @@ functions:
         parameters:
             refCon:
                 type: "@Pointer long"
+    MIDIDestinationCreateWithBlock:
+        class: MIDIPort
+        name: "createDestination"
+        visibility: protected
+        return_type: MIDIError
     MIDISourceCreate:
         class: MIDIEndpoint
         name: "createSource"

--- a/compiler/cocoatouch/src/main/bro-gen/coremotion.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/coremotion.yaml
@@ -13,6 +13,7 @@ enums:
     CMMagneticFieldCalibrationAccuracy: { first: CMMagneticFieldCalibrationAccuracyUncalibrated }
     CMErrorCode: { first: CMErrorNULL }
     CMMotionActivityConfidence: {}
+    CMPedometerEventType: {}
         
 classes:
     CMError:
@@ -93,15 +94,21 @@ classes:
                 parameters:
                     handler:
                         type: '@Block VoidBlock2<CMPedometerData, NSError>'
+            '-startPedometerEventUpdatesWithHandler:':
+                name: startPedometerEventUpdates
+                parameters:
+                    handler:
+                        type: '@Block VoidBlock2<CMPedometerEvent, NSError>'
     CMPedometerData: {} # DONE
+    CMPedometerEvent: {}
     CMSensorDataList: {}      ### TODO make enumeratable
     CMSensorRecorder: # DONE
         methods:
             '-accelerometerDataSince:':
                 name: getAccelerometerDataSince
-            '-accelerometerDataFrom:to:':
+            '-accelerometerDataFromDate:toDate:':
                 name: getAccelerometerDataBetween
-            '-recordAccelerometerFor:':
+            '-recordAccelerometerForDuration:':
                 trim_after_first_colon: true
     CMStepCounter: # DONE
         methods:

--- a/compiler/cocoatouch/src/main/bro-gen/coretext.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/coretext.yaml
@@ -15,7 +15,7 @@ private_typedefs:
     '__CFURL *': NSURL
     '__CFDictionary *': NSDictionary
     '__CFCharacterSet *': NSCharacterSet
-    
+
 enums:
     CTFontOptions: { bits: true, marshaler: Bits.AsMachineSizedIntMarshaler }
     CTFontUIFontType: { marshaler: ValuedEnum.AsMachineSizedUIntMarshaler }
@@ -485,6 +485,13 @@ functions:
         class: CTLine
         name: '#{g[0]}'
         return_marshaler: CFType.NoRetainMarshaler
+    CTLineEnumerateCaretOffsets:
+        class: CTLine
+        parameters:
+        name: 'enumerateCaretOffsets'
+        parameters:
+            block:
+                type: '@Block VoidBlock4<Double, Long, Boolean, BooleanPtr>'
     CTLine(.*):
         class: CTLine
         name: '#{g[0]}'

--- a/compiler/cocoatouch/src/main/bro-gen/corevideo.yaml
+++ b/compiler/cocoatouch/src/main/bro-gen/corevideo.yaml
@@ -28,6 +28,7 @@ enums:
     CVAttachmentMode: { first: kCVAttachmentMode_ShouldNotPropagate, marshaler: ValuedEnum.AsMachineSizedUIntMarshaler }
     CVPixelFormatType: { first: kCVPixelFormatType_1Monochrome, marshaler: ValuedEnum.AsMachineSizedUIntMarshaler }
     CVPixelBufferLockFlags: { first: kCVPixelBufferLock_ReadOnly, prefix: kCVPixelBufferLock_, bits: true, marshaler: Bits.AsMachineSizedIntMarshaler }
+    CVPixelBufferPoolFlushFlags: { first: kCVPixelBufferPoolFlushExcessBuffers, bits: false, prefix: kCVPixelBufferPoolFlush}
     CVReturn: { first: kCVReturnSuccess }
 
 classes:

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAAnimation.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAAnimation.java
@@ -37,7 +37,9 @@ import org.robovm.apple.metal.*;
 import org.robovm.rt.annotation.WeaklyLinked;
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 2.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CAAnimation/*</name>*/ 
@@ -49,9 +51,11 @@ import org.robovm.rt.annotation.WeaklyLinked;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CAAnimation() {}
-    protected CAAnimation(long handle) { super(handle); }
+    @Deprecated protected CAAnimation(long handle) { super(handle); }
+    protected CAAnimation(Handle h, long handle) { super(h, handle); }
     protected CAAnimation(SkipInit skipInit) { super(skipInit); }
-    public CAAnimation(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    @Method(selector = "initWithCoder:")
+    public CAAnimation(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     
     /* SceneKit extensions */
@@ -148,7 +152,7 @@ import org.robovm.rt.annotation.WeaklyLinked;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     @Method(selector = "runActionForKey:object:arguments:")
     public native void runAction(String event, NSObject anObject, NSDictionary<NSString, ?> dict);
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAAnimationGroup.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAAnimationGroup.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 2.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CAAnimationGroup/*</name>*/ 
@@ -48,6 +50,7 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CAAnimationGroup() {}
+    protected CAAnimationGroup(Handle h, long handle) { super(h, handle); }
     protected CAAnimationGroup(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CABasicAnimation.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CABasicAnimation.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 2.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CABasicAnimation/*</name>*/ 
@@ -48,6 +50,7 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CABasicAnimation() {}
+    protected CABasicAnimation(Handle h, long handle) { super(h, handle); }
     protected CABasicAnimation(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     public CABasicAnimation(String path) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CADisplayLink.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CADisplayLink.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 3.1 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CADisplayLink/*</name>*/ 
@@ -64,8 +66,9 @@ import org.robovm.apple.metal.*;
     /*<bind>*/static { ObjCRuntime.bind(CADisplayLink.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
+    protected CADisplayLink(Handle h, long handle) { super(h, handle); }
     protected CADisplayLink(SkipInit skipInit) { super(skipInit); }
-    public CADisplayLink(NSObject target, Selector sel) { super(create(target, sel)); retain(getHandle()); }
+    public CADisplayLink(NSObject target, Selector sel) { super((Handle) null, create(target, sel)); retain(getHandle()); }
     /*</constructors>*/
     public CADisplayLink(OnUpdateListener listener) {
         super(create(listener));
@@ -86,14 +89,39 @@ import org.robovm.apple.metal.*;
     public native double getTimestamp();
     @Property(selector = "duration")
     public native double getDuration();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "targetTimestamp")
+    public native double getTargetTimestamp();
     @Property(selector = "isPaused")
     public native boolean isPaused();
     @Property(selector = "setPaused:")
     public native void setPaused(boolean v);
+    /**
+     * @since Available in iOS 3.1 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
     @Property(selector = "frameInterval")
     public native @MachineSizedSInt long getFrameInterval();
+    /**
+     * @since Available in iOS 3.1 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
     @Property(selector = "setFrameInterval:")
     public native void setFrameInterval(@MachineSizedSInt long v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "preferredFramesPerSecond")
+    public native @MachineSizedSInt long getPreferredFramesPerSecond();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setPreferredFramesPerSecond:")
+    public native void setPreferredFramesPerSecond(@MachineSizedSInt long v);
     /*</properties>*/
     /*<members>*//*</members>*/
     public void addToRunLoop(NSRunLoop runloop, NSRunLoopMode mode) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAEAGLLayer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAEAGLLayer.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 2.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass @WeaklyLinked/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CAEAGLLayer/*</name>*/ 
@@ -48,6 +50,7 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CAEAGLLayer() {}
+    protected CAEAGLLayer(Handle h, long handle) { super(h, handle); }
     protected CAEAGLLayer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAEmitterCell.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAEmitterCell.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 5.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CAEmitterCell/*</name>*/ 
@@ -48,8 +50,10 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CAEmitterCell() {}
+    protected CAEmitterCell(Handle h, long handle) { super(h, handle); }
     protected CAEmitterCell(SkipInit skipInit) { super(skipInit); }
-    public CAEmitterCell(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    @Method(selector = "initWithCoder:")
+    public CAEmitterCell(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "name")
@@ -234,6 +238,6 @@ import org.robovm.apple.metal.*;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAEmitterLayer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAEmitterLayer.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 5.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CAEmitterLayer/*</name>*/ 
@@ -48,6 +50,7 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CAEmitterLayer() {}
+    protected CAEmitterLayer(Handle h, long handle) { super(h, handle); }
     protected CAEmitterLayer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAGradientLayer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAGradientLayer.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 3.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CAGradientLayer/*</name>*/ 
@@ -48,6 +50,7 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CAGradientLayer() {}
+    protected CAGradientLayer(Handle h, long handle) { super(h, handle); }
     protected CAGradientLayer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     public void setLocations(double... locations) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAKeyframeAnimation.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAKeyframeAnimation.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 2.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CAKeyframeAnimation/*</name>*/ 
@@ -48,6 +50,7 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CAKeyframeAnimation() {}
+    protected CAKeyframeAnimation(Handle h, long handle) { super(h, handle); }
     protected CAKeyframeAnimation(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     public CAKeyframeAnimation(String path) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CALayer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CALayer.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 2.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CALayer/*</name>*/ 
@@ -48,10 +50,13 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CALayer() {}
-    protected CALayer(long handle) { super(handle); }
+    @Deprecated protected CALayer(long handle) { super(handle); }
+    protected CALayer(Handle h, long handle) { super(h, handle); }
     protected CALayer(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithLayer:")
     public CALayer(CALayer layer) { super((SkipInit) null); initObject(init(layer)); }
-    public CALayer(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    @Method(selector = "initWithCoder:")
+    public CALayer(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "bounds")
@@ -138,6 +143,16 @@ import org.robovm.apple.metal.*;
     public native @ByVal CGRect getContentsCenter();
     @Property(selector = "setContentsCenter:")
     public native void setContentsCenter(@ByVal CGRect v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "contentsFormat")
+    public native String getContentsFormat();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setContentsFormat:")
+    public native void setContentsFormat(String v);
     @Property(selector = "minificationFilter")
     public native CAFilter getMinificationFilter();
     @Property(selector = "setMinificationFilter:")
@@ -390,6 +405,6 @@ import org.robovm.apple.metal.*;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CALayerContentsFormat.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CALayerContentsFormat.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2013-2015 RoboVM AB
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,34 +36,34 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-/**
- * @since Available in iOS 2.0 and later.
- */
 /*</javadoc>*/
-/*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class /*<name>*/CAScrollLayer/*</name>*/ 
-    extends /*<extends>*/CALayer/*</extends>*/ 
+/*<annotations>*/@Library("QuartzCore")/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/CALayerContentsFormat/*</name>*/ 
+    extends /*<extends>*/CocoaUtility/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 
-    /*<ptr>*/public static class CAScrollLayerPtr extends Ptr<CAScrollLayer, CAScrollLayerPtr> {}/*</ptr>*/
-    /*<bind>*/static { ObjCRuntime.bind(CAScrollLayer.class); }/*</bind>*/
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/static { Bro.bind(CALayerContentsFormat.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
-    /*<constructors>*/
-    public CAScrollLayer() {}
-    protected CAScrollLayer(Handle h, long handle) { super(h, handle); }
-    protected CAScrollLayer(SkipInit skipInit) { super(skipInit); }
-    /*</constructors>*/
-    /*<properties>*/
-    @Property(selector = "scrollMode")
-    public native CAScrollMode getScrollMode();
-    @Property(selector = "setScrollMode:")
-    public native void setScrollMode(CAScrollMode v);
-    /*</properties>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*//*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
-    @Method(selector = "scrollToPoint:")
-    public native void scrollTo(@ByVal CGPoint p);
-    @Method(selector = "scrollToRect:")
-    public native void scrollTo(@ByVal CGRect r);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="kCAContentsFormatRGBA8Uint", optional=true)
+    public static native String RGBA8Uint();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="kCAContentsFormatRGBA16Float", optional=true)
+    public static native String RGBA16Float();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="kCAContentsFormatGray8Uint", optional=true)
+    public static native String Gray8Uint();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CALayerDelegate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CALayerDelegate.java
@@ -55,6 +55,11 @@ import org.robovm.apple.metal.*;
     void displayLayer(CALayer layer);
     @Method(selector = "drawLayer:inContext:")
     void drawLayer(CALayer layer, CGContext ctx);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "layerWillDraw:")
+    void willDrawLayer(CALayer layer);
     @Method(selector = "layoutSublayersOfLayer:")
     void layoutSublayers(CALayer layer);
     @Method(selector = "actionForLayer:forKey:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CALayerDelegateAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CALayerDelegateAdapter.java
@@ -57,6 +57,11 @@ import org.robovm.apple.metal.*;
     public void displayLayer(CALayer layer) {}
     @NotImplemented("drawLayer:inContext:")
     public void drawLayer(CALayer layer, CGContext ctx) {}
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @NotImplemented("layerWillDraw:")
+    public void willDrawLayer(CALayer layer) {}
     @NotImplemented("layoutSublayersOfLayer:")
     public void layoutSublayers(CALayer layer) {}
     @NotImplemented("actionForLayer:forKey:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAMediaTimingFunction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAMediaTimingFunction.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 2.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CAMediaTimingFunction/*</name>*/ 
@@ -48,10 +50,13 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CAMediaTimingFunction() {}
+    protected CAMediaTimingFunction(Handle h, long handle) { super(h, handle); }
     protected CAMediaTimingFunction(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithControlPoints::::")
     public CAMediaTimingFunction(float c1x, float c1y, float c2x, float c2y) { super((SkipInit) null); initObject(init(c1x, c1y, c2x, c2y)); }
-    public CAMediaTimingFunction(CAMediaTimingFunctionName name) { super(create(name)); retain(getHandle()); }
-    public CAMediaTimingFunction(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    public CAMediaTimingFunction(CAMediaTimingFunctionName name) { super((Handle) null, create(name)); retain(getHandle()); }
+    @Method(selector = "initWithCoder:")
+    public CAMediaTimingFunction(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     
@@ -72,6 +77,6 @@ import org.robovm.apple.metal.*;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAMetalLayer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAMetalLayer.java
@@ -50,6 +50,7 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CAMetalLayer() {}
+    protected CAMetalLayer(Handle h, long handle) { super(h, handle); }
     protected CAMetalLayer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAPropertyAnimation.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAPropertyAnimation.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 2.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CAPropertyAnimation/*</name>*/ 
@@ -48,9 +50,10 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CAPropertyAnimation() {}
-    protected CAPropertyAnimation(long handle) { super(handle); }
+    @Deprecated protected CAPropertyAnimation(long handle) { super(handle); }
+    protected CAPropertyAnimation(Handle h, long handle) { super(h, handle); }
     protected CAPropertyAnimation(SkipInit skipInit) { super(skipInit); }
-    public CAPropertyAnimation(String path) { super(create(path)); retain(getHandle()); }
+    public CAPropertyAnimation(String path) { super((Handle) null, create(path)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "keyPath")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAReplicatorLayer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAReplicatorLayer.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 3.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CAReplicatorLayer/*</name>*/ 
@@ -48,6 +50,7 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CAReplicatorLayer() {}
+    protected CAReplicatorLayer(Handle h, long handle) { super(h, handle); }
     protected CAReplicatorLayer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAShapeLayer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAShapeLayer.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 3.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CAShapeLayer/*</name>*/ 
@@ -48,6 +50,7 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CAShapeLayer() {}
+    protected CAShapeLayer(Handle h, long handle) { super(h, handle); }
     protected CAShapeLayer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CASpringAnimation.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CASpringAnimation.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 9.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CASpringAnimation/*</name>*/ 
@@ -48,6 +50,7 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CASpringAnimation() {}
+    protected CASpringAnimation(Handle h, long handle) { super(h, handle); }
     protected CASpringAnimation(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CATextLayer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CATextLayer.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 2.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CATextLayer/*</name>*/ 
@@ -48,6 +50,7 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CATextLayer() {}
+    protected CATextLayer(Handle h, long handle) { super(h, handle); }
     protected CATextLayer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CATiledLayer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CATiledLayer.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 2.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CATiledLayer/*</name>*/ 
@@ -48,6 +50,7 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CATiledLayer() {}
+    protected CATiledLayer(Handle h, long handle) { super(h, handle); }
     protected CATiledLayer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CATransaction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CATransaction.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 2.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CATransaction/*</name>*/ 
@@ -48,6 +50,7 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CATransaction() {}
+    protected CATransaction(Handle h, long handle) { super(h, handle); }
     protected CATransaction(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CATransformLayer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CATransformLayer.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 3.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CATransformLayer/*</name>*/ 
@@ -48,6 +50,7 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CATransformLayer() {}
+    protected CATransformLayer(Handle h, long handle) { super(h, handle); }
     protected CATransformLayer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CATransition.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CATransition.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 2.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CATransition/*</name>*/ 
@@ -48,6 +50,7 @@ import org.robovm.apple.metal.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CATransition() {}
+    protected CATransition(Handle h, long handle) { super(h, handle); }
     protected CATransition(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAValueFunction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreanimation/CAValueFunction.java
@@ -36,7 +36,9 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 3.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("QuartzCore") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CAValueFunction/*</name>*/ 
@@ -47,9 +49,11 @@ import org.robovm.apple.metal.*;
     /*<bind>*/static { ObjCRuntime.bind(CAValueFunction.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
+    protected CAValueFunction(Handle h, long handle) { super(h, handle); }
     protected CAValueFunction(SkipInit skipInit) { super(skipInit); }
-    public CAValueFunction(CAValueFunctionName name) { super(create(name)); retain(getHandle()); }
-    public CAValueFunction(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    public CAValueFunction(CAValueFunctionName name) { super((Handle) null, create(name)); retain(getHandle()); }
+    @Method(selector = "initWithCoder:")
+    public CAValueFunction(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "name")
@@ -62,6 +66,6 @@ import org.robovm.apple.metal.*;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudio/AudioFormat.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudio/AudioFormat.java
@@ -72,7 +72,8 @@ public enum /*<name>*/AudioFormat/*</name>*/ implements ValuedEnum {
     iLBC(1768710755L),
     DVIIntelIMA(1836253201L),
     MicrosoftGSM(1836253233L),
-    AES3(1634038579L);
+    AES3(1634038579L),
+    EnhancedAC3(1700998451L);
     /*</values>*/
 
     /*<bind>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudio/AudioFormatFlags.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudio/AudioFormatFlags.java
@@ -61,8 +61,6 @@ public final class /*<name>*/AudioFormatFlags/*</name>*/ extends Bits</*<name>*/
     public static final AudioFormatFlags AppleLossless24BitSourceData = new AudioFormatFlags(3L);
     public static final AudioFormatFlags AppleLossless32BitSourceData = new AudioFormatFlags(4L);
     public static final AudioFormatFlags NativeEndian = new AudioFormatFlags(0L);
-    public static final AudioFormatFlags Canonical = new AudioFormatFlags(12L);
-    public static final AudioFormatFlags AudioUnitCanonical = new AudioFormatFlags(3116L);
     public static final AudioFormatFlags NativeFloatPacked = new AudioFormatFlags(9L);
     /*</values>*/
 

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudio/AudioStreamBasicDescription.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudio/AudioStreamBasicDescription.java
@@ -34,14 +34,13 @@ import org.robovm.apple.corefoundation.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
+/*<annotations>*/@Library("CoreAudio")/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/AudioStreamBasicDescription/*</name>*/ 
     extends /*<extends>*/Struct<AudioStreamBasicDescription>/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 
     /*<ptr>*/public static class AudioStreamBasicDescriptionPtr extends Ptr<AudioStreamBasicDescription, AudioStreamBasicDescriptionPtr> {}/*</ptr>*/
-    /*<bind>*/
-    /*</bind>*/
+    /*<bind>*/static { Bro.bind(AudioStreamBasicDescription.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public AudioStreamBasicDescription() {}
@@ -77,5 +76,8 @@ import org.robovm.apple.corefoundation.*;
     @StructMember(8) private native int getReserved();
     @StructMember(8) private native AudioStreamBasicDescription setReserved(int reserved);
     /*</members>*/
-    /*<methods>*//*</methods>*/
+    /*<methods>*/
+    @GlobalValue(symbol="kAudioStreamAnyRate", optional=true)
+    public static native double AnyRate();
+    /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudio/AudioTimeStampFlags.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudio/AudioTimeStampFlags.java
@@ -38,6 +38,7 @@ import org.robovm.apple.corefoundation.*;
 public final class /*<name>*/AudioTimeStampFlags/*</name>*/ extends Bits</*<name>*/AudioTimeStampFlags/*</name>*/> {
     /*<values>*/
     public static final AudioTimeStampFlags None = new AudioTimeStampFlags(0L);
+    public static final AudioTimeStampFlags NothingValid = new AudioTimeStampFlags(0L);
     public static final AudioTimeStampFlags SampleTimeValid = new AudioTimeStampFlags(1L);
     public static final AudioTimeStampFlags HostTimeValid = new AudioTimeStampFlags(2L);
     public static final AudioTimeStampFlags RateScalarValid = new AudioTimeStampFlags(4L);

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudiokit/CABTMIDICentralViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudiokit/CABTMIDICentralViewController.java
@@ -48,6 +48,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CABTMIDICentralViewController() {}
+    protected CABTMIDICentralViewController(Handle h, long handle) { super(h, handle); }
     protected CABTMIDICentralViewController(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudiokit/CABTMIDILocalPeripheralViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudiokit/CABTMIDILocalPeripheralViewController.java
@@ -48,6 +48,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CABTMIDILocalPeripheralViewController() {}
+    protected CABTMIDILocalPeripheralViewController(Handle h, long handle) { super(h, handle); }
     protected CABTMIDILocalPeripheralViewController(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudiokit/CAInterAppAudioSwitcherView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudiokit/CAInterAppAudioSwitcherView.java
@@ -48,6 +48,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CAInterAppAudioSwitcherView() {}
+    protected CAInterAppAudioSwitcherView(Handle h, long handle) { super(h, handle); }
     protected CAInterAppAudioSwitcherView(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudiokit/CAInterAppAudioTransportView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreaudiokit/CAInterAppAudioTransportView.java
@@ -48,6 +48,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CAInterAppAudioTransportView() {}
+    protected CAInterAppAudioTransportView(Handle h, long handle) { super(h, handle); }
     protected CAInterAppAudioTransportView(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBATTRequest.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBATTRequest.java
@@ -46,7 +46,8 @@ import org.robovm.apple.dispatch.*;
     /*<bind>*/static { ObjCRuntime.bind(CBATTRequest.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public CBATTRequest() {}
+    protected CBATTRequest() {}
+    protected CBATTRequest(Handle h, long handle) { super(h, handle); }
     protected CBATTRequest(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBAttribute.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBAttribute.java
@@ -46,7 +46,8 @@ import org.robovm.apple.dispatch.*;
     /*<bind>*/static { ObjCRuntime.bind(CBAttribute.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public CBAttribute() {}
+    protected CBAttribute() {}
+    protected CBAttribute(Handle h, long handle) { super(h, handle); }
     protected CBAttribute(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBCentralManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBCentralManager.java
@@ -39,7 +39,7 @@ import org.robovm.apple.dispatch.*;
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreBluetooth") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CBCentralManager/*</name>*/ 
-    extends /*<extends>*/NSObject/*</extends>*/ 
+    extends /*<extends>*/CBManager/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 
     /*<ptr>*/public static class CBCentralManagerPtr extends Ptr<CBCentralManager, CBCentralManagerPtr> {}/*</ptr>*/
@@ -47,13 +47,16 @@ import org.robovm.apple.dispatch.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CBCentralManager() {}
+    protected CBCentralManager(Handle h, long handle) { super(h, handle); }
     protected CBCentralManager(SkipInit skipInit) { super(skipInit); }
     @WeaklyLinked
+    @Method(selector = "initWithDelegate:queue:")
     public CBCentralManager(CBCentralManagerDelegate delegate, DispatchQueue queue) { super((SkipInit) null); initObject(init(delegate, queue)); }
     /**
      * @since Available in iOS 7.0 and later.
      */
     @WeaklyLinked
+    @Method(selector = "initWithDelegate:queue:options:")
     public CBCentralManager(CBCentralManagerDelegate delegate, DispatchQueue queue, CBCentralManagerOptions options) { super((SkipInit) null); initObject(init(delegate, queue, options)); }
     /*</constructors>*/
     /*<properties>*/
@@ -61,8 +64,6 @@ import org.robovm.apple.dispatch.*;
     public native CBCentralManagerDelegate getDelegate();
     @Property(selector = "setDelegate:", strongRef = true)
     public native void setDelegate(CBCentralManagerDelegate v);
-    @Property(selector = "state")
-    public native CBCentralManagerState getState();
     /**
      * @since Available in iOS 9.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBCentralManagerState.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBCentralManagerState.java
@@ -33,7 +33,11 @@ import org.robovm.apple.dispatch.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 5.0 and later.
+ * @deprecated Deprecated in iOS 10.0.
+ */
+@Deprecated
 /*</javadoc>*/
 /*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
 public enum /*<name>*/CBCentralManagerState/*</name>*/ implements ValuedEnum {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBCharacteristic.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBCharacteristic.java
@@ -47,6 +47,7 @@ import org.robovm.apple.dispatch.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CBCharacteristic() {}
+    protected CBCharacteristic(Handle h, long handle) { super(h, handle); }
     protected CBCharacteristic(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBDescriptor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBDescriptor.java
@@ -47,6 +47,7 @@ import org.robovm.apple.dispatch.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CBDescriptor() {}
+    protected CBDescriptor(Handle h, long handle) { super(h, handle); }
     protected CBDescriptor(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBManager.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2013-2015 RoboVM AB
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,25 +34,25 @@ import org.robovm.apple.dispatch.*;
 
 /*<javadoc>*/
 /**
- * @since Available in iOS 6.0 and later.
+ * @since Available in iOS 10.0 and later.
  */
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreBluetooth") @NativeClass/*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class /*<name>*/CBCentral/*</name>*/ 
-    extends /*<extends>*/CBPeer/*</extends>*/ 
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/CBManager/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 
-    /*<ptr>*/public static class CBCentralPtr extends Ptr<CBCentral, CBCentralPtr> {}/*</ptr>*/
-    /*<bind>*/static { ObjCRuntime.bind(CBCentral.class); }/*</bind>*/
+    /*<ptr>*/public static class CBManagerPtr extends Ptr<CBManager, CBManagerPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(CBManager.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public CBCentral() {}
-    protected CBCentral(Handle h, long handle) { super(h, handle); }
-    protected CBCentral(SkipInit skipInit) { super(skipInit); }
+    protected CBManager() {}
+    protected CBManager(Handle h, long handle) { super(h, handle); }
+    protected CBManager(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
-    @Property(selector = "maximumUpdateValueLength")
-    public native @MachineSizedUInt long getMaximumUpdateValueLength();
+    @Property(selector = "state")
+    public native CBManagerState getState();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBManagerState.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBManagerState.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2013-2015 RoboVM AB
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,28 +34,36 @@ import org.robovm.apple.dispatch.*;
 
 /*<javadoc>*/
 /**
- * @since Available in iOS 6.0 and later.
+ * @since Available in iOS 10.0 and later.
  */
 /*</javadoc>*/
-/*<annotations>*/@Library("CoreBluetooth") @NativeClass/*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class /*<name>*/CBCentral/*</name>*/ 
-    extends /*<extends>*/CBPeer/*</extends>*/ 
-    /*<implements>*//*</implements>*/ {
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/CBManagerState/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Unknown(0L),
+    Resetting(1L),
+    Unsupported(2L),
+    Unauthorized(3L),
+    PoweredOff(4L),
+    PoweredOn(5L);
+    /*</values>*/
 
-    /*<ptr>*/public static class CBCentralPtr extends Ptr<CBCentral, CBCentralPtr> {}/*</ptr>*/
-    /*<bind>*/static { ObjCRuntime.bind(CBCentral.class); }/*</bind>*/
+    /*<bind>*/
+    /*</bind>*/
     /*<constants>*//*</constants>*/
-    /*<constructors>*/
-    public CBCentral() {}
-    protected CBCentral(Handle h, long handle) { super(h, handle); }
-    protected CBCentral(SkipInit skipInit) { super(skipInit); }
-    /*</constructors>*/
-    /*<properties>*/
-    @Property(selector = "maximumUpdateValueLength")
-    public native @MachineSizedUInt long getMaximumUpdateValueLength();
-    /*</properties>*/
-    /*<members>*//*</members>*/
-    /*<methods>*/
-    
-    /*</methods>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/CBManagerState/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/CBManagerState/*</name>*/ valueOf(long n) {
+        for (/*<name>*/CBManagerState/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/CBManagerState/*</name>*/.class.getName());
+    }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBMutableCharacteristic.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBMutableCharacteristic.java
@@ -47,7 +47,9 @@ import org.robovm.apple.dispatch.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CBMutableCharacteristic() {}
+    protected CBMutableCharacteristic(Handle h, long handle) { super(h, handle); }
     protected CBMutableCharacteristic(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithType:properties:value:permissions:")
     public CBMutableCharacteristic(CBUUID UUID, CBCharacteristicProperties properties, NSData value, CBAttributePermissions permissions) { super((SkipInit) null); initObject(init(UUID, properties, value, permissions)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBMutableDescriptor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBMutableDescriptor.java
@@ -47,7 +47,9 @@ import org.robovm.apple.dispatch.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CBMutableDescriptor() {}
+    protected CBMutableDescriptor(Handle h, long handle) { super(h, handle); }
     protected CBMutableDescriptor(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithType:value:")
     public CBMutableDescriptor(CBUUID UUID, NSObject value) { super((SkipInit) null); initObject(init(UUID, value)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBMutableService.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBMutableService.java
@@ -47,7 +47,9 @@ import org.robovm.apple.dispatch.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CBMutableService() {}
+    protected CBMutableService(Handle h, long handle) { super(h, handle); }
     protected CBMutableService(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithType:primary:")
     public CBMutableService(CBUUID UUID, boolean isPrimary) { super((SkipInit) null); initObject(init(UUID, isPrimary)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBPeer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBPeer.java
@@ -46,7 +46,8 @@ import org.robovm.apple.dispatch.*;
     /*<bind>*/static { ObjCRuntime.bind(CBPeer.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public CBPeer() {}
+    protected CBPeer() {}
+    protected CBPeer(Handle h, long handle) { super(h, handle); }
     protected CBPeer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBPeripheral.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBPeripheral.java
@@ -47,6 +47,7 @@ import org.robovm.apple.dispatch.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CBPeripheral() {}
+    protected CBPeripheral(Handle h, long handle) { super(h, handle); }
     protected CBPeripheral(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBPeripheralManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBPeripheralManager.java
@@ -39,7 +39,7 @@ import org.robovm.apple.dispatch.*;
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreBluetooth") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CBPeripheralManager/*</name>*/ 
-    extends /*<extends>*/NSObject/*</extends>*/ 
+    extends /*<extends>*/CBManager/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 
     /*<ptr>*/public static class CBPeripheralManagerPtr extends Ptr<CBPeripheralManager, CBPeripheralManagerPtr> {}/*</ptr>*/
@@ -47,13 +47,16 @@ import org.robovm.apple.dispatch.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CBPeripheralManager() {}
+    protected CBPeripheralManager(Handle h, long handle) { super(h, handle); }
     protected CBPeripheralManager(SkipInit skipInit) { super(skipInit); }
     @WeaklyLinked
+    @Method(selector = "initWithDelegate:queue:")
     public CBPeripheralManager(CBPeripheralManagerDelegate delegate, DispatchQueue queue) { super((SkipInit) null); initObject(init(delegate, queue)); }
     /**
      * @since Available in iOS 7.0 and later.
      */
     @WeaklyLinked
+    @Method(selector = "initWithDelegate:queue:options:")
     public CBPeripheralManager(CBPeripheralManagerDelegate delegate, DispatchQueue queue, CBPeripheralManagerOptions options) { super((SkipInit) null); initObject(init(delegate, queue, options)); }
     /*</constructors>*/
     /*<properties>*/
@@ -61,8 +64,6 @@ import org.robovm.apple.dispatch.*;
     public native CBPeripheralManagerDelegate getDelegate();
     @Property(selector = "setDelegate:", strongRef = true)
     public native void setDelegate(CBPeripheralManagerDelegate v);
-    @Property(selector = "state")
-    public native CBPeripheralManagerState getState();
     @Property(selector = "isAdvertising")
     public native boolean isAdvertising();
     /*</properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBPeripheralManagerState.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBPeripheralManagerState.java
@@ -35,7 +35,9 @@ import org.robovm.apple.dispatch.*;
 /*<javadoc>*/
 /**
  * @since Available in iOS 6.0 and later.
+ * @deprecated Deprecated in iOS 10.0.
  */
+@Deprecated
 /*</javadoc>*/
 /*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
 public enum /*<name>*/CBPeripheralManagerState/*</name>*/ implements ValuedEnum {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBService.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBService.java
@@ -47,6 +47,7 @@ import org.robovm.apple.dispatch.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CBService() {}
+    protected CBService(Handle h, long handle) { super(h, handle); }
     protected CBService(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBUUID.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBUUID.java
@@ -47,20 +47,21 @@ import org.robovm.apple.dispatch.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CBUUID() {}
+    protected CBUUID(Handle h, long handle) { super(h, handle); }
     protected CBUUID(SkipInit skipInit) { super(skipInit); }
-    public CBUUID(String theString) { super(create(theString)); retain(getHandle()); }
-    public CBUUID(NSData theData) { super(create(theData)); retain(getHandle()); }
+    public CBUUID(String theString) { super((Handle) null, create(theString)); retain(getHandle()); }
+    public CBUUID(NSData theData) { super((Handle) null, create(theData)); retain(getHandle()); }
     /**
      * @since Available in iOS 5.0 and later.
      * @deprecated Deprecated in iOS 9.0.
      */
     @Deprecated
     @WeaklyLinked
-    public CBUUID(CFUUID theUUID) { super(create(theUUID)); retain(getHandle()); }
+    public CBUUID(CFUUID theUUID) { super((Handle) null, create(theUUID)); retain(getHandle()); }
     /**
      * @since Available in iOS 7.0 and later.
      */
-    public CBUUID(NSUUID theUUID) { super(create(theUUID)); retain(getHandle()); }
+    public CBUUID(NSUUID theUUID) { super((Handle) null, create(theUUID)); retain(getHandle()); }
     /*</constructors>*/
     public CBUUID(CBUUIDIdentifier identifier) {
         super(create(identifier.value().toString()));

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBUUIDIdentifier.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corebluetooth/CBUUIDIdentifier.java
@@ -95,9 +95,10 @@ import org.robovm.apple.dispatch.*;
     public static final CBUUIDIdentifier ServerCharacteristicConfiguration = new CBUUIDIdentifier("ServerCharacteristicConfiguration");
     public static final CBUUIDIdentifier CharacteristicFormat = new CBUUIDIdentifier("CharacteristicFormat");
     public static final CBUUIDIdentifier CharacteristicAggregateFormat = new CBUUIDIdentifier("CharacteristicAggregateFormat");
+    public static final CBUUIDIdentifier CharacteristicValidRange = new CBUUIDIdentifier("CharacteristicValidRange");
     /*</constants>*/
     
-    private static /*<name>*/CBUUIDIdentifier/*</name>*/[] values = new /*<name>*/CBUUIDIdentifier/*</name>*/[] {/*<value_list>*/CharacteristicExtendedProperties, CharacteristicUserDescription, ClientCharacteristicConfiguration, ServerCharacteristicConfiguration, CharacteristicFormat, CharacteristicAggregateFormat/*</value_list>*/};
+    private static /*<name>*/CBUUIDIdentifier/*</name>*/[] values = new /*<name>*/CBUUIDIdentifier/*</name>*/[] {/*<value_list>*/CharacteristicExtendedProperties, CharacteristicUserDescription, ClientCharacteristicConfiguration, ServerCharacteristicConfiguration, CharacteristicFormat, CharacteristicAggregateFormat, CharacteristicValidRange/*</value_list>*/};
     
     /*<name>*/CBUUIDIdentifier/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -132,6 +133,8 @@ import org.robovm.apple.dispatch.*;
         public static native NSString CharacteristicFormat();
         @GlobalValue(symbol="CBUUIDCharacteristicAggregateFormatString", optional=true)
         public static native NSString CharacteristicAggregateFormat();
+        @GlobalValue(symbol="CBUUIDCharacteristicValidRangeString", optional=true)
+        public static native NSString CharacteristicValidRange();
         /*</values>*/
     }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/CoreDataVersionNumber.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/CoreDataVersionNumber.java
@@ -60,6 +60,8 @@ import org.robovm.apple.foundation.*;
     public static final double Version10_10 = 526.0;
     public static final double Version10_10_2 = 526.1;
     public static final double Version10_10_3 = 526.2;
+    public static final double Version10_11 = 640.0;
+    public static final double Version10_11_3 = 641.3;
     public static final double Version_iPhoneOS_3_0 = 241.0;
     public static final double Version_iPhoneOS_3_1 = 248.0;
     public static final double Version_iPhoneOS_3_2 = 310.2;
@@ -75,6 +77,9 @@ import org.robovm.apple.foundation.*;
     public static final double Version_iPhoneOS_7_1 = 479.3;
     public static final double Version_iPhoneOS_8_0 = 519.0;
     public static final double Version_iPhoneOS_8_3 = 519.15;
+    public static final double Version_iPhoneOS_9_0 = 640.0;
+    public static final double Version_iPhoneOS_9_2 = 641.4;
+    public static final double Version_iPhoneOS_9_3 = 641.6;
     /*</constants>*/
     /*<constructors>*//*</constructors>*/
     /*<properties>*//*</properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSAsynchronousFetchRequest.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSAsynchronousFetchRequest.java
@@ -45,7 +45,9 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSAsynchronousFetchRequest() {}
+    protected NSAsynchronousFetchRequest(Handle h, long handle) { super(h, handle); }
     protected NSAsynchronousFetchRequest(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithFetchRequest:completionBlock:")
     public NSAsynchronousFetchRequest(NSFetchRequest request, @Block VoidBlock1<NSAsynchronousFetchResult> blk) { super((SkipInit) null); initObject(init(request, blk)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSAsynchronousFetchResult.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSAsynchronousFetchResult.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSAsynchronousFetchResult() {}
+    protected NSAsynchronousFetchResult(Handle h, long handle) { super(h, handle); }
     protected NSAsynchronousFetchResult(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSAtomicStore.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSAtomicStore.java
@@ -46,7 +46,9 @@ import org.robovm.apple.foundation.NSError.NSErrorPtr;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSAtomicStore() {}
+    protected NSAtomicStore(Handle h, long handle) { super(h, handle); }
     protected NSAtomicStore(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithPersistentStoreCoordinator:configurationName:URL:options:")
     public NSAtomicStore(NSPersistentStoreCoordinator coordinator, String configurationName, NSURL url, NSPersistentStoreOptions options) { super((SkipInit) null); initObject(init(coordinator, configurationName, url, options)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSAtomicStoreCacheNode.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSAtomicStoreCacheNode.java
@@ -45,7 +45,9 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSAtomicStoreCacheNode() {}
+    protected NSAtomicStoreCacheNode(Handle h, long handle) { super(h, handle); }
     protected NSAtomicStoreCacheNode(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithObjectID:")
     public NSAtomicStoreCacheNode(NSManagedObjectID moid) { super((SkipInit) null); initObject(init(moid)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSAttributeDescription.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSAttributeDescription.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSAttributeDescription() {}
+    protected NSAttributeDescription(Handle h, long handle) { super(h, handle); }
     protected NSAttributeDescription(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSBatchDeleteRequest.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSBatchDeleteRequest.java
@@ -44,9 +44,12 @@ import org.robovm.apple.foundation.*;
     /*<bind>*/static { ObjCRuntime.bind(NSBatchDeleteRequest.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public NSBatchDeleteRequest() {}
+    protected NSBatchDeleteRequest() {}
+    protected NSBatchDeleteRequest(Handle h, long handle) { super(h, handle); }
     protected NSBatchDeleteRequest(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithFetchRequest:")
     public NSBatchDeleteRequest(NSFetchRequest fetch) { super((SkipInit) null); initObject(init(fetch)); }
+    @Method(selector = "initWithObjectIDs:")
     public NSBatchDeleteRequest(NSArray<NSManagedObjectID> objects) { super((SkipInit) null); initObject(init(objects)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSBatchDeleteResult.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSBatchDeleteResult.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSBatchDeleteResult() {}
+    protected NSBatchDeleteResult(Handle h, long handle) { super(h, handle); }
     protected NSBatchDeleteResult(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSBatchUpdateRequest.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSBatchUpdateRequest.java
@@ -45,8 +45,11 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSBatchUpdateRequest() {}
+    protected NSBatchUpdateRequest(Handle h, long handle) { super(h, handle); }
     protected NSBatchUpdateRequest(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithEntityName:")
     public NSBatchUpdateRequest(String entityName) { super((SkipInit) null); initObject(init(entityName)); }
+    @Method(selector = "initWithEntity:")
     public NSBatchUpdateRequest(NSEntityDescription entity) { super((SkipInit) null); initObject(init(entity)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSBatchUpdateResult.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSBatchUpdateResult.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSBatchUpdateResult() {}
+    protected NSBatchUpdateResult(Handle h, long handle) { super(h, handle); }
     protected NSBatchUpdateResult(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSConstraintConflict.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSConstraintConflict.java
@@ -45,7 +45,9 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSConstraintConflict() {}
+    protected NSConstraintConflict(Handle h, long handle) { super(h, handle); }
     protected NSConstraintConflict(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithConstraint:databaseObject:databaseSnapshot:conflictingObjects:conflictingSnapshots:")
     public NSConstraintConflict(@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> constraint, NSManagedObject databaseObject, NSDictionary<?, ?> databaseSnapshot, NSArray<NSManagedObject> conflictingObjects, NSArray<NSDictionary> conflictingSnapshots) { super((SkipInit) null); initObject(init(constraint, databaseObject, databaseSnapshot, conflictingObjects, conflictingSnapshots)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSEntityDescription.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSEntityDescription.java
@@ -45,8 +45,10 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSEntityDescription() {}
+    protected NSEntityDescription(Handle h, long handle) { super(h, handle); }
     protected NSEntityDescription(SkipInit skipInit) { super(skipInit); }
-    public NSEntityDescription(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    @Method(selector = "initWithCoder:")
+    public NSEntityDescription(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "managedObjectModel")
@@ -147,6 +149,6 @@ import org.robovm.apple.foundation.*;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSEntityMapping.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSEntityMapping.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSEntityMapping() {}
+    protected NSEntityMapping(Handle h, long handle) { super(h, handle); }
     protected NSEntityMapping(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSEntityMigrationPolicy.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSEntityMigrationPolicy.java
@@ -46,6 +46,7 @@ import org.robovm.apple.foundation.NSError.NSErrorPtr;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSEntityMigrationPolicy() {}
+    protected NSEntityMigrationPolicy(Handle h, long handle) { super(h, handle); }
     protected NSEntityMigrationPolicy(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSExpressionDescription.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSExpressionDescription.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSExpressionDescription() {}
+    protected NSExpressionDescription(Handle h, long handle) { super(h, handle); }
     protected NSExpressionDescription(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSFetchRequest.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSFetchRequest.java
@@ -45,12 +45,15 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSFetchRequest() {}
+    protected NSFetchRequest(Handle h, long handle) { super(h, handle); }
     protected NSFetchRequest(SkipInit skipInit) { super(skipInit); }
     /**
      * @since Available in iOS 4.0 and later.
      */
+    @Method(selector = "initWithEntityName:")
     public NSFetchRequest(String entityName) { super((SkipInit) null); initObject(init(entityName)); }
-    public NSFetchRequest(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    @Method(selector = "initWithCoder:")
+    public NSFetchRequest(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "entity")
@@ -216,9 +219,23 @@ import org.robovm.apple.foundation.*;
      */
     @Method(selector = "initWithEntityName:")
     protected native @Pointer long init(String entityName);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public NSArray<?> execute() throws NSErrorException {
+       NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
+       NSArray<?> result = execute(ptr);
+       if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
+       return result;
+    }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "execute:")
+    private native NSArray<?> execute(NSError.NSErrorPtr error);
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSFetchRequestExpression.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSFetchRequestExpression.java
@@ -45,8 +45,9 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSFetchRequestExpression() {}
+    protected NSFetchRequestExpression(Handle h, long handle) { super(h, handle); }
     protected NSFetchRequestExpression(SkipInit skipInit) { super(skipInit); }
-    public NSFetchRequestExpression(NSExpression fetch, NSExpression context, boolean countFlag) { super(create(fetch, context, countFlag)); retain(getHandle()); }
+    public NSFetchRequestExpression(NSExpression fetch, NSExpression context, boolean countFlag) { super((Handle) null, create(fetch, context, countFlag)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "requestExpression")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSFetchRequestResult.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSFetchRequestResult.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2013-2015 RoboVM AB
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,31 +31,23 @@ import org.robovm.apple.foundation.*;
 /*</imports>*/
 
 /*<javadoc>*/
-/**
- * @since Available in iOS 3.0 and later.
- */
-/*</javadoc>*/
-/*<annotations>*/@Library("CoreData") @NativeClass/*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class /*<name>*/NSFetchedPropertyDescription/*</name>*/ 
-    extends /*<extends>*/NSPropertyDescription/*</extends>*/ 
-    /*<implements>*//*</implements>*/ {
 
-    /*<ptr>*/public static class NSFetchedPropertyDescriptionPtr extends Ptr<NSFetchedPropertyDescription, NSFetchedPropertyDescriptionPtr> {}/*</ptr>*/
-    /*<bind>*/static { ObjCRuntime.bind(NSFetchedPropertyDescription.class); }/*</bind>*/
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/NSFetchRequestResult/*</name>*/ 
+    /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
     /*<constants>*//*</constants>*/
-    /*<constructors>*/
-    public NSFetchedPropertyDescription() {}
-    protected NSFetchedPropertyDescription(Handle h, long handle) { super(h, handle); }
-    protected NSFetchedPropertyDescription(SkipInit skipInit) { super(skipInit); }
-    /*</constructors>*/
     /*<properties>*/
-    @Property(selector = "fetchRequest")
-    public native NSFetchRequest getFetchRequest();
-    @Property(selector = "setFetchRequest:")
-    public native void setFetchRequest(NSFetchRequest v);
+    
     /*</properties>*/
-    /*<members>*//*</members>*/
     /*<methods>*/
     
     /*</methods>*/
+    /*<adapter>*/
+    /*</adapter>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSFetchedResultsController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSFetchedResultsController.java
@@ -45,7 +45,9 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSFetchedResultsController() {}
+    protected NSFetchedResultsController(Handle h, long handle) { super(h, handle); }
     protected NSFetchedResultsController(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithFetchRequest:managedObjectContext:sectionNameKeyPath:cacheName:")
     public NSFetchedResultsController(NSFetchRequest fetchRequest, NSManagedObjectContext context, String sectionNameKeyPath, String name) { super((SkipInit) null); initObject(init(fetchRequest, context, sectionNameKeyPath, name)); }
     /*</constructors>*/
     /*<properties>*/
@@ -81,9 +83,9 @@ import org.robovm.apple.foundation.*;
     @Method(selector = "performFetch:")
     private native boolean performFetch(NSError.NSErrorPtr error);
     @Method(selector = "objectAtIndexPath:")
-    public native NSObject getObjectAtIndexPath(NSIndexPath indexPath);
+    public native NSFetchRequestResult getObjectAtIndexPath(NSIndexPath indexPath);
     @Method(selector = "indexPathForObject:")
-    public native NSIndexPath getIndexPathForObject(NSObject object);
+    public native NSIndexPath getIndexPathForObject(NSFetchRequestResult object);
     @Method(selector = "sectionIndexTitleForSectionName:")
     public native String getSectionIndexTitleForSectionName(String sectionName);
     @Method(selector = "sectionForSectionIndexTitle:atIndex:")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSIncrementalStore.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSIncrementalStore.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSIncrementalStore() {}
+    protected NSIncrementalStore(Handle h, long handle) { super(h, handle); }
     protected NSIncrementalStore(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSIncrementalStoreNode.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSIncrementalStoreNode.java
@@ -45,7 +45,9 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSIncrementalStoreNode() {}
+    protected NSIncrementalStoreNode(Handle h, long handle) { super(h, handle); }
     protected NSIncrementalStoreNode(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithObjectID:withValues:version:")
     public NSIncrementalStoreNode(NSManagedObjectID objectID, NSDictionary<NSString, ?> values, long version) { super((SkipInit) null); initObject(init(objectID, values, version)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSManagedObject.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSManagedObject.java
@@ -38,17 +38,29 @@ import org.robovm.apple.foundation.*;
 /*<annotations>*/@Library("CoreData") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/NSManagedObject/*</name>*/ 
     extends /*<extends>*/NSObject/*</extends>*/ 
-    /*<implements>*//*</implements>*/ {
+    /*<implements>*/implements NSFetchRequestResult/*</implements>*/ {
 
     /*<ptr>*/public static class NSManagedObjectPtr extends Ptr<NSManagedObject, NSManagedObjectPtr> {}/*</ptr>*/
     /*<bind>*/static { ObjCRuntime.bind(NSManagedObject.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSManagedObject() {}
+    protected NSManagedObject(Handle h, long handle) { super(h, handle); }
     protected NSManagedObject(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithEntity:insertIntoManagedObjectContext:")
     public NSManagedObject(NSEntityDescription entity, NSManagedObjectContext context) { super((SkipInit) null); initObject(init(entity, context)); }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "initWithContext:")
+    public NSManagedObject(NSManagedObjectContext moc) { super((SkipInit) null); initObject(init(moc)); }
     /*</constructors>*/
     /*<properties>*/
+    /**
+     * @since Available in iOS 3.0 and later.
+     */
+    @Property(selector = "contextShouldIgnoreUnmodeledPropertyChanges")
+    public static native boolean isContextShouldIgnoreUnmodeledPropertyChanges();
     @Property(selector = "managedObjectContext")
     public native NSManagedObjectContext getManagedObjectContext();
     @Property(selector = "entity")
@@ -99,6 +111,11 @@ import org.robovm.apple.foundation.*;
     /*<methods>*/
     @Method(selector = "initWithEntity:insertIntoManagedObjectContext:")
     protected native @Pointer long init(NSEntityDescription entity, NSManagedObjectContext context);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "initWithContext:")
+    protected native @Pointer long init(NSManagedObjectContext moc);
     /**
      * @since Available in iOS 3.0 and later.
      */
@@ -196,9 +213,14 @@ import org.robovm.apple.foundation.*;
     @Method(selector = "validateForUpdate:")
     private native boolean validateForUpdate(NSError.NSErrorPtr error);
     /**
-     * @since Available in iOS 3.0 and later.
+     * @since Available in iOS 10.0 and later.
      */
-    @Method(selector = "contextShouldIgnoreUnmodeledPropertyChanges")
-    public static native boolean shouldContextIgnoreUnmodeledPropertyChanges();
+    @Method(selector = "entity")
+    public static native NSEntityDescription entity();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "fetchRequest")
+    public static native NSFetchRequest fetchRequest();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSManagedObjectContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSManagedObjectContext.java
@@ -92,12 +92,15 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSManagedObjectContext() {}
+    protected NSManagedObjectContext(Handle h, long handle) { super(h, handle); }
     protected NSManagedObjectContext(SkipInit skipInit) { super(skipInit); }
     /**
      * @since Available in iOS 5.0 and later.
      */
+    @Method(selector = "initWithConcurrencyType:")
     public NSManagedObjectContext(NSManagedObjectContextConcurrencyType ct) { super((SkipInit) null); initObject(init(ct)); }
-    public NSManagedObjectContext(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    @Method(selector = "initWithCoder:")
+    public NSManagedObjectContext(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "persistentStoreCoordinator")
@@ -174,6 +177,21 @@ import org.robovm.apple.foundation.*;
     public native NSObject getMergePolicy();
     @Property(selector = "setMergePolicy:")
     public native void setMergePolicy(NSObject v);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "queryGenerationToken")
+    public native NSQueryGenerationToken getQueryGenerationToken();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "automaticallyMergesChangesFromParent")
+    public native boolean automaticallyMergesChangesFromParent();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "setAutomaticallyMergesChangesFromParent:")
+    public native void setAutomaticallyMergesChangesFromParent(boolean v);
     /*</properties>*/
     /*<members>*//*</members>*/
     public void observeValue(String keyPath, NSObject object, NSKeyValueChangeInfo change) {}
@@ -198,6 +216,11 @@ import org.robovm.apple.foundation.*;
      */
     @GlobalValue(symbol="NSManagedObjectContextObjectsDidChangeNotification", optional=true)
     public static native NSString ObjectsDidChangeNotification();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="NSManagedObjectContextQueryGenerationKey", optional=true)
+    public static native NSString QueryGenerationKey();
     
     /**
      * @since Available in iOS 5.0 and later.
@@ -347,6 +370,20 @@ import org.robovm.apple.foundation.*;
     @Method(selector = "mergeChangesFromContextDidSaveNotification:")
     public native void mergeChangesFromContextDidSaveNotification(NSNotification notification);
     /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public boolean setQueryGenerationFromToken(NSQueryGenerationToken generation) throws NSErrorException {
+       NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
+       boolean result = setQueryGenerationFromToken(generation, ptr);
+       if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
+       return result;
+    }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "setQueryGenerationFromToken:error:")
+    private native boolean setQueryGenerationFromToken(NSQueryGenerationToken generation, NSError.NSErrorPtr error);
+    /**
      * @since Available in iOS 9.0 and later.
      */
     @Method(selector = "mergeChangesFromRemoteContextSave:intoContexts:")
@@ -354,6 +391,6 @@ import org.robovm.apple.foundation.*;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSManagedObjectID.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSManagedObjectID.java
@@ -38,13 +38,14 @@ import org.robovm.apple.foundation.*;
 /*<annotations>*/@Library("CoreData") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/NSManagedObjectID/*</name>*/ 
     extends /*<extends>*/NSObject/*</extends>*/ 
-    /*<implements>*//*</implements>*/ {
+    /*<implements>*/implements NSFetchRequestResult/*</implements>*/ {
 
     /*<ptr>*/public static class NSManagedObjectIDPtr extends Ptr<NSManagedObjectID, NSManagedObjectIDPtr> {}/*</ptr>*/
     /*<bind>*/static { ObjCRuntime.bind(NSManagedObjectID.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSManagedObjectID() {}
+    protected NSManagedObjectID(Handle h, long handle) { super(h, handle); }
     protected NSManagedObjectID(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSManagedObjectModel.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSManagedObjectModel.java
@@ -45,9 +45,12 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSManagedObjectModel() {}
+    protected NSManagedObjectModel(Handle h, long handle) { super(h, handle); }
     protected NSManagedObjectModel(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithContentsOfURL:")
     public NSManagedObjectModel(NSURL url) { super((SkipInit) null); initObject(init(url)); }
-    public NSManagedObjectModel(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    @Method(selector = "initWithCoder:")
+    public NSManagedObjectModel(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "entitiesByName")
@@ -119,6 +122,6 @@ import org.robovm.apple.foundation.*;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSMappingModel.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSMappingModel.java
@@ -45,9 +45,11 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSMappingModel() {}
+    protected NSMappingModel(Handle h, long handle) { super(h, handle); }
     protected NSMappingModel(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithContentsOfURL:")
     public NSMappingModel(NSURL url) { super((SkipInit) null); initObject(init(url)); }
-    public NSMappingModel(NSArray<NSBundle> bundles, NSManagedObjectModel sourceModel, NSManagedObjectModel destinationModel) { super(create(bundles, sourceModel, destinationModel)); retain(getHandle()); }
+    public NSMappingModel(NSArray<NSBundle> bundles, NSManagedObjectModel sourceModel, NSManagedObjectModel destinationModel) { super((Handle) null, create(bundles, sourceModel, destinationModel)); retain(getHandle()); }
     /*</constructors>*/
     /**
      * @since Available in iOS 3.0 and later.

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSMergeConflict.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSMergeConflict.java
@@ -44,8 +44,10 @@ import org.robovm.apple.foundation.*;
     /*<bind>*/static { ObjCRuntime.bind(NSMergeConflict.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public NSMergeConflict() {}
+    protected NSMergeConflict() {}
+    protected NSMergeConflict(Handle h, long handle) { super(h, handle); }
     protected NSMergeConflict(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithSource:newVersion:oldVersion:cachedSnapshot:persistedSnapshot:")
     public NSMergeConflict(NSManagedObject srcObject, @MachineSizedUInt long newvers, @MachineSizedUInt long oldvers, NSDictionary<NSString, ?> cachesnap, NSDictionary<NSString, ?> persnap) { super((SkipInit) null); initObject(init(srcObject, newvers, oldvers, cachesnap, persnap)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSMergePolicy.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSMergePolicy.java
@@ -45,11 +45,38 @@ import org.robovm.apple.foundation.NSError.NSErrorPtr;
     /*<bind>*/static { ObjCRuntime.bind(NSMergePolicy.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public NSMergePolicy() {}
+    protected NSMergePolicy() {}
+    protected NSMergePolicy(Handle h, long handle) { super(h, handle); }
     protected NSMergePolicy(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithMergeType:")
     public NSMergePolicy(NSMergePolicyType ty) { super((SkipInit) null); initObject(init(ty)); }
     /*</constructors>*/
     /*<properties>*/
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "errorMergePolicy")
+    public static native NSMergePolicy getErrorMergePolicy();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "rollbackMergePolicy")
+    public static native NSMergePolicy getRollbackMergePolicy();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "overwriteMergePolicy")
+    public static native NSMergePolicy getOverwriteMergePolicy();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "mergeByPropertyObjectTrumpMergePolicy")
+    public static native NSMergePolicy getMergeByPropertyObjectTrumpMergePolicy();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "mergeByPropertyStoreTrumpMergePolicy")
+    public static native NSMergePolicy getMergeByPropertyStoreTrumpMergePolicy();
     @Property(selector = "mergeType")
     public native NSMergePolicyType getMergeType();
     /*</properties>*/
@@ -58,27 +85,27 @@ import org.robovm.apple.foundation.NSError.NSErrorPtr;
      * @since Available in iOS 3.0 and later.
      */
     @GlobalValue(symbol="NSErrorMergePolicy", optional=true)
-    public static native NSMergePolicy getErrorMergePolicy();
+    public static native NSMergePolicy getErrorMergePolicyConst();
     /**
      * @since Available in iOS 3.0 and later.
      */
     @GlobalValue(symbol="NSMergeByPropertyStoreTrumpMergePolicy", optional=true)
-    public static native NSMergePolicy getMergeByPropertyStoreTrumpMergePolicy();
+    public static native NSMergePolicy getMergeByPropertyStoreTrumpMergePolicyConst();
     /**
      * @since Available in iOS 3.0 and later.
      */
     @GlobalValue(symbol="NSMergeByPropertyObjectTrumpMergePolicy", optional=true)
-    public static native NSMergePolicy getMergeByPropertyObjectTrumpMergePolicy();
+    public static native NSMergePolicy getMergeByPropertyObjectTrumpMergePolicyConst();
     /**
      * @since Available in iOS 3.0 and later.
      */
     @GlobalValue(symbol="NSOverwriteMergePolicy", optional=true)
-    public static native NSMergePolicy getOverwriteMergePolicy();
+    public static native NSMergePolicy getOverwriteMergePolicyConst();
     /**
      * @since Available in iOS 3.0 and later.
      */
     @GlobalValue(symbol="NSRollbackMergePolicy", optional=true)
-    public static native NSMergePolicy getRollbackMergePolicy();
+    public static native NSMergePolicy getRollbackMergePolicyConst();
     
     @Method(selector = "initWithMergeType:")
     protected native @Pointer long init(NSMergePolicyType ty);

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSMigrationManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSMigrationManager.java
@@ -45,7 +45,9 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSMigrationManager() {}
+    protected NSMigrationManager(Handle h, long handle) { super(h, handle); }
     protected NSMigrationManager(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithSourceModel:destinationModel:")
     public NSMigrationManager(NSManagedObjectModel sourceModel, NSManagedObjectModel destinationModel) { super((SkipInit) null); initObject(init(sourceModel, destinationModel)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStore.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStore.java
@@ -44,8 +44,10 @@ import org.robovm.apple.foundation.*;
     /*<bind>*/static { ObjCRuntime.bind(NSPersistentStore.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public NSPersistentStore() {}
+    protected NSPersistentStore() {}
+    protected NSPersistentStore(Handle h, long handle) { super(h, handle); }
     protected NSPersistentStore(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithPersistentStoreCoordinator:configurationName:URL:options:")
     public NSPersistentStore(NSPersistentStoreCoordinator root, String name, NSURL url, NSPersistentStoreOptions options) { super((SkipInit) null); initObject(init(root, name, url, options)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreAsynchronousResult.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreAsynchronousResult.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSPersistentStoreAsynchronousResult() {}
+    protected NSPersistentStoreAsynchronousResult(Handle h, long handle) { super(h, handle); }
     protected NSPersistentStoreAsynchronousResult(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreCoordinator.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreCoordinator.java
@@ -102,7 +102,9 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSPersistentStoreCoordinator() {}
+    protected NSPersistentStoreCoordinator(Handle h, long handle) { super(h, handle); }
     protected NSPersistentStoreCoordinator(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithManagedObjectModel:")
     public NSPersistentStoreCoordinator(NSManagedObjectModel model) { super((SkipInit) null); initObject(init(model)); }
     /*</constructors>*/
     /*<properties>*/
@@ -120,6 +122,11 @@ import org.robovm.apple.foundation.*;
      */
     @Property(selector = "setName:")
     public native void setName(String v);
+    /**
+     * @since Available in iOS 3.0 and later.
+     */
+    @Property(selector = "registeredStoreTypes")
+    public static native NSDictionary<NSString, NSPersistentStore> getRegisteredStoreTypes();
     /*</properties>*/
     /*<members>*//*</members>*/
     /**
@@ -196,7 +203,9 @@ import org.robovm.apple.foundation.*;
     public static native NSString WillRemoveStoreNotification();
     /**
      * @since Available in iOS 5.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @GlobalValue(symbol="NSPersistentStoreDidImportUbiquitousContentChangesNotification", optional=true)
     public static native NSString DidImportUbiquitousContentChangesNotification();
     
@@ -219,6 +228,11 @@ import org.robovm.apple.foundation.*;
     }
     @Method(selector = "addPersistentStoreWithType:configuration:URL:options:error:")
     private native NSPersistentStore addPersistentStore(String storeType, String configuration, NSURL storeURL, NSPersistentStoreOptions options, NSError.NSErrorPtr error);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "addPersistentStoreWithDescription:completionHandler:")
+    public native void addPersistentStoreWithDescription(NSPersistentStoreDescription storeDescription, @Block VoidBlock2<NSPersistentStoreDescription, NSError> block);
     public boolean removePersistentStore(NSPersistentStore store) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        boolean result = removePersistentStore(store, ptr);
@@ -317,11 +331,6 @@ import org.robovm.apple.foundation.*;
     /**
      * @since Available in iOS 3.0 and later.
      */
-    @Method(selector = "registeredStoreTypes")
-    public static native NSDictionary<NSString, NSPersistentStore> getRegisteredStoreTypes();
-    /**
-     * @since Available in iOS 3.0 and later.
-     */
     @Method(selector = "registerStoreClass:forStoreType:")
     public static native void registerStoreClassForType(Class<? extends NSPersistentStore> storeClass, String storeType);
     /**
@@ -389,8 +398,10 @@ import org.robovm.apple.foundation.*;
     @Method(selector = "setMetadata:forPersistentStoreOfType:URL:error:")
     private static native boolean setMetadataForPersistentStoreType(NSPersistentStoreMetadata metadata, String storeType, NSURL url, NSError.NSErrorPtr error);
     /**
-     * @since Available in iOS 7.0 and later.
+     * @since Available in iOS 5.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     public static boolean removeUbiquitousContentAndPersistentStore(NSURL storeURL, NSPersistentStoreOptions options) throws NSErrorException {
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
        boolean result = removeUbiquitousContentAndPersistentStore(storeURL, options, ptr);
@@ -398,8 +409,10 @@ import org.robovm.apple.foundation.*;
        return result;
     }
     /**
-     * @since Available in iOS 7.0 and later.
+     * @since Available in iOS 5.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     @Method(selector = "removeUbiquitousContentAndPersistentStoreAtURL:options:error:")
     private static native boolean removeUbiquitousContentAndPersistentStore(NSURL storeURL, NSPersistentStoreOptions options, NSError.NSErrorPtr error);
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreCoordinatorChangeNotification.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreCoordinatorChangeNotification.java
@@ -133,7 +133,9 @@ import org.robovm.apple.foundation.*;
     }
     /**
      * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     public NSPersistentStoreUbiquitousTransitionType getUbiquitousTransitionType() {
         if (has(Keys.UbiquitousTransitionType())) {
             NSNumber val = (NSNumber) get(Keys.UbiquitousTransitionType());
@@ -164,7 +166,9 @@ import org.robovm.apple.foundation.*;
         public static native NSString UUIDChanged();
         /**
          * @since Available in iOS 7.0 and later.
+         * @deprecated Deprecated in iOS 10.0.
          */
+        @Deprecated
         @GlobalValue(symbol="NSPersistentStoreUbiquitousTransitionTypeKey", optional=true)
         public static native NSString UbiquitousTransitionType();
     }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreDescription.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreDescription.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.coredata;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/**
+ * @since Available in iOS 10.0 and later.
+ */
+/*</javadoc>*/
+/*<annotations>*/@Library("CoreData") @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/NSPersistentStoreDescription/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/public static class NSPersistentStoreDescriptionPtr extends Ptr<NSPersistentStoreDescription, NSPersistentStoreDescriptionPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(NSPersistentStoreDescription.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    public NSPersistentStoreDescription() {}
+    protected NSPersistentStoreDescription(Handle h, long handle) { super(h, handle); }
+    protected NSPersistentStoreDescription(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithURL:")
+    public NSPersistentStoreDescription(NSURL url) { super((SkipInit) null); initObject(initWithURL$(url)); }
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "type")
+    public native String getType();
+    @Property(selector = "setType:")
+    public native void setType(String v);
+    @Property(selector = "configuration")
+    public native String getConfiguration();
+    @Property(selector = "setConfiguration:")
+    public native void setConfiguration(String v);
+    @Property(selector = "URL")
+    public native NSURL getURL();
+    @Property(selector = "setURL:")
+    public native void setURL(NSURL v);
+    @Property(selector = "options")
+    public native NSDictionary<?, ?> getOptions();
+    @Property(selector = "isReadOnly")
+    public native boolean isReadOnly();
+    @Property(selector = "setReadOnly:")
+    public native void setReadOnly(boolean v);
+    @Property(selector = "timeout")
+    public native double getTimeout();
+    @Property(selector = "setTimeout:")
+    public native void setTimeout(double v);
+    @Property(selector = "sqlitePragmas")
+    public native NSDictionary<?, ?> getSqlitePragmas();
+    @Property(selector = "shouldAddStoreAsynchronously")
+    public native boolean shouldAddStoreAsynchronously();
+    @Property(selector = "setShouldAddStoreAsynchronously:")
+    public native void setShouldAddStoreAsynchronously(boolean v);
+    @Property(selector = "shouldMigrateStoreAutomatically")
+    public native boolean shouldMigrateStoreAutomatically();
+    @Property(selector = "setShouldMigrateStoreAutomatically:")
+    public native void setShouldMigrateStoreAutomatically(boolean v);
+    @Property(selector = "shouldInferMappingModelAutomatically")
+    public native boolean shouldInferMappingModelAutomatically();
+    @Property(selector = "setShouldInferMappingModelAutomatically:")
+    public native void setShouldInferMappingModelAutomatically(boolean v);
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "setOption:forKey:")
+    public native void setOption$forKey$(NSObject option, String key);
+    @Method(selector = "setValue:forPragmaNamed:")
+    public native void setValue$forPragmaNamed$(NSObject value, String name);
+    @Method(selector = "initWithURL:")
+    protected native @Pointer long initWithURL$(NSURL url);
+    @Method(selector = "persistentStoreDescriptionWithURL:")
+    public static native NSPersistentStoreDescription persistentStoreDescriptionWithURL$(NSURL URL);
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreOptions.java
@@ -243,108 +243,6 @@ import org.robovm.apple.foundation.*;
         return this;
     }
     /**
-     * @since Available in iOS 5.0 and later.
-     */
-    public String getUbiquitousContentName() {
-        if (has(Keys.UbiquitousContentName())) {
-            NSString val = (NSString) get(Keys.UbiquitousContentName());
-            return val.toString();
-        }
-        return null;
-    }
-    /**
-     * @since Available in iOS 5.0 and later.
-     */
-    public NSPersistentStoreOptions setUbiquitousContentName(String ubiquitousContentName) {
-        set(Keys.UbiquitousContentName(), new NSString(ubiquitousContentName));
-        return this;
-    }
-    /**
-     * @since Available in iOS 5.0 and later.
-     */
-    public String getUbiquitousContentURL() {
-        if (has(Keys.UbiquitousContentURL())) {
-            NSString val = (NSString) get(Keys.UbiquitousContentURL());
-            return val.toString();
-        }
-        return null;
-    }
-    /**
-     * @since Available in iOS 5.0 and later.
-     */
-    public NSPersistentStoreOptions setUbiquitousContentURL(String ubiquitousContentURL) {
-        set(Keys.UbiquitousContentURL(), new NSString(ubiquitousContentURL));
-        return this;
-    }
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    public String getUbiquitousPeerToken() {
-        if (has(Keys.UbiquitousPeerToken())) {
-            NSString val = (NSString) get(Keys.UbiquitousPeerToken());
-            return val.toString();
-        }
-        return null;
-    }
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    public NSPersistentStoreOptions setUbiquitousPeerToken(String ubiquitousPeerToken) {
-        set(Keys.UbiquitousPeerToken(), new NSString(ubiquitousPeerToken));
-        return this;
-    }
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    public boolean shouldRemoveUbiquitousMetadata() {
-        if (has(Keys.RemoveUbiquitousMetadata())) {
-            NSNumber val = (NSNumber) get(Keys.RemoveUbiquitousMetadata());
-            return val.booleanValue();
-        }
-        return false;
-    }
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    public NSPersistentStoreOptions setShouldRemoveUbiquitousMetadata(boolean shouldRemoveUbiquitousMetadata) {
-        set(Keys.RemoveUbiquitousMetadata(), NSNumber.valueOf(shouldRemoveUbiquitousMetadata));
-        return this;
-    }
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    public String getUbiquitousContainerIdentifier() {
-        if (has(Keys.UbiquitousContainerIdentifier())) {
-            NSString val = (NSString) get(Keys.UbiquitousContainerIdentifier());
-            return val.toString();
-        }
-        return null;
-    }
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    public NSPersistentStoreOptions setUbiquitousContainerIdentifier(String ubiquitousContainerIdentifier) {
-        set(Keys.UbiquitousContainerIdentifier(), new NSString(ubiquitousContainerIdentifier));
-        return this;
-    }
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    public boolean shouldRebuildFromUbiquitousContent() {
-        if (has(Keys.RebuildFromUbiquitousContent())) {
-            NSNumber val = (NSNumber) get(Keys.RebuildFromUbiquitousContent());
-            return val.booleanValue();
-        }
-        return false;
-    }
-    /**
-     * @since Available in iOS 7.0 and later.
-     */
-    public NSPersistentStoreOptions setShouldRebuildFromUbiquitousContent(boolean shouldRebuildFromUbiquitousContent) {
-        set(Keys.RebuildFromUbiquitousContent(), NSNumber.valueOf(shouldRebuildFromUbiquitousContent));
-        return this;
-    }
-    /**
      * @since Available in iOS 6.0 and later.
      */
     public boolean isForceDestroy() {
@@ -376,6 +274,132 @@ import org.robovm.apple.foundation.*;
      */
     public NSPersistentStoreOptions setFileProtection(NSFileProtection fileProtection) {
         set(Keys.FileProtection(), fileProtection.value());
+        return this;
+    }
+    /**
+     * @since Available in iOS 5.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    public String getUbiquitousContentName() {
+        if (has(Keys.UbiquitousContentName())) {
+            NSString val = (NSString) get(Keys.UbiquitousContentName());
+            return val.toString();
+        }
+        return null;
+    }
+    /**
+     * @since Available in iOS 5.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    public NSPersistentStoreOptions setUbiquitousContentName(String ubiquitousContentName) {
+        set(Keys.UbiquitousContentName(), new NSString(ubiquitousContentName));
+        return this;
+    }
+    /**
+     * @since Available in iOS 5.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    public String getUbiquitousContentURL() {
+        if (has(Keys.UbiquitousContentURL())) {
+            NSString val = (NSString) get(Keys.UbiquitousContentURL());
+            return val.toString();
+        }
+        return null;
+    }
+    /**
+     * @since Available in iOS 5.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    public NSPersistentStoreOptions setUbiquitousContentURL(String ubiquitousContentURL) {
+        set(Keys.UbiquitousContentURL(), new NSString(ubiquitousContentURL));
+        return this;
+    }
+    /**
+     * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    public String getUbiquitousPeerToken() {
+        if (has(Keys.UbiquitousPeerToken())) {
+            NSString val = (NSString) get(Keys.UbiquitousPeerToken());
+            return val.toString();
+        }
+        return null;
+    }
+    /**
+     * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    public NSPersistentStoreOptions setUbiquitousPeerToken(String ubiquitousPeerToken) {
+        set(Keys.UbiquitousPeerToken(), new NSString(ubiquitousPeerToken));
+        return this;
+    }
+    /**
+     * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    public boolean shouldRemoveUbiquitousMetadata() {
+        if (has(Keys.RemoveUbiquitousMetadata())) {
+            NSNumber val = (NSNumber) get(Keys.RemoveUbiquitousMetadata());
+            return val.booleanValue();
+        }
+        return false;
+    }
+    /**
+     * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    public NSPersistentStoreOptions setShouldRemoveUbiquitousMetadata(boolean shouldRemoveUbiquitousMetadata) {
+        set(Keys.RemoveUbiquitousMetadata(), NSNumber.valueOf(shouldRemoveUbiquitousMetadata));
+        return this;
+    }
+    /**
+     * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    public String getUbiquitousContainerIdentifier() {
+        if (has(Keys.UbiquitousContainerIdentifier())) {
+            NSString val = (NSString) get(Keys.UbiquitousContainerIdentifier());
+            return val.toString();
+        }
+        return null;
+    }
+    /**
+     * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    public NSPersistentStoreOptions setUbiquitousContainerIdentifier(String ubiquitousContainerIdentifier) {
+        set(Keys.UbiquitousContainerIdentifier(), new NSString(ubiquitousContainerIdentifier));
+        return this;
+    }
+    /**
+     * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    public boolean shouldRebuildFromUbiquitousContent() {
+        if (has(Keys.RebuildFromUbiquitousContent())) {
+            NSNumber val = (NSNumber) get(Keys.RebuildFromUbiquitousContent());
+            return val.booleanValue();
+        }
+        return false;
+    }
+    /**
+     * @since Available in iOS 7.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
+     */
+    @Deprecated
+    public NSPersistentStoreOptions setShouldRebuildFromUbiquitousContent(boolean shouldRebuildFromUbiquitousContent) {
+        set(Keys.RebuildFromUbiquitousContent(), NSNumber.valueOf(shouldRebuildFromUbiquitousContent));
         return this;
     }
     /*</methods>*/
@@ -425,35 +449,10 @@ import org.robovm.apple.foundation.*;
         @GlobalValue(symbol="NSInferMappingModelAutomaticallyOption", optional=true)
         public static native NSString InferMappingModelAutomatically();
         /**
-         * @since Available in iOS 5.0 and later.
+         * @since Available in iOS 10.0 and later.
          */
-        @GlobalValue(symbol="NSPersistentStoreUbiquitousContentNameKey", optional=true)
-        public static native NSString UbiquitousContentName();
-        /**
-         * @since Available in iOS 5.0 and later.
-         */
-        @GlobalValue(symbol="NSPersistentStoreUbiquitousContentURLKey", optional=true)
-        public static native NSString UbiquitousContentURL();
-        /**
-         * @since Available in iOS 7.0 and later.
-         */
-        @GlobalValue(symbol="NSPersistentStoreUbiquitousPeerTokenOption", optional=true)
-        public static native NSString UbiquitousPeerToken();
-        /**
-         * @since Available in iOS 7.0 and later.
-         */
-        @GlobalValue(symbol="NSPersistentStoreRemoveUbiquitousMetadataOption", optional=true)
-        public static native NSString RemoveUbiquitousMetadata();
-        /**
-         * @since Available in iOS 7.0 and later.
-         */
-        @GlobalValue(symbol="NSPersistentStoreUbiquitousContainerIdentifierKey", optional=true)
-        public static native NSString UbiquitousContainerIdentifier();
-        /**
-         * @since Available in iOS 7.0 and later.
-         */
-        @GlobalValue(symbol="NSPersistentStoreRebuildFromUbiquitousContentOption", optional=true)
-        public static native NSString RebuildFromUbiquitousContent();
+        @GlobalValue(symbol="NSPersistentStoreConnectionPoolMaxSizeKey", optional=true)
+        public static native NSString ConnectionPoolMaxSize();
         /**
          * @since Available in iOS 6.0 and later.
          */
@@ -464,6 +463,48 @@ import org.robovm.apple.foundation.*;
          */
         @GlobalValue(symbol="NSPersistentStoreFileProtectionKey", optional=true)
         public static native NSString FileProtection();
+        /**
+         * @since Available in iOS 5.0 and later.
+         * @deprecated Deprecated in iOS 10.0.
+         */
+        @Deprecated
+        @GlobalValue(symbol="NSPersistentStoreUbiquitousContentNameKey", optional=true)
+        public static native NSString UbiquitousContentName();
+        /**
+         * @since Available in iOS 5.0 and later.
+         * @deprecated Deprecated in iOS 10.0.
+         */
+        @Deprecated
+        @GlobalValue(symbol="NSPersistentStoreUbiquitousContentURLKey", optional=true)
+        public static native NSString UbiquitousContentURL();
+        /**
+         * @since Available in iOS 7.0 and later.
+         * @deprecated Deprecated in iOS 10.0.
+         */
+        @Deprecated
+        @GlobalValue(symbol="NSPersistentStoreUbiquitousPeerTokenOption", optional=true)
+        public static native NSString UbiquitousPeerToken();
+        /**
+         * @since Available in iOS 7.0 and later.
+         * @deprecated Deprecated in iOS 10.0.
+         */
+        @Deprecated
+        @GlobalValue(symbol="NSPersistentStoreRemoveUbiquitousMetadataOption", optional=true)
+        public static native NSString RemoveUbiquitousMetadata();
+        /**
+         * @since Available in iOS 7.0 and later.
+         * @deprecated Deprecated in iOS 10.0.
+         */
+        @Deprecated
+        @GlobalValue(symbol="NSPersistentStoreUbiquitousContainerIdentifierKey", optional=true)
+        public static native NSString UbiquitousContainerIdentifier();
+        /**
+         * @since Available in iOS 7.0 and later.
+         * @deprecated Deprecated in iOS 10.0.
+         */
+        @Deprecated
+        @GlobalValue(symbol="NSPersistentStoreRebuildFromUbiquitousContentOption", optional=true)
+        public static native NSString RebuildFromUbiquitousContent();
     }
     /*</keys>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreRequest.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreRequest.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSPersistentStoreRequest() {}
+    protected NSPersistentStoreRequest(Handle h, long handle) { super(h, handle); }
     protected NSPersistentStoreRequest(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreResult.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreResult.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSPersistentStoreResult() {}
+    protected NSPersistentStoreResult(Handle h, long handle) { super(h, handle); }
     protected NSPersistentStoreResult(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreUbiquitousTransitionType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPersistentStoreUbiquitousTransitionType.java
@@ -33,7 +33,9 @@ import org.robovm.apple.foundation.*;
 /*<javadoc>*/
 /**
  * @since Available in iOS 7.0 and later.
+ * @deprecated Deprecated in iOS 10.0.
  */
+@Deprecated
 /*</javadoc>*/
 /*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedUIntMarshaler.class)/*</annotations>*/
 public enum /*<name>*/NSPersistentStoreUbiquitousTransitionType/*</name>*/ implements ValuedEnum {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPropertyDescription.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSPropertyDescription.java
@@ -45,8 +45,10 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSPropertyDescription() {}
+    protected NSPropertyDescription(Handle h, long handle) { super(h, handle); }
     protected NSPropertyDescription(SkipInit skipInit) { super(skipInit); }
-    public NSPropertyDescription(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    @Method(selector = "initWithCoder:")
+    public NSPropertyDescription(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "entity")
@@ -134,6 +136,6 @@ import org.robovm.apple.foundation.*;
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder coder);
     @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected native @Pointer long init(NSCoder decoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSQueryGenerationToken.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSQueryGenerationToken.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2013-2015 RoboVM AB
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,35 +32,25 @@ import org.robovm.apple.foundation.*;
 
 /*<javadoc>*/
 /**
- * @since Available in iOS 3.0 and later.
+ * @since Available in iOS 10.0 and later.
  */
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreData") @NativeClass/*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class /*<name>*/NSPropertyMapping/*</name>*/ 
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/NSQueryGenerationToken/*</name>*/ 
     extends /*<extends>*/NSObject/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 
-    /*<ptr>*/public static class NSPropertyMappingPtr extends Ptr<NSPropertyMapping, NSPropertyMappingPtr> {}/*</ptr>*/
-    /*<bind>*/static { ObjCRuntime.bind(NSPropertyMapping.class); }/*</bind>*/
+    /*<ptr>*/public static class NSQueryGenerationTokenPtr extends Ptr<NSQueryGenerationToken, NSQueryGenerationTokenPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(NSQueryGenerationToken.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public NSPropertyMapping() {}
-    protected NSPropertyMapping(Handle h, long handle) { super(h, handle); }
-    protected NSPropertyMapping(SkipInit skipInit) { super(skipInit); }
+    public NSQueryGenerationToken() {}
+    protected NSQueryGenerationToken(Handle h, long handle) { super(h, handle); }
+    protected NSQueryGenerationToken(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
-    @Property(selector = "name")
-    public native String getName();
-    @Property(selector = "setName:")
-    public native void setName(String v);
-    @Property(selector = "valueExpression")
-    public native NSExpression getValueExpression();
-    @Property(selector = "setValueExpression:")
-    public native void setValueExpression(NSExpression v);
-    @Property(selector = "userInfo")
-    public native NSDictionary<?, ?> getUserInfo();
-    @Property(selector = "setUserInfo:")
-    public native void setUserInfo(NSDictionary<?, ?> v);
+    @Property(selector = "currentQueryGenerationToken")
+    public static native NSQueryGenerationToken getCurrentQueryGenerationToken();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSRelationshipDescription.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSRelationshipDescription.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSRelationshipDescription() {}
+    protected NSRelationshipDescription(Handle h, long handle) { super(h, handle); }
     protected NSRelationshipDescription(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSSaveChangesRequest.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coredata/NSSaveChangesRequest.java
@@ -45,7 +45,9 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public NSSaveChangesRequest() {}
+    protected NSSaveChangesRequest(Handle h, long handle) { super(h, handle); }
     protected NSSaveChangesRequest(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithInsertedObjects:updatedObjects:deletedObjects:lockedObjects:")
     public NSSaveChangesRequest(NSSet<NSManagedObject> insertedObjects, NSSet<NSManagedObject> updatedObjects, NSSet<NSManagedObject> deletedObjects, NSSet<NSManagedObject> lockedObjects) { super((SkipInit) null); initObject(init(insertedObjects, updatedObjects, deletedObjects, lockedObjects)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFDateFormatter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFDateFormatter.java
@@ -81,6 +81,11 @@ import org.robovm.apple.coretext.*;
     private static native @org.robovm.rt.bro.annotation.Marshaler(CFString.AsStringNoRetainMarshaler.class) String getDateFormat(CFAllocator allocator, String tmplate, @MachineSizedUInt long options, CFLocale locale);
     @Bridge(symbol="CFDateFormatterGetTypeID", optional=true)
     public static native @MachineSizedUInt long getClassTypeID();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Bridge(symbol="CFDateFormatterCreateISO8601Formatter", optional=true)
+    public static native CFDateFormatter createISO8601Formatter(CFAllocator allocator, CFISO8601DateFormatOptions formatOptions);
     @Bridge(symbol="CFDateFormatterCreate", optional=true)
     public static native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) CFDateFormatter create(CFAllocator allocator, CFLocale locale, CFDateFormatterStyle dateStyle, CFDateFormatterStyle timeStyle);
     @Bridge(symbol="CFDateFormatterGetLocale", optional=true)

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFISO8601DateFormatOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFISO8601DateFormatOptions.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.corefoundation;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.dispatch.*;
+import org.robovm.apple.coreservices.*;
+import org.robovm.apple.coremedia.*;
+import org.robovm.apple.uikit.*;
+import org.robovm.apple.coretext.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/CFISO8601DateFormatOptions/*</name>*/ 
+    extends /*<extends>*/CocoaUtility/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*/
+    public static final long Year = 1L;
+    public static final long Month = 2L;
+    public static final long WeekOfYear = 4L;
+    public static final long Day = 16L;
+    public static final long Time = 32L;
+    public static final long TimeZone = 64L;
+    public static final long SpaceBetweenDateAndTime = 128L;
+    public static final long DashSeparatorInDate = 256L;
+    public static final long ColonSeparatorInTime = 512L;
+    public static final long ColonSeparatorInTimeZone = 1024L;
+    public static final long FullDate = 275L;
+    public static final long FullTime = 1632L;
+    public static final long InternetDateTime = 1907L;
+    /*</constants>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*//*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*//*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFURLBookmarkCreationOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFURLBookmarkCreationOptions.java
@@ -46,8 +46,6 @@ public final class /*<name>*/CFURLBookmarkCreationOptions/*</name>*/ extends Bit
     public static final CFURLBookmarkCreationOptions None = new CFURLBookmarkCreationOptions(0L);
     public static final CFURLBookmarkCreationOptions MinimalBookmarkMask = new CFURLBookmarkCreationOptions(512L);
     public static final CFURLBookmarkCreationOptions SuitableForBookmarkFile = new CFURLBookmarkCreationOptions(1024L);
-    public static final CFURLBookmarkCreationOptions WithSecurityScope = new CFURLBookmarkCreationOptions(2048L);
-    public static final CFURLBookmarkCreationOptions SecurityScopeAllowOnlyReadAccess = new CFURLBookmarkCreationOptions(4096L);
     /**
      * @since Available in iOS 4.0 and later.
      * @deprecated Deprecated in iOS 7.0.

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFURLBookmarkResolutionOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFURLBookmarkResolutionOptions.java
@@ -46,7 +46,6 @@ public final class /*<name>*/CFURLBookmarkResolutionOptions/*</name>*/ extends B
     public static final CFURLBookmarkResolutionOptions None = new CFURLBookmarkResolutionOptions(0L);
     public static final CFURLBookmarkResolutionOptions WithoutUIMask = new CFURLBookmarkResolutionOptions(256L);
     public static final CFURLBookmarkResolutionOptions WithoutMountingMask = new CFURLBookmarkResolutionOptions(512L);
-    public static final CFURLBookmarkResolutionOptions WithSecurityScope = new CFURLBookmarkResolutionOptions(1024L);
     /*</values>*/
 
     private static final /*<name>*/CFURLBookmarkResolutionOptions/*</name>*/[] values = _values(/*<name>*/CFURLBookmarkResolutionOptions/*</name>*/.class);

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFURLFileSystemProperty.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFURLFileSystemProperty.java
@@ -177,7 +177,9 @@ import org.robovm.apple.coretext.*;
     public static final CFURLFileSystemProperty LabelNumber = new CFURLFileSystemProperty("LabelNumber");
     /**
      * @since Available in iOS 4.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     public static final CFURLFileSystemProperty LabelColor = new CFURLFileSystemProperty("LabelColor");
     /**
      * @since Available in iOS 4.0 and later.
@@ -185,11 +187,15 @@ import org.robovm.apple.coretext.*;
     public static final CFURLFileSystemProperty LocalizedLabel = new CFURLFileSystemProperty("LocalizedLabel");
     /**
      * @since Available in iOS 4.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     public static final CFURLFileSystemProperty EffectiveIcon = new CFURLFileSystemProperty("EffectiveIcon");
     /**
      * @since Available in iOS 4.0 and later.
+     * @deprecated Deprecated in iOS 10.0.
      */
+    @Deprecated
     public static final CFURLFileSystemProperty CustomIcon = new CFURLFileSystemProperty("CustomIcon");
     /**
      * @since Available in iOS 5.0 and later.
@@ -224,6 +230,10 @@ import org.robovm.apple.coretext.*;
      */
     public static final CFURLFileSystemProperty Path = new CFURLFileSystemProperty("Path");
     /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final CFURLFileSystemProperty CanonicalPath = new CFURLFileSystemProperty("CanonicalPath");
+    /**
      * @since Available in iOS 8.0 and later.
      */
     public static final CFURLFileSystemProperty GenerationIdentifier = new CFURLFileSystemProperty("GenerationIdentifier");
@@ -241,7 +251,7 @@ import org.robovm.apple.coretext.*;
     public static final CFURLFileSystemProperty FileProtection = new CFURLFileSystemProperty("FileProtection");
     /*</constants>*/
     
-    private static /*<name>*/CFURLFileSystemProperty/*</name>*/[] values = new /*<name>*/CFURLFileSystemProperty/*</name>*/[] {/*<value_list>*/Name, LocalizedName, IsRegularFile, IsDirectory, IsSymbolicLink, IsVolume, IsPackage, IsApplication, IsSystemImmutable, IsUserImmutable, IsHidden, HasHiddenExtension, CreationDate, ContentAccessDate, ContentModificationDate, AttributeModificationDate, LinkCount, ParentDirectoryURL, TypeIdentifier, LocalizedTypeDescription, LabelNumber, LabelColor, LocalizedLabel, EffectiveIcon, CustomIcon, FileResourceIdentifier, PreferredIOBlockSize, IsReadable, IsWritable, IsExecutable, FileSecurity, IsExcludedFromBackup, Path, GenerationIdentifier, DocumentIdentifier, AddedToDirectoryDate, FileProtection/*</value_list>*/};
+    private static /*<name>*/CFURLFileSystemProperty/*</name>*/[] values = new /*<name>*/CFURLFileSystemProperty/*</name>*/[] {/*<value_list>*/Name, LocalizedName, IsRegularFile, IsDirectory, IsSymbolicLink, IsVolume, IsPackage, IsApplication, IsSystemImmutable, IsUserImmutable, IsHidden, HasHiddenExtension, CreationDate, ContentAccessDate, ContentModificationDate, AttributeModificationDate, LinkCount, ParentDirectoryURL, TypeIdentifier, LocalizedTypeDescription, LabelNumber, LabelColor, LocalizedLabel, EffectiveIcon, CustomIcon, FileResourceIdentifier, PreferredIOBlockSize, IsReadable, IsWritable, IsExecutable, FileSecurity, IsExcludedFromBackup, Path, CanonicalPath, GenerationIdentifier, DocumentIdentifier, AddedToDirectoryDate, FileProtection/*</value_list>*/};
     
     /*<name>*/CFURLFileSystemProperty/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -371,7 +381,9 @@ import org.robovm.apple.coretext.*;
         public static native CFString LabelNumber();
         /**
          * @since Available in iOS 4.0 and later.
+         * @deprecated Deprecated in iOS 10.0.
          */
+        @Deprecated
         @GlobalValue(symbol="kCFURLLabelColorKey", optional=true)
         public static native CFString LabelColor();
         /**
@@ -381,12 +393,16 @@ import org.robovm.apple.coretext.*;
         public static native CFString LocalizedLabel();
         /**
          * @since Available in iOS 4.0 and later.
+         * @deprecated Deprecated in iOS 10.0.
          */
+        @Deprecated
         @GlobalValue(symbol="kCFURLEffectiveIconKey", optional=true)
         public static native CFString EffectiveIcon();
         /**
          * @since Available in iOS 4.0 and later.
+         * @deprecated Deprecated in iOS 10.0.
          */
+        @Deprecated
         @GlobalValue(symbol="kCFURLCustomIconKey", optional=true)
         public static native CFString CustomIcon();
         /**
@@ -429,6 +445,11 @@ import org.robovm.apple.coretext.*;
          */
         @GlobalValue(symbol="kCFURLPathKey", optional=true)
         public static native CFString Path();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCFURLCanonicalPathKey", optional=true)
+        public static native CFString CanonicalPath();
         /**
          * @since Available in iOS 8.0 and later.
          */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFURLVolumeProperty.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CFURLVolumeProperty.java
@@ -223,9 +223,33 @@ import org.robovm.apple.coretext.*;
      * @since Available in iOS 5.0 and later.
      */
     public static final CFURLVolumeProperty LocalizedName = new CFURLVolumeProperty("LocalizedName");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final CFURLVolumeProperty IsEncrypted = new CFURLVolumeProperty("IsEncrypted");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final CFURLVolumeProperty IsRootFileSystem = new CFURLVolumeProperty("IsRootFileSystem");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final CFURLVolumeProperty SupportsCompression = new CFURLVolumeProperty("SupportsCompression");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final CFURLVolumeProperty SupportsFileCloning = new CFURLVolumeProperty("SupportsFileCloning");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final CFURLVolumeProperty SupportsSwapRenaming = new CFURLVolumeProperty("SupportsSwapRenaming");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final CFURLVolumeProperty SupportsExclusiveRenaming = new CFURLVolumeProperty("SupportsExclusiveRenaming");
     /*</constants>*/
     
-    private static /*<name>*/CFURLVolumeProperty/*</name>*/[] values = new /*<name>*/CFURLVolumeProperty/*</name>*/[] {/*<value_list>*/URL, Identifier, LocalizedFormatDescription, TotalCapacity, AvailableCapacity, ResourceCount, SupportsPersistentIDs, SupportsSymbolicLinks, SupportsHardLinks, SupportsJournaling, IsJournaling, SupportsSparseFiles, SupportsZeroRuns, SupportsCaseSensitiveNames, SupportsCasePreservedNames, SupportsRootDirectoryDates, SupportsVolumeSizes, SupportsRenaming, SupportsAdvisoryFileLocking, SupportsExtendedSecurity, IsBrowsable, MaximumFileSize, IsEjectable, IsRemovable, IsInternal, IsAutomounted, IsLocal, IsReadOnly, CreationDate, URLForRemounting, UUIDString, Name, LocalizedName/*</value_list>*/};
+    private static /*<name>*/CFURLVolumeProperty/*</name>*/[] values = new /*<name>*/CFURLVolumeProperty/*</name>*/[] {/*<value_list>*/URL, Identifier, LocalizedFormatDescription, TotalCapacity, AvailableCapacity, ResourceCount, SupportsPersistentIDs, SupportsSymbolicLinks, SupportsHardLinks, SupportsJournaling, IsJournaling, SupportsSparseFiles, SupportsZeroRuns, SupportsCaseSensitiveNames, SupportsCasePreservedNames, SupportsRootDirectoryDates, SupportsVolumeSizes, SupportsRenaming, SupportsAdvisoryFileLocking, SupportsExtendedSecurity, IsBrowsable, MaximumFileSize, IsEjectable, IsRemovable, IsInternal, IsAutomounted, IsLocal, IsReadOnly, CreationDate, URLForRemounting, UUIDString, Name, LocalizedName, IsEncrypted, IsRootFileSystem, SupportsCompression, SupportsFileCloning, SupportsSwapRenaming, SupportsExclusiveRenaming/*</value_list>*/};
     
     /*<name>*/CFURLVolumeProperty/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -413,6 +437,36 @@ import org.robovm.apple.coretext.*;
          */
         @GlobalValue(symbol="kCFURLVolumeLocalizedNameKey", optional=true)
         public static native CFString LocalizedName();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCFURLVolumeIsEncryptedKey", optional=true)
+        public static native CFString IsEncrypted();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCFURLVolumeIsRootFileSystemKey", optional=true)
+        public static native CFString IsRootFileSystem();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCFURLVolumeSupportsCompressionKey", optional=true)
+        public static native CFString SupportsCompression();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCFURLVolumeSupportsFileCloningKey", optional=true)
+        public static native CFString SupportsFileCloning();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCFURLVolumeSupportsSwapRenamingKey", optional=true)
+        public static native CFString SupportsSwapRenaming();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCFURLVolumeSupportsExclusiveRenamingKey", optional=true)
+        public static native CFString SupportsExclusiveRenaming();
         /*</values>*/
     }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CoreFoundationVersionNumber.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corefoundation/CoreFoundationVersionNumber.java
@@ -123,6 +123,15 @@ import org.robovm.apple.coretext.*;
     public static final double VersionNumber10_10_1 = 1151.16;
     public static final int VersionNumber10_10_2 = 1152;
     public static final double VersionNumber10_10_3 = 1153.18;
+    public static final double VersionNumber10_10_4 = 1153.18;
+    public static final double VersionNumber10_10_5 = 1153.18;
+    public static final int VersionNumber10_10_Max = 1199;
+    public static final int VersionNumber10_11 = 1253;
+    public static final double VersionNumber10_11_1 = 1255.1;
+    public static final double VersionNumber10_11_2 = 1256.14;
+    public static final double VersionNumber10_11_3 = 1256.14;
+    public static final double VersionNumber10_11_4 = 1258.1;
+    public static final int VersionNumber10_11_Max = 1299;
     public static final double VersionNumber_iPhoneOS_2_0 = 478.23;
     public static final double VersionNumber_iPhoneOS_2_1 = 478.26;
     public static final double VersionNumber_iPhoneOS_2_2 = 478.29;
@@ -142,6 +151,15 @@ import org.robovm.apple.coretext.*;
     public static final double VersionNumber_iOS_8_0 = 1140.1;
     public static final double VersionNumber_iOS_8_1 = 1141.14;
     public static final double VersionNumber_iOS_8_2 = 1142.16;
+    public static final double VersionNumber_iOS_8_3 = 1144.17;
+    public static final double VersionNumber_iOS_8_4 = 1145.15;
+    public static final int VersionNumber_iOS_8_x_Max = 1199;
+    public static final double VersionNumber_iOS_9_0 = 1240.1;
+    public static final double VersionNumber_iOS_9_1 = 1241.11;
+    public static final double VersionNumber_iOS_9_2 = 1242.13;
+    public static final double VersionNumber_iOS_9_3 = 1242.13;
+    public static final double VersionNumber_iOS_9_4 = 1280.38;
+    public static final int VersionNumber_iOS_9_x_Max = 1299;
     /*</constants>*/
     /*<constructors>*//*</constructors>*/
     /*<properties>*//*</properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGBitmapInfo.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGBitmapInfo.java
@@ -42,6 +42,7 @@ public final class /*<name>*/CGBitmapInfo/*</name>*/ extends Bits</*<name>*/CGBi
     /*<values>*/
     public static final CGBitmapInfo None = new CGBitmapInfo(0L);
     public static final CGBitmapInfo AlphaInfoMask = new CGBitmapInfo(31L);
+    public static final CGBitmapInfo FloatInfoMask = new CGBitmapInfo(3840L);
     public static final CGBitmapInfo FloatComponents = new CGBitmapInfo(256L);
     public static final CGBitmapInfo ByteOrderMask = new CGBitmapInfo(28672L);
     public static final CGBitmapInfo ByteOrderDefault = new CGBitmapInfo(0L);

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGColor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGColor.java
@@ -137,6 +137,11 @@ import org.robovm.apple.uikit.*;
     @Bridge(symbol="CGColorCreateCopyWithAlpha", optional=true)
     public static native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) CGColor createCopy(CGColor color, @MachineSizedFloat double alpha);
     /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Bridge(symbol="CGColorCreateCopyByMatchingToColorSpace", optional=true)
+    public static native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) CGColor createCopy(CGColorSpace p0, CGColorRenderingIntent intent, CGColor color, NSDictionary options);
+    /**
      * @since Available in iOS 2.0 and later.
      */
     @Bridge(symbol="CGColorEqualToColor", optional=true)

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGColorConversionInfo.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGColorConversionInfo.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2013-2015 RoboVM AB
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,30 +33,32 @@ import org.robovm.apple.uikit.*;
 /*</imports>*/
 
 /*<javadoc>*/
-/**
- * @since Available in iOS 2.0 and later.
- * @deprecated Deprecated in iOS 7.0.
- */
-@Deprecated
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
-public enum /*<name>*/CGTextEncoding/*</name>*/ implements ValuedEnum {
-    /*<values>*/
-    FontSpecific(0L),
-    MacRoman(1L);
-    /*</values>*/
+/*<annotations>*/@Library("CoreGraphics")/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/CGColorConversionInfo/*</name>*/ 
+    extends /*<extends>*/CocoaUtility/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
 
-    private final long n;
-
-    private /*<name>*/CGTextEncoding/*</name>*/(long n) { this.n = n; }
-    public long value() { return n; }
-    public static /*<name>*/CGTextEncoding/*</name>*/ valueOf(long n) {
-        for (/*<name>*/CGTextEncoding/*</name>*/ v : values()) {
-            if (v.n == n) {
-                return v;
-            }
-        }
-        throw new IllegalArgumentException("No constant with value " + n + " found in " 
-            + /*<name>*/CGTextEncoding/*</name>*/.class.getName());
-    }
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/static { Bro.bind(CGColorConversionInfo.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*//*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorConversionBlackPointCompensation", optional=true)
+    public static native String BlackPointCompensation();
+    
+    @Bridge(symbol="CGColorConversionInfoGetTypeID", optional=true)
+    public static native @MachineSizedUInt long getClassTypeID();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Bridge(symbol="CGColorConversionInfoCreate", optional=true)
+    public static native CGColorConversionInfo create(CGColorSpace src, CGColorSpace dst);
+    /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGColorConversionInfoTransformType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGColorConversionInfoTransformType.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2013-2015 RoboVM AB
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,30 +33,32 @@ import org.robovm.apple.uikit.*;
 /*</imports>*/
 
 /*<javadoc>*/
-/**
- * @since Available in iOS 2.0 and later.
- * @deprecated Deprecated in iOS 7.0.
- */
-@Deprecated
+
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-public enum /*<name>*/CGTextEncoding/*</name>*/ implements ValuedEnum {
+public enum /*<name>*/CGColorConversionInfoTransformType/*</name>*/ implements ValuedEnum {
     /*<values>*/
-    FontSpecific(0L),
-    MacRoman(1L);
+    FromSpace(0L),
+    ToSpace(1L),
+    ApplySpace(2L);
     /*</values>*/
+
+    /*<bind>*/
+    /*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<methods>*//*</methods>*/
 
     private final long n;
 
-    private /*<name>*/CGTextEncoding/*</name>*/(long n) { this.n = n; }
+    private /*<name>*/CGColorConversionInfoTransformType/*</name>*/(long n) { this.n = n; }
     public long value() { return n; }
-    public static /*<name>*/CGTextEncoding/*</name>*/ valueOf(long n) {
-        for (/*<name>*/CGTextEncoding/*</name>*/ v : values()) {
+    public static /*<name>*/CGColorConversionInfoTransformType/*</name>*/ valueOf(long n) {
+        for (/*<name>*/CGColorConversionInfoTransformType/*</name>*/ v : values()) {
             if (v.n == n) {
                 return v;
             }
         }
         throw new IllegalArgumentException("No constant with value " + n + " found in " 
-            + /*<name>*/CGTextEncoding/*</name>*/.class.getName());
+            + /*<name>*/CGColorConversionInfoTransformType/*</name>*/.class.getName());
     }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGColorSpace.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGColorSpace.java
@@ -251,6 +251,107 @@ import org.robovm.apple.uikit.*;
     
     /*<methods>*/
     /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceGenericGray", optional=true)
+    public static native String GenericGray();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceGenericRGB", optional=true)
+    public static native String GenericRGB();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceGenericCMYK", optional=true)
+    public static native String GenericCMYK();
+    /**
+     * @since Available in iOS 9.3 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceDisplayP3", optional=true)
+    public static native String DisplayP3();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceGenericRGBLinear", optional=true)
+    public static native String GenericRGBLinear();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceAdobeRGB1998", optional=true)
+    public static native String AdobeRGB1998();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceSRGB", optional=true)
+    public static native String SRGB();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceGenericGrayGamma2_2", optional=true)
+    public static native String GenericGrayGamma2_2();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceGenericXYZ", optional=true)
+    public static native String GenericXYZ();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceACESCGLinear", optional=true)
+    public static native String ACESCGLinear();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceITUR_709", optional=true)
+    public static native String ITUR_709();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceITUR_2020", optional=true)
+    public static native String ITUR_2020();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceROMMRGB", optional=true)
+    public static native String ROMMRGB();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceDCIP3", optional=true)
+    public static native String DCIP3();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceExtendedSRGB", optional=true)
+    public static native String ExtendedSRGB();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceLinearSRGB", optional=true)
+    public static native String LinearSRGB();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceExtendedLinearSRGB", optional=true)
+    public static native String ExtendedLinearSRGB();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceExtendedGray", optional=true)
+    public static native String ExtendedGray();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceLinearGray", optional=true)
+    public static native String LinearGray();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="kCGColorSpaceExtendedLinearGray", optional=true)
+    public static native String ExtendedLinearGray();
+    
+    /**
      * @since Available in iOS 2.0 and later.
      */
     @Bridge(symbol="CGColorSpaceCreateDeviceGray", optional=true)
@@ -306,6 +407,11 @@ import org.robovm.apple.uikit.*;
     @Bridge(symbol="CGColorSpaceCreateWithName", optional=true)
     public static native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) CGColorSpace create(String name);
     /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Bridge(symbol="CGColorSpaceCopyName", optional=true)
+    public native @org.robovm.rt.bro.annotation.Marshaler(CFString.AsStringNoRetainMarshaler.class) String getName();
+    /**
      * @since Available in iOS 2.0 and later.
      */
     @Bridge(symbol="CGColorSpaceGetTypeID", optional=true)
@@ -335,10 +441,22 @@ import org.robovm.apple.uikit.*;
      */
     @Bridge(symbol="CGColorSpaceGetColorTable", optional=true)
     private native void getColorTable(@Pointer long table);
-    /**
-     * @since Available in iOS 6.0 and later.
-     */
     @Bridge(symbol="CGColorSpaceCopyICCProfile", optional=true)
     public native @org.robovm.rt.bro.annotation.Marshaler(NSObject.NoRetainMarshaler.class) NSData getICCProfile();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Bridge(symbol="CGColorSpaceCopyICCData", optional=true)
+    public native NSData copyICCData();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Bridge(symbol="CGColorSpaceIsWideGamutRGB", optional=true)
+    public native boolean isWideGamutRGB();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Bridge(symbol="CGColorSpaceSupportsOutput", optional=true)
+    public native boolean supportsOutput();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGContext.java
@@ -624,7 +624,7 @@ import org.robovm.apple.uikit.*;
      * @since Available in iOS 2.0 and later.
      */
     @Bridge(symbol="CGContextShowGlyphsAtPositions", optional=true)
-    private native void showGlyphsAtPositions(@Pointer long glyphs, CGPoint positions, @MachineSizedUInt long count);
+    private native void showGlyphsAtPositions(@Pointer long glyphs, CGPoint Lpositions, @MachineSizedUInt long count);
     /**
      * @since Available in iOS 2.0 and later.
      */
@@ -699,7 +699,7 @@ import org.robovm.apple.uikit.*;
      * @since Available in iOS 2.0 and later.
      */
     @Bridge(symbol="CGContextBeginTransparencyLayerWithRect", optional=true)
-    public native void beginTransparencyLayer(@ByVal CGRect rect, NSDictionary auxiliaryInfo);
+    public native void beginTransparencyLayer(@ByVal CGRect rect, NSDictionary auxInfo);
     /**
      * @since Available in iOS 2.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGImage.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGImage.java
@@ -41,7 +41,13 @@ import org.robovm.apple.uikit.*;
 
     /*<ptr>*/public static class CGImagePtr extends Ptr<CGImage, CGImagePtr> {}/*</ptr>*/
     /*<bind>*/static { Bro.bind(CGImage.class); }/*</bind>*/
-    /*<constants>*//*</constants>*/
+    /*<constants>*/
+    public static final int ByteOrderMask = 28672;
+    public static final int ByteOrder16Little = 4096;
+    public static final int ByteOrder32Little = 8192;
+    public static final int ByteOrder16Big = 12288;
+    public static final int ByteOrder32Big = 16384;
+    /*</constants>*/
     /*<constructors>*/
     protected CGImage() {}
     /*</constructors>*/
@@ -201,5 +207,10 @@ import org.robovm.apple.uikit.*;
      */
     @Bridge(symbol="CGImageGetBitmapInfo", optional=true)
     public native CGBitmapInfo getBitmapInfo();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Bridge(symbol="CGImageGetUTType", optional=true)
+    public native String getUTType();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGRect.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coregraphics/CGRect.java
@@ -333,4 +333,32 @@ import org.robovm.apple.uikit.*;
     @Bridge(symbol="CGRectApplyAffineTransform", optional=true)
     private static native @ByVal CGRect apply(@ByVal CGRect rect, @ByVal CGAffineTransform t);
     /*</methods>*/
+
+    public double getX() {
+        return this.getOrigin().getX();
+    }
+
+    public double getY() {
+        return this.getOrigin().getY();
+    }
+
+    public CGRect setX(double x) {
+         this.getOrigin().setX(x);
+         return this;
+    }
+
+    public CGRect setY(double y) {
+        this.getOrigin().setY(y);
+        return this;
+    }
+
+    public CGRect setWidth(double w) {
+        this.getSize().setWidth(w);
+        return this;
+    }
+
+    public CGRect setHeight(double h) {
+        this.getSize().setHeight(h);
+        return this;
+    }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIColor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIColor.java
@@ -34,46 +34,74 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 5.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreImage") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CIColor/*</name>*/ 
     extends /*<extends>*/NSObject/*</extends>*/ 
-    /*<implements>*/implements NSCoding/*</implements>*/ {
+    /*<implements>*//*</implements>*/ {
 
     /*<ptr>*/public static class CIColorPtr extends Ptr<CIColor, CIColorPtr> {}/*</ptr>*/
     /*<bind>*/static { ObjCRuntime.bind(CIColor.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CIColor() {}
+    protected CIColor(Handle h, long handle) { super(h, handle); }
     protected CIColor(SkipInit skipInit) { super(skipInit); }
-    public CIColor(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "initWithRed:green:blue:alpha:colorSpace:")
+    public CIColor(@MachineSizedFloat double r, @MachineSizedFloat double g, @MachineSizedFloat double b, @MachineSizedFloat double a, CGColorSpace colorSpace) { super((SkipInit) null); initObject(init(r, g, b, a, colorSpace)); }
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "initWithRed:green:blue:colorSpace:")
+    public CIColor(@MachineSizedFloat double r, @MachineSizedFloat double g, @MachineSizedFloat double b, CGColorSpace colorSpace) { super((SkipInit) null); initObject(init(r, g, b, colorSpace)); }
     /*</constructors>*/
     
     public CIColor(double r, double g, double b, double a) {
-        super(init(r, g, b, a));
+        super((Handle)null, create(r, g, b, a));
     }
     public CIColor(double r, double g, double b) {
-        super(init(r, g, b));
+        super((Handle)null, create(r, g, b));
     }
     public CIColor(String representation) {
-        super(init(representation));
+        super((Handle)null, create(representation));
     }
     
     /*<properties>*/
-    
+    @Property(selector = "numberOfComponents")
+    public native @MachineSizedUInt long getNumberOfComponents();
+    @Property(selector = "components")
+    protected native MachineSizedFloatPtr getComponents();
+    @Property(selector = "alpha")
+    public native @MachineSizedFloat double getAlpha();
+    @Property(selector = "colorSpace")
+    public native CGColorSpace getColorSpace();
+    @Property(selector = "red")
+    public native @MachineSizedFloat double getRed();
+    @Property(selector = "green")
+    public native @MachineSizedFloat double getGreen();
+    @Property(selector = "blue")
+    public native @MachineSizedFloat double getBlue();
+    @Property(selector = "stringRepresentation")
+    public native String getStringRepresentation();
     /*</properties>*/
     /*<members>*//*</members>*/
     
     public double[] getComponentsD() {
-        return components().toDoubleArray((int) getNumberOfComponents());
+        return getComponents().toDoubleArray((int) getNumberOfComponents());
     }
 
     public float[] getComponentsF() {
-        return components().toFloatArray((int) getNumberOfComponents());
+        return getComponents().toFloatArray((int) getNumberOfComponents());
     }
 
     /* UIKit extensions */
@@ -83,33 +111,83 @@ import org.robovm.apple.uikit.*;
     }
     
     /*<methods>*/
-    @Method(selector = "numberOfComponents")
-    public native @MachineSizedUInt long getNumberOfComponents();
-    @Method(selector = "components")
-    protected native MachineSizedFloatPtr components();
-    @Method(selector = "alpha")
-    public native @MachineSizedFloat double getAlpha();
-    @Method(selector = "colorSpace")
-    public native CGColorSpace getColorSpace();
-    @Method(selector = "red")
-    public native @MachineSizedFloat double getRed();
-    @Method(selector = "green")
-    public native @MachineSizedFloat double getGreen();
-    @Method(selector = "blue")
-    public native @MachineSizedFloat double getBlue();
-    @Method(selector = "stringRepresentation")
-    public native String getStringRepresentation();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "initWithRed:green:blue:alpha:colorSpace:")
+    protected native @Pointer long init(@MachineSizedFloat double r, @MachineSizedFloat double g, @MachineSizedFloat double b, @MachineSizedFloat double a, CGColorSpace colorSpace);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "initWithRed:green:blue:colorSpace:")
+    protected native @Pointer long init(@MachineSizedFloat double r, @MachineSizedFloat double g, @MachineSizedFloat double b, CGColorSpace colorSpace);
     @Method(selector = "colorWithCGColor:")
-    protected static native @Pointer long init(CGColor c);
+    protected static native @Pointer long create(CGColor c);
     @Method(selector = "colorWithRed:green:blue:alpha:")
-    protected static native @Pointer long init(@MachineSizedFloat double r, @MachineSizedFloat double g, @MachineSizedFloat double b, @MachineSizedFloat double a);
+    protected static native @Pointer long create(@MachineSizedFloat double r, @MachineSizedFloat double g, @MachineSizedFloat double b, @MachineSizedFloat double a);
     @Method(selector = "colorWithRed:green:blue:")
-    protected static native @Pointer long init(@MachineSizedFloat double r, @MachineSizedFloat double g, @MachineSizedFloat double b);
+    protected static native @Pointer long create(@MachineSizedFloat double r, @MachineSizedFloat double g, @MachineSizedFloat double b);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "colorWithRed:green:blue:alpha:colorSpace:")
+    protected static native @Pointer long create(@MachineSizedFloat double r, @MachineSizedFloat double g, @MachineSizedFloat double b, @MachineSizedFloat double a, CGColorSpace colorSpace);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "colorWithRed:green:blue:colorSpace:")
+    protected static native @Pointer long create(@MachineSizedFloat double r, @MachineSizedFloat double g, @MachineSizedFloat double b, CGColorSpace colorSpace);
     @Method(selector = "colorWithString:")
-    protected static native @Pointer long init(String representation);
-    @Method(selector = "encodeWithCoder:")
-    public native void encode(NSCoder coder);
-    @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    protected static native @Pointer long create(String representation);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "blackColor")
+    public static native CIColor blackColor();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "whiteColor")
+    public static native CIColor whiteColor();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "grayColor")
+    public static native CIColor grayColor();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "redColor")
+    public static native CIColor redColor();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "greenColor")
+    public static native CIColor greenColor();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "blueColor")
+    public static native CIColor blueColor();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "cyanColor")
+    public static native CIColor cyanColor();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "magentaColor")
+    public static native CIColor magentaColor();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "yellowColor")
+    public static native CIColor yellowColor();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "clearColor")
+    public static native CIColor clearColor();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIColorKernel.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIColorKernel.java
@@ -34,10 +34,13 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 8.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreImage") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CIColorKernel/*</name>*/ 
@@ -49,6 +52,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CIColorKernel() {}
+    protected CIColorKernel(Handle h, long handle) { super(h, handle); }
     protected CIColorKernel(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
@@ -56,9 +60,6 @@ import org.robovm.apple.uikit.*;
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
-    /**
-     * @since Available in iOS 8.0 and later.
-     */
     @Method(selector = "applyWithExtent:arguments:")
     public native CIImage apply(@ByVal CGRect extent, NSArray<?> args);
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIContext.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIContext.java
@@ -34,10 +34,13 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 5.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreImage") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CIContext/*</name>*/ 
@@ -49,42 +52,58 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CIContext() {}
+    protected CIContext(Handle h, long handle) { super(h, handle); }
     protected CIContext(SkipInit skipInit) { super(skipInit); }
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
+    @Method(selector = "initWithOptions:")
+    public CIContext(CIContextOptions options) { super((SkipInit) null); initObject(init(options)); }
     /*</constructors>*/
     
-    public CIContext(CIContextOptions options) {
-        super(init(options));
-    }
     public CIContext(EAGLContext eaglContext) {
-        super(init(eaglContext));
+        super((Handle)null, create(eaglContext));
     }
     public CIContext(EAGLContext eaglContext, CIContextOptions options) {
-        super(init(eaglContext, options));
+        super((Handle)null, create(eaglContext, options));
     }
     
     /*<properties>*/
-    
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "workingColorSpace")
+    public native CGColorSpace getWorkingColorSpace();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "workingFormat")
+    public native int getWorkingFormat();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
     /**
      * @since Available in iOS 5.0 and later.
-     * @deprecated Deprecated in iOS 6.0.
      */
-    @Deprecated
-    @Method(selector = "drawImage:atPoint:fromRect:")
-    public native void drawImage(CIImage im, @ByVal CGPoint p, @ByVal CGRect src);
+    @Method(selector = "initWithOptions:")
+    protected native @Pointer long init(CIContextOptions options);
     @Method(selector = "drawImage:inRect:fromRect:")
-    public native void drawImage(CIImage im, @ByVal CGRect dest, @ByVal CGRect src);
+    public native void drawImage(CIImage image, @ByVal CGRect inRect, @ByVal CGRect fromRect);
     @WeaklyLinked
     @Method(selector = "createCGImage:fromRect:")
-    public native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) CGImage createCGImage(CIImage im, @ByVal CGRect r);
+    public native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) CGImage createCGImage(CIImage image, @ByVal CGRect fromRect);
     @WeaklyLinked
     @Method(selector = "createCGImage:fromRect:format:colorSpace:")
-    public native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) CGImage createCGImage(CIImage im, @ByVal CGRect r, int f, CGColorSpace cs);
+    public native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) CGImage createCGImage(CIImage image, @ByVal CGRect fromRect, int format, CGColorSpace colorSpace);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @WeaklyLinked
+    @Method(selector = "createCGImage:fromRect:format:colorSpace:deferred:")
+    public native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) CGImage createCGImage(CIImage image, @ByVal CGRect fromRect, int format, CGColorSpace colorSpace, boolean deferred);
     @WeaklyLinked
     @Method(selector = "render:toBitmap:rowBytes:bounds:format:colorSpace:")
-    public native void render(CIImage im, VoidPtr data, @MachineSizedSInt long rb, @ByVal CGRect r, int f, CGColorSpace cs);
+    public native void render(CIImage image, VoidPtr data, @MachineSizedSInt long rowBytes, @ByVal CGRect bounds, int format, CGColorSpace colorSpace);
     /**
      * @since Available in iOS 5.0 and later.
      */
@@ -96,7 +115,18 @@ import org.robovm.apple.uikit.*;
      */
     @WeaklyLinked
     @Method(selector = "render:toCVPixelBuffer:bounds:colorSpace:")
-    public native void render(CIImage image, CVPixelBuffer buffer, @ByVal CGRect r, CGColorSpace cs);
+    public native void render(CIImage image, CVPixelBuffer buffer, @ByVal CGRect bounds, CGColorSpace colorSpace);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @WeaklyLinked
+    @Method(selector = "render:toMTLTexture:commandBuffer:bounds:colorSpace:")
+    public native void render(CIImage image, MTLTexture texture, MTLCommandBuffer commandBuffer, @ByVal CGRect bounds, CGColorSpace colorSpace);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "clearCaches")
+    public native void clearCaches();
     /**
      * @since Available in iOS 5.0 and later.
      */
@@ -108,22 +138,66 @@ import org.robovm.apple.uikit.*;
     @Method(selector = "outputImageMaximumSize")
     public native @ByVal CGSize getOutputImageMaximumSize();
     /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @WeaklyLinked
+    @Method(selector = "contextWithCGContext:options:")
+    protected static native @Pointer long create(CGContext cgctx, CIContextOptions options);
+    /**
      * @since Available in iOS 5.0 and later.
      */
     @WeaklyLinked
     @Method(selector = "contextWithOptions:")
-    protected static native @Pointer long init(CIContextOptions options);
+    protected static native @Pointer long create(CIContextOptions options);
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
+    @WeaklyLinked
+    @Method(selector = "context")
+    protected static native @Pointer long create();
     /**
      * @since Available in iOS 5.0 and later.
      */
     @WeaklyLinked
     @Method(selector = "contextWithEAGLContext:")
-    protected static native @Pointer long init(EAGLContext eaglContext);
+    protected static native @Pointer long create(EAGLContext eaglContext);
     /**
      * @since Available in iOS 5.0 and later.
      */
     @WeaklyLinked
     @Method(selector = "contextWithEAGLContext:options:")
-    protected static native @Pointer long init(EAGLContext eaglContext, CIContextOptions options);
+    protected static native @Pointer long create(EAGLContext eaglContext, CIContextOptions options);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @WeaklyLinked
+    @Method(selector = "contextWithMTLDevice:")
+    protected static native @Pointer long create(MTLDevice device);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @WeaklyLinked
+    @Method(selector = "contextWithMTLDevice:options:")
+    protected static native @Pointer long create(MTLDevice device, CIContextOptions options);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "TIFFRepresentationOfImage:format:colorSpace:options:")
+    public native NSData tiffRepresentationOfImage(CIImage image, int format, CGColorSpace colorSpace, NSDictionary<?, ?> options);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "JPEGRepresentationOfImage:colorSpace:options:")
+    public native NSData jpegRepresentationOfImage(CIImage image, CGColorSpace colorSpace, NSDictionary<?, ?> options);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "writeTIFFRepresentationOfImage:toURL:format:colorSpace:options:error:")
+    public native boolean writeTIFFRepresentationOfImage(CIImage image, NSURL url, int format, CGColorSpace colorSpace, NSDictionary<?, ?> options, NSError.NSErrorPtr errorPtr);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "writeJPEGRepresentationOfImage:toURL:colorSpace:options:error:")
+    public native boolean writeJPEGRepresentationOfImage(CIImage image, NSURL url, CGColorSpace colorSpace, NSDictionary<?, ?> options, NSError.NSErrorPtr errorPtr);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIContextOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIContextOptions.java
@@ -34,6 +34,7 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -194,6 +195,21 @@ import org.robovm.apple.uikit.*;
          */
         @GlobalValue(symbol="kCIContextWorkingFormat", optional=true)
         public static native NSString WorkingFormat();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIContextHighQualityDownsample", optional=true)
+        public static native NSString HighQualityDownsample();
+        /**
+         * @since Available in iOS 7.0 and later.
+         */
+        @GlobalValue(symbol="kCIContextOutputPremultiplied", optional=true)
+        public static native NSString OutputPremultiplied();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIContextCacheIntermediates", optional=true)
+        public static native NSString CacheIntermediates();
         @GlobalValue(symbol="kCIContextUseSoftwareRenderer", optional=true)
         public static native NSString UseSoftwareRenderer();
         /**

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIDetector.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIDetector.java
@@ -34,10 +34,13 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 5.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreImage") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CIDetector/*</name>*/ 
@@ -49,6 +52,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CIDetector() {}
+    protected CIDetector(Handle h, long handle) { super(h, handle); }
     protected CIDetector(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIDetectorAccuracy.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIDetectorAccuracy.java
@@ -34,6 +34,7 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIDetectorFeatureOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIDetectorFeatureOptions.java
@@ -34,6 +34,7 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIDetectorOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIDetectorOptions.java
@@ -34,6 +34,7 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -184,6 +185,21 @@ import org.robovm.apple.uikit.*;
          */
         @GlobalValue(symbol="CIDetectorMinFeatureSize", optional=true)
         public static native NSString MinFeatureSize();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="CIDetectorMaxFeatureCount", optional=true)
+        public static native NSString MaxFeatureCount();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="CIDetectorNumberOfAngles", optional=true)
+        public static native NSString NumberOfAngles();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="CIDetectorReturnSubFeatures", optional=true)
+        public static native NSString ReturnSubFeatures();
     }
     /*</keys>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIDetectorType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIDetectorType.java
@@ -34,6 +34,7 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -105,9 +106,13 @@ import org.robovm.apple.uikit.*;
      * @since Available in iOS 8.0 and later.
      */
     public static final CIDetectorType QRCode = new CIDetectorType("QRCode");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIDetectorType Text = new CIDetectorType("Text");
     /*</constants>*/
     
-    private static /*<name>*/CIDetectorType/*</name>*/[] values = new /*<name>*/CIDetectorType/*</name>*/[] {/*<value_list>*/Face, Rectangle, QRCode/*</value_list>*/};
+    private static /*<name>*/CIDetectorType/*</name>*/[] values = new /*<name>*/CIDetectorType/*</name>*/[] {/*<value_list>*/Face, Rectangle, QRCode, Text/*</value_list>*/};
     
     /*<name>*/CIDetectorType/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -145,6 +150,11 @@ import org.robovm.apple.uikit.*;
          */
         @GlobalValue(symbol="CIDetectorTypeQRCode", optional=true)
         public static native NSString QRCode();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="CIDetectorTypeText", optional=true)
+        public static native NSString Text();
         /*</values>*/
     }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFaceFeature.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFaceFeature.java
@@ -34,10 +34,13 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 5.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreImage") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CIFaceFeature/*</name>*/ 
@@ -49,6 +52,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CIFaceFeature() {}
+    protected CIFaceFeature(Handle h, long handle) { super(h, handle); }
     protected CIFaceFeature(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFeature.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFeature.java
@@ -34,10 +34,13 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 5.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreImage") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CIFeature/*</name>*/ 
@@ -49,6 +52,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CIFeature() {}
+    protected CIFeature(Handle h, long handle) { super(h, handle); }
     protected CIFeature(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFeatureType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFeatureType.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2013-2015 RoboVM AB
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,37 +38,25 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-/**
- * @since Available in iOS 8.0 and later.
- */
 /*</javadoc>*/
-/*<annotations>*/@Library("CoreImage") @NativeClass/*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class /*<name>*/CIRectangleFeature/*</name>*/ 
-    extends /*<extends>*/CIFeature/*</extends>*/ 
+/*<annotations>*/@Library("CoreImage")/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/CIFeatureType/*</name>*/ 
+    extends /*<extends>*/CocoaUtility/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 
-    /*<ptr>*/public static class CIRectangleFeaturePtr extends Ptr<CIRectangleFeature, CIRectangleFeaturePtr> {}/*</ptr>*/
-    /*<bind>*/static { ObjCRuntime.bind(CIRectangleFeature.class); }/*</bind>*/
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/static { Bro.bind(CIFeatureType.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
-    /*<constructors>*/
-    public CIRectangleFeature() {}
-    protected CIRectangleFeature(Handle h, long handle) { super(h, handle); }
-    protected CIRectangleFeature(SkipInit skipInit) { super(skipInit); }
-    /*</constructors>*/
-    /*<properties>*/
-    @Property(selector = "bounds")
-    public native @ByVal CGRect getBounds();
-    @Property(selector = "topLeft")
-    public native @ByVal CGPoint getTopLeft();
-    @Property(selector = "topRight")
-    public native @ByVal CGPoint getTopRight();
-    @Property(selector = "bottomLeft")
-    public native @ByVal CGPoint getBottomLeft();
-    @Property(selector = "bottomRight")
-    public native @ByVal CGPoint getBottomRight();
-    /*</properties>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*//*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
-    
+    @GlobalValue(symbol="CIFeatureTypeRectangle", optional=true)
+    public static native String Rectangle();
+    @GlobalValue(symbol="CIFeatureTypeQRCode", optional=true)
+    public static native String QRCode();
+    @GlobalValue(symbol="CIFeatureTypeText", optional=true)
+    public static native String Text();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFilter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFilter.java
@@ -34,26 +34,42 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 5.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreImage") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CIFilter/*</name>*/ 
     extends /*<extends>*/NSObject/*</extends>*/ 
-    /*<implements>*/implements NSCoding/*</implements>*/ {
+    /*<implements>*//*</implements>*/ {
 
     /*<ptr>*/public static class CIFilterPtr extends Ptr<CIFilter, CIFilterPtr> {}/*</ptr>*/
     /*<bind>*/static { ObjCRuntime.bind(CIFilter.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
+    protected CIFilter(Handle h, long handle) { super(h, handle); }
     protected CIFilter(SkipInit skipInit) { super(skipInit); }
-    public CIFilter(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
     @Property(selector = "outputImage")
     public native CIImage getOutputImage();
+    @Property(selector = "name")
+    public native String getName();
+    @Property(selector = "setName:")
+    public native void setName(String v);
+    @Property(selector = "inputKeys")
+    public native NSArray<?> getInputKeys();
+    @Property(selector = "outputKeys")
+    public native NSArray<?> getOutputKeys();
+    @Property(selector = "attributes")
+    public native NSDictionary<?, ?> getAttributes();
     /*</properties>*/
     /*<members>*//*</members>*/
     
@@ -130,30 +146,44 @@ import org.robovm.apple.uikit.*;
         NSObject key3, NSObject value3, NSObject key4, NSObject value4, NSObject key5, NSObject value5, NSObject key6, NSObject value6, NSObject key7,
         NSObject value7, NSObject key8, NSObject value8, NSObject key9, NSObject value9);
     /*<methods>*/
-    /**
-     * @since Available in iOS 5.0 and later.
-     */
-    @Method(selector = "name")
-    public native String getName();
-    @Method(selector = "inputKeys")
-    public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getInputKeys();
-    @Method(selector = "outputKeys")
-    public native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getOutputKeys();
     @Method(selector = "setDefaults")
     public native void setDefaults();
-    @Method(selector = "attributes")
-    public native CIFilterAttributes getAttributes();
     @Method(selector = "filterWithName:")
     public static native CIFilter create(String name);
     /**
      * @since Available in iOS 8.0 and later.
      */
     @Method(selector = "filterWithName:withInputParameters:")
-    public static native CIFilter create(String name, CIFilterInputParameters params);
+    public static native CIFilter create(String name, NSDictionary<?, ?> params);
     @Method(selector = "filterNamesInCategory:")
     public static native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getFilterNames(CIFilterCategory category);
     @Method(selector = "filterNamesInCategories:")
     public static native @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> getFilterNames(@org.robovm.rt.bro.annotation.Marshaler(CIFilterCategory.AsListMarshaler.class) List<CIFilterCategory> categories);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "registerFilterName:constructor:classAttributes:")
+    public static native void register(String name, CIFilterConstructor anObject, NSDictionary<?, ?> attributes);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "localizedNameForFilterName:")
+    public static native String localizedNameForFilterName(String filterName);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "localizedNameForCategory:")
+    public static native String localizedNameForCategory(String category);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "localizedDescriptionForFilterName:")
+    public static native String localizedDescriptionForFilterName(String filterName);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "localizedReferenceDocumentationForFilterName:")
+    public static native NSURL localizedReferenceDocumentationForFilterName(String filterName);
     /**
      * @since Available in iOS 6.0 and later.
      */
@@ -173,9 +203,20 @@ import org.robovm.apple.uikit.*;
      */
     @Method(selector = "filterArrayFromSerializedXMP:inputImageExtent:error:")
     private static native NSArray<CIFilter> deserializeFromXMP(NSData xmpData, @ByVal CGRect extent, NSError.NSErrorPtr outError);
-    @Method(selector = "encodeWithCoder:")
-    public native void encode(NSCoder coder);
-    @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "filterWithImageURL:options:")
+    public static native CIFilter create(NSURL url, NSDictionary<?, ?> options);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "filterWithImageData:options:")
+    public static native CIFilter create(NSData data, NSDictionary<?, ?> options);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "filterWithCVPixelBuffer:properties:options:")
+    public static native CIFilter create(CVPixelBuffer pixelBuffer, NSDictionary<?, ?> properties, NSDictionary<?, ?> options);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFilterAttribute.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFilterAttribute.java
@@ -34,6 +34,7 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -183,6 +184,16 @@ import org.robovm.apple.uikit.*;
     @Library("CoreImage")
     public static class Keys {
         static { Bro.bind(Keys.class); }
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIAttributeDescription", optional=true)
+        public static native NSString Description();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIAttributeReferenceDocumentation", optional=true)
+        public static native NSString ReferenceDocumentation();
         @GlobalValue(symbol="kCIAttributeClass", optional=true)
         public static native NSString Class();
         @GlobalValue(symbol="kCIAttributeType", optional=true)

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFilterAttributeType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFilterAttributeType.java
@@ -34,6 +34,7 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -110,7 +111,18 @@ import org.robovm.apple.uikit.*;
     public static final CIFilterAttributeType Offset = new CIFilterAttributeType("Offset");
     public static final CIFilterAttributeType Position3 = new CIFilterAttributeType("Position3");
     public static final CIFilterAttributeType Rectangle = new CIFilterAttributeType("Rectangle");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFilterAttributeType OpaqueColor = new CIFilterAttributeType("OpaqueColor");
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
     public static final CIFilterAttributeType Color = new CIFilterAttributeType("Color");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFilterAttributeType Gradient = new CIFilterAttributeType("Gradient");
     /**
      * @since Available in iOS 5.0 and later.
      */
@@ -121,7 +133,7 @@ import org.robovm.apple.uikit.*;
     public static final CIFilterAttributeType Transform = new CIFilterAttributeType("Transform");
     /*</constants>*/
     
-    private static /*<name>*/CIFilterAttributeType/*</name>*/[] values = new /*<name>*/CIFilterAttributeType/*</name>*/[] {/*<value_list>*/Time, Scalar, Distance, Angle, Boolean, Integer, Count, Position, Offset, Position3, Rectangle, Color, Image, Transform/*</value_list>*/};
+    private static /*<name>*/CIFilterAttributeType/*</name>*/[] values = new /*<name>*/CIFilterAttributeType/*</name>*/[] {/*<value_list>*/Time, Scalar, Distance, Angle, Boolean, Integer, Count, Position, Offset, Position3, Rectangle, OpaqueColor, Color, Gradient, Image, Transform/*</value_list>*/};
     
     /*<name>*/CIFilterAttributeType/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -172,8 +184,21 @@ import org.robovm.apple.uikit.*;
         public static native NSString Position3();
         @GlobalValue(symbol="kCIAttributeTypeRectangle", optional=true)
         public static native NSString Rectangle();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIAttributeTypeOpaqueColor", optional=true)
+        public static native NSString OpaqueColor();
+        /**
+         * @since Available in iOS 5.0 and later.
+         */
         @GlobalValue(symbol="kCIAttributeTypeColor", optional=true)
         public static native NSString Color();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIAttributeTypeGradient", optional=true)
+        public static native NSString Gradient();
         /**
          * @since Available in iOS 5.0 and later.
          */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFilterAttributes.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFilterAttributes.java
@@ -34,6 +34,7 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -153,6 +154,16 @@ import org.robovm.apple.uikit.*;
         public static native NSString Name();
         @GlobalValue(symbol="kCIAttributeFilterDisplayName", optional=true)
         public static native NSString DisplayName();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIAttributeFilterAvailable_Mac", optional=true)
+        public static native NSString Available_Mac();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIAttributeFilterAvailable_iOS", optional=true)
+        public static native NSString Available_iOS();
         @GlobalValue(symbol="kCIAttributeFilterCategories", optional=true)
         public static native NSString Categories();
     }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFilterCategory.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFilterCategory.java
@@ -34,6 +34,7 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -116,9 +117,13 @@ import org.robovm.apple.uikit.*;
     public static final CIFilterCategory NonSquarePixels = new CIFilterCategory("NonSquarePixels");
     public static final CIFilterCategory HighDynamicRange = new CIFilterCategory("HighDynamicRange");
     public static final CIFilterCategory BuiltIn = new CIFilterCategory("BuiltIn");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFilterCategory FilterGenerator = new CIFilterCategory("FilterGenerator");
     /*</constants>*/
     
-    private static /*<name>*/CIFilterCategory/*</name>*/[] values = new /*<name>*/CIFilterCategory/*</name>*/[] {/*<value_list>*/DistortionEffect, GeometryAdjustment, CompositeOperation, HalftoneEffect, ColorAdjustment, ColorEffect, Transition, TileEffect, Generator, Reduction, Gradient, Stylize, Sharpen, Blur, Video, StillImage, Interlaced, NonSquarePixels, HighDynamicRange, BuiltIn/*</value_list>*/};
+    private static /*<name>*/CIFilterCategory/*</name>*/[] values = new /*<name>*/CIFilterCategory/*</name>*/[] {/*<value_list>*/DistortionEffect, GeometryAdjustment, CompositeOperation, HalftoneEffect, ColorAdjustment, ColorEffect, Transition, TileEffect, Generator, Reduction, Gradient, Stylize, Sharpen, Blur, Video, StillImage, Interlaced, NonSquarePixels, HighDynamicRange, BuiltIn, FilterGenerator/*</value_list>*/};
     
     /*<name>*/CIFilterCategory/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -184,6 +189,11 @@ import org.robovm.apple.uikit.*;
         public static native NSString HighDynamicRange();
         @GlobalValue(symbol="kCICategoryBuiltIn", optional=true)
         public static native NSString BuiltIn();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCICategoryFilterGenerator", optional=true)
+        public static native NSString FilterGenerator();
         /*</values>*/
     }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFilterConstructor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFilterConstructor.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2013-2015 RoboVM AB
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,37 +38,24 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-/**
- * @since Available in iOS 8.0 and later.
- */
-/*</javadoc>*/
-/*<annotations>*/@Library("CoreImage") @NativeClass/*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class /*<name>*/CIRectangleFeature/*</name>*/ 
-    extends /*<extends>*/CIFeature/*</extends>*/ 
-    /*<implements>*//*</implements>*/ {
 
-    /*<ptr>*/public static class CIRectangleFeaturePtr extends Ptr<CIRectangleFeature, CIRectangleFeaturePtr> {}/*</ptr>*/
-    /*<bind>*/static { ObjCRuntime.bind(CIRectangleFeature.class); }/*</bind>*/
+/*</javadoc>*/
+/*<annotations>*//*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/CIFilterConstructor/*</name>*/ 
+    /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/
+    /*</bind>*/
     /*<constants>*//*</constants>*/
-    /*<constructors>*/
-    public CIRectangleFeature() {}
-    protected CIRectangleFeature(Handle h, long handle) { super(h, handle); }
-    protected CIRectangleFeature(SkipInit skipInit) { super(skipInit); }
-    /*</constructors>*/
     /*<properties>*/
-    @Property(selector = "bounds")
-    public native @ByVal CGRect getBounds();
-    @Property(selector = "topLeft")
-    public native @ByVal CGPoint getTopLeft();
-    @Property(selector = "topRight")
-    public native @ByVal CGPoint getTopRight();
-    @Property(selector = "bottomLeft")
-    public native @ByVal CGPoint getBottomLeft();
-    @Property(selector = "bottomRight")
-    public native @ByVal CGPoint getBottomRight();
-    /*</properties>*/
-    /*<members>*//*</members>*/
-    /*<methods>*/
     
+    /*</properties>*/
+    /*<methods>*/
+    @Method(selector = "filterWithName:")
+    CIFilter filterWithName$(String name);
     /*</methods>*/
+    /*<adapter>*/
+    /*</adapter>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFilterInputParameters.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFilterInputParameters.java
@@ -34,6 +34,7 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -211,10 +212,170 @@ import org.robovm.apple.uikit.*;
         @GlobalValue(symbol="kCIInputImageKey", optional=true)
         public static native NSString Image();
         /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputRefractionKey", optional=true)
+        public static native NSString Refraction();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputBiasKey", optional=true)
+        public static native NSString Bias();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputWeightsKey", optional=true)
+        public static native NSString Weights();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputGradientImageKey", optional=true)
+        public static native NSString GradientImage();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputShadingImageKey", optional=true)
+        public static native NSString ShadingImage();
+        /**
          * @since Available in iOS 6.0 and later.
          */
         @GlobalValue(symbol="kCIInputVersionKey", optional=true)
         public static native NSString Version();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputAllowDraftModeKey", optional=true)
+        public static native NSString AllowDraftMode();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputDecoderVersionKey", optional=true)
+        public static native NSString DecoderVersion();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCISupportedDecoderVersionsKey", optional=true)
+        public static native String SupportedDecoderVersions();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputBaselineExposureKey", optional=true)
+        public static native NSString BaselineExposure();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputBoostKey", optional=true)
+        public static native NSString Boost();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputBoostShadowAmountKey", optional=true)
+        public static native NSString BoostShadowAmount();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputDisableGamutMapKey", optional=true)
+        public static native NSString DisableGamutMap();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputNeutralChromaticityXKey", optional=true)
+        public static native NSString NeutralChromaticityX();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputNeutralChromaticityYKey", optional=true)
+        public static native NSString NeutralChromaticityY();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputNeutralTemperatureKey", optional=true)
+        public static native NSString NeutralTemperature();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputNeutralTintKey", optional=true)
+        public static native NSString NeutralTint();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputNeutralLocationKey", optional=true)
+        public static native NSString NeutralLocation();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputScaleFactorKey", optional=true)
+        public static native NSString ScaleFactor();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputIgnoreImageOrientationKey", optional=true)
+        public static native NSString IgnoreImageOrientation();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputImageOrientationKey", optional=true)
+        public static native NSString ImageOrientation();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputEnableSharpeningKey", optional=true)
+        public static native NSString EnableSharpening();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputEnableChromaticNoiseTrackingKey", optional=true)
+        public static native NSString EnableChromaticNoiseTracking();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputNoiseReductionAmountKey", optional=true)
+        public static native NSString NoiseReductionAmount();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputEnableVendorLensCorrectionKey", optional=true)
+        public static native NSString EnableVendorLensCorrection();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputLuminanceNoiseReductionAmountKey", optional=true)
+        public static native NSString LuminanceNoiseReductionAmount();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputColorNoiseReductionAmountKey", optional=true)
+        public static native NSString ColorNoiseReductionAmount();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputNoiseReductionSharpnessAmountKey", optional=true)
+        public static native NSString NoiseReductionSharpnessAmount();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputNoiseReductionContrastAmountKey", optional=true)
+        public static native NSString NoiseReductionContrastAmount();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputNoiseReductionDetailAmountKey", optional=true)
+        public static native NSString NoiseReductionDetailAmount();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIInputLinearSpaceFilter", optional=true)
+        public static native String LinearSpaceFilter();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIOutputNativeSizeKey", optional=true)
+        public static native String NativeSize();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCIActiveKeys", optional=true)
+        public static native String ActiveKeys();
     }
     /*</keys>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFormat.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIFormat.java
@@ -34,6 +34,7 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -97,14 +98,12 @@ import org.robovm.apple.uikit.*;
      * @since Available in iOS 6.0 and later.
      */
     public static final CIFormat ARGB8 = new CIFormat("ARGB8");
-    /**
-     * @since Available in iOS 5.0 and later.
-     */
     public static final CIFormat BGRA8 = new CIFormat("BGRA8");
-    /**
-     * @since Available in iOS 5.0 and later.
-     */
     public static final CIFormat RGBA8 = new CIFormat("RGBA8");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFormat ABGR8 = new CIFormat("ABGR8");
     /**
      * @since Available in iOS 7.0 and later.
      */
@@ -113,9 +112,57 @@ import org.robovm.apple.uikit.*;
      * @since Available in iOS 6.0 and later.
      */
     public static final CIFormat RGBAh = new CIFormat("RGBAh");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFormat A8 = new CIFormat("A8");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFormat A16 = new CIFormat("A16");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFormat Ah = new CIFormat("Ah");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFormat Af = new CIFormat("Af");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFormat R8 = new CIFormat("R8");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFormat R16 = new CIFormat("R16");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFormat Rh = new CIFormat("Rh");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFormat Rf = new CIFormat("Rf");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFormat RG8 = new CIFormat("RG8");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFormat RG16 = new CIFormat("RG16");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFormat RGh = new CIFormat("RGh");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CIFormat RGf = new CIFormat("RGf");
     /*</constants>*/
     
-    private static /*<name>*/CIFormat/*</name>*/[] values = new /*<name>*/CIFormat/*</name>*/[] {/*<value_list>*/ARGB8, BGRA8, RGBA8, RGBAf, RGBAh/*</value_list>*/};
+    private static /*<name>*/CIFormat/*</name>*/[] values = new /*<name>*/CIFormat/*</name>*/[] {/*<value_list>*/ARGB8, BGRA8, RGBA8, ABGR8, RGBAf, RGBAh, A8, A16, Ah, Af, R8, R16, Rh, Rf, RG8, RG16, RGh, RGf/*</value_list>*/};
     
     /*<name>*/CIFormat/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -143,16 +190,15 @@ import org.robovm.apple.uikit.*;
          */
         @GlobalValue(symbol="kCIFormatARGB8", optional=true)
         public static native int ARGB8();
-        /**
-         * @since Available in iOS 5.0 and later.
-         */
         @GlobalValue(symbol="kCIFormatBGRA8", optional=true)
         public static native int BGRA8();
-        /**
-         * @since Available in iOS 5.0 and later.
-         */
         @GlobalValue(symbol="kCIFormatRGBA8", optional=true)
         public static native int RGBA8();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIFormatABGR8", optional=true)
+        public static native int ABGR8();
         /**
          * @since Available in iOS 7.0 and later.
          */
@@ -163,6 +209,66 @@ import org.robovm.apple.uikit.*;
          */
         @GlobalValue(symbol="kCIFormatRGBAh", optional=true)
         public static native int RGBAh();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIFormatA8", optional=true)
+        public static native int A8();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIFormatA16", optional=true)
+        public static native int A16();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIFormatAh", optional=true)
+        public static native int Ah();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIFormatAf", optional=true)
+        public static native int Af();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIFormatR8", optional=true)
+        public static native int R8();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIFormatR16", optional=true)
+        public static native int R16();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIFormatRh", optional=true)
+        public static native int Rh();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIFormatRf", optional=true)
+        public static native int Rf();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIFormatRG8", optional=true)
+        public static native int RG8();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIFormatRG16", optional=true)
+        public static native int RG16();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIFormatRGh", optional=true)
+        public static native int RGh();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIFormatRGf", optional=true)
+        public static native int RGf();
         /*</values>*/
     }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIImage.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIImage.java
@@ -34,48 +34,108 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 5.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreImage") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CIImage/*</name>*/ 
     extends /*<extends>*/NSObject/*</extends>*/ 
-    /*<implements>*/implements NSCoding/*</implements>*/ {
+    /*<implements>*//*</implements>*/ {
 
     /*<ptr>*/public static class CIImagePtr extends Ptr<CIImage, CIImagePtr> {}/*</ptr>*/
     /*<bind>*/static { ObjCRuntime.bind(CIImage.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public CIImage() {}
+    protected CIImage() {}
+    protected CIImage(Handle h, long handle) { super(h, handle); }
     protected CIImage(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCGImage:")
     public CIImage(CGImage image) { super((SkipInit) null); initObject(init(image)); }
-    public CIImage(CGImage image, CIImageOptions d) { super((SkipInit) null); initObject(init(image, d)); }
+    @Method(selector = "initWithCGImage:options:")
+    public CIImage(CGImage image, CIImageOptions options) { super((SkipInit) null); initObject(init(image, options)); }
+    @Method(selector = "initWithData:")
     public CIImage(NSData data) { super((SkipInit) null); initObject(init(data)); }
-    public CIImage(NSData data, CIImageOptions d) { super((SkipInit) null); initObject(init(data, d)); }
-    public CIImage(CIImageOptions d, @MachineSizedUInt long bpr, @ByVal CGSize size, int f, CGColorSpace c) { super((SkipInit) null); initObject(init(d, bpr, size, f, c)); }
+    @Method(selector = "initWithData:options:")
+    public CIImage(NSData data, CIImageOptions options) { super((SkipInit) null); initObject(init(data, options)); }
+    @Method(selector = "initWithBitmapData:bytesPerRow:size:format:colorSpace:")
+    public CIImage(NSData data, @MachineSizedUInt long bytesPerRow, @ByVal CGSize size, int format, CGColorSpace colorSpace) { super((SkipInit) null); initObject(init(data, bytesPerRow, size, format, colorSpace)); }
     /**
      * @since Available in iOS 6.0 and later.
      */
-    public CIImage(int name, @ByVal CGSize size, boolean flag, CGColorSpace cs) { super((SkipInit) null); initObject(init(name, size, flag, cs)); }
+    @Method(selector = "initWithTexture:size:flipped:colorSpace:")
+    public CIImage(int name, @ByVal CGSize size, boolean flipped, CGColorSpace colorSpace) { super((SkipInit) null); initObject(init(name, size, flipped, colorSpace)); }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "initWithMTLTexture:options:")
+    public CIImage(MTLTexture texture, CIImageOptions options) { super((SkipInit) null); initObject(init(texture, options)); }
+    @Method(selector = "initWithContentsOfURL:")
     public CIImage(NSURL url) { super((SkipInit) null); initObject(init(url)); }
-    public CIImage(NSURL url, CIImageOptions d) { super((SkipInit) null); initObject(init(url, d)); }
+    @Method(selector = "initWithContentsOfURL:options:")
+    public CIImage(NSURL url, CIImageOptions options) { super((SkipInit) null); initObject(init(url, options)); }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "initWithCVImageBuffer:")
+    public CIImage(CVImageBuffer imageBuffer) { super((SkipInit) null); initObject(init(imageBuffer)); }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "initWithCVImageBuffer:options:")
+    public CIImage(CVImageBuffer imageBuffer, CIImageOptions options) { super((SkipInit) null); initObject(init(imageBuffer, options)); }
     /**
      * @since Available in iOS 5.0 and later.
      */
     @WeaklyLinked
-    public CIImage(CVPixelBuffer buffer) { super((SkipInit) null); initObject(init(buffer)); }
+    @Method(selector = "initWithCVPixelBuffer:")
+    public CIImage(CVPixelBuffer pixelBuffer) { super((SkipInit) null); initObject(init(pixelBuffer)); }
     /**
      * @since Available in iOS 5.0 and later.
      */
     @WeaklyLinked
-    public CIImage(CVPixelBuffer buffer, NSDictionary dict) { super((SkipInit) null); initObject(init(buffer, dict)); }
+    @Method(selector = "initWithCVPixelBuffer:options:")
+    public CIImage(CVPixelBuffer pixelBuffer, NSDictionary<?, ?> options) { super((SkipInit) null); initObject(init(pixelBuffer, options)); }
+    @Method(selector = "initWithColor:")
     public CIImage(CIColor color) { super((SkipInit) null); initObject(init(color)); }
-    public CIImage(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "initWithImageProvider:size::format:colorSpace:options:")
+    public CIImage(NSObject p, @MachineSizedUInt long width, @MachineSizedUInt long height, int f, CGColorSpace cs, CIImageOptions options) { super((SkipInit) null); initObject(init(p, width, height, f, cs, options)); }
     /*</constructors>*/
     /*<properties>*/
-    
+    @Property(selector = "extent")
+    public native @ByVal CGRect getExtent();
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
+    @Property(selector = "properties")
+    public native NSDictionary<?, ?> getProperties();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "url")
+    public native NSURL getUrl();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Property(selector = "colorSpace")
+    public native CGColorSpace getColorSpace();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "pixelBuffer")
+    public native CVPixelBuffer getPixelBuffer();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "CGImage")
+    public native CGImage getCGImage();
     /*</properties>*/
     /*<members>*//*</members>*/
     /**
@@ -98,34 +158,49 @@ import org.robovm.apple.uikit.*;
     @Method(selector = "initWithCGImage:")
     protected native @Pointer long init(CGImage image);
     @Method(selector = "initWithCGImage:options:")
-    protected native @Pointer long init(CGImage image, CIImageOptions d);
+    protected native @Pointer long init(CGImage image, CIImageOptions options);
     @Method(selector = "initWithData:")
     protected native @Pointer long init(NSData data);
     @Method(selector = "initWithData:options:")
-    protected native @Pointer long init(NSData data, CIImageOptions d);
+    protected native @Pointer long init(NSData data, CIImageOptions options);
     @Method(selector = "initWithBitmapData:bytesPerRow:size:format:colorSpace:")
-    protected native @Pointer long init(CIImageOptions d, @MachineSizedUInt long bpr, @ByVal CGSize size, int f, CGColorSpace c);
+    protected native @Pointer long init(NSData data, @MachineSizedUInt long bytesPerRow, @ByVal CGSize size, int format, CGColorSpace colorSpace);
     /**
      * @since Available in iOS 6.0 and later.
      */
     @Method(selector = "initWithTexture:size:flipped:colorSpace:")
-    protected native @Pointer long init(int name, @ByVal CGSize size, boolean flag, CGColorSpace cs);
+    protected native @Pointer long init(int name, @ByVal CGSize size, boolean flipped, CGColorSpace colorSpace);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "initWithMTLTexture:options:")
+    protected native @Pointer long init(MTLTexture texture, CIImageOptions options);
     @Method(selector = "initWithContentsOfURL:")
     protected native @Pointer long init(NSURL url);
     @Method(selector = "initWithContentsOfURL:options:")
-    protected native @Pointer long init(NSURL url, CIImageOptions d);
+    protected native @Pointer long init(NSURL url, CIImageOptions options);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "initWithCVImageBuffer:")
+    protected native @Pointer long init(CVImageBuffer imageBuffer);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "initWithCVImageBuffer:options:")
+    protected native @Pointer long init(CVImageBuffer imageBuffer, CIImageOptions options);
     /**
      * @since Available in iOS 5.0 and later.
      */
     @WeaklyLinked
     @Method(selector = "initWithCVPixelBuffer:")
-    protected native @Pointer long init(CVPixelBuffer buffer);
+    protected native @Pointer long init(CVPixelBuffer pixelBuffer);
     /**
      * @since Available in iOS 5.0 and later.
      */
     @WeaklyLinked
     @Method(selector = "initWithCVPixelBuffer:options:")
-    protected native @Pointer long init(CVPixelBuffer buffer, NSDictionary dict);
+    protected native @Pointer long init(CVPixelBuffer pixelBuffer, NSDictionary<?, ?> options);
     @Method(selector = "initWithColor:")
     protected native @Pointer long init(CIColor color);
     @Method(selector = "imageByApplyingTransform:")
@@ -148,29 +223,62 @@ import org.robovm.apple.uikit.*;
     @Method(selector = "imageByCompositingOverImage:")
     public native CIImage newImageByCompositingOverImage(CIImage dest);
     @Method(selector = "imageByCroppingToRect:")
-    public native CIImage newImageByCroppingToRect(@ByVal CGRect r);
+    public native CIImage newImageByCroppingToRect(@ByVal CGRect rect);
     /**
      * @since Available in iOS 8.0 and later.
      */
     @Method(selector = "imageByClampingToExtent")
     public native CIImage newImageByClampingToExtent();
-    @Method(selector = "extent")
-    public native @ByVal CGRect getExtent();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "imageByClampingToRect:")
+    public native CIImage newImageByClampingToRect(@ByVal CGRect rect);
     /**
      * @since Available in iOS 8.0 and later.
      */
     @Method(selector = "imageByApplyingFilter:withInputParameters:")
     public native CIImage newImageByApplyingFilter(String filterName, CIFilterInputParameters params);
     /**
-     * @since Available in iOS 5.0 and later.
+     * @since Available in iOS 10.0 and later.
      */
-    @Method(selector = "properties")
-    public native CGImageProperties getProperties();
+    @Method(selector = "imageByColorMatchingColorSpaceToWorkingSpace:")
+    public native CIImage newImageByColorMatchingColorSpaceToWorkingSpace(CGColorSpace colorSpace);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "imageByColorMatchingWorkingSpaceToColorSpace:")
+    public native CIImage newImageByColorMatchingWorkingSpaceToColorSpace(CGColorSpace colorSpace);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "imageByPremultiplyingAlpha")
+    public native CIImage newImageByPremultiplyingAlpha();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "imageByUnpremultiplyingAlpha")
+    public native CIImage newImageByUnpremultiplyingAlpha();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "imageBySettingAlphaOneInExtent:")
+    public native CIImage newImageBySettingAlphaOneInExtent(@ByVal CGRect extent);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "imageByApplyingGaussianBlurWithSigma:")
+    public native CIImage newImageByApplyingGaussianBlurWithSigma(double sigma);
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Method(selector = "imageBySettingProperties:")
+    public native CIImage newImageBySettingProperties(NSDictionary<?, ?> properties);
     /**
      * @since Available in iOS 6.0 and later.
      */
     @Method(selector = "regionOfInterestForImage:inRect:")
-    public native @ByVal CGRect getRegionOfInterest(CIImage im, @ByVal CGRect r);
+    public native @ByVal CGRect getRegionOfInterest(CIImage image, @ByVal CGRect rect);
     @Method(selector = "emptyImage")
     public static native CIImage getEmptyImage();
     /**
@@ -182,10 +290,11 @@ import org.robovm.apple.uikit.*;
      * @since Available in iOS 5.0 and later.
      */
     @Method(selector = "autoAdjustmentFiltersWithOptions:")
-    public native NSArray<CIFilter> getAutoAdjustmentFilters(CIImageAutoAdjustOptions options);
-    @Method(selector = "encodeWithCoder:")
-    public native void encode(NSCoder coder);
-    @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
+    public native NSArray<CIFilter> getAutoAdjustmentFilters(NSDictionary<?, ?> options);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "initWithImageProvider:size::format:colorSpace:options:")
+    protected native @Pointer long init(NSObject p, @MachineSizedUInt long width, @MachineSizedUInt long height, int f, CGColorSpace cs, CIImageOptions options);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIImageAutoAdjustOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIImageAutoAdjustOptions.java
@@ -34,6 +34,7 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIImageOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIImageOptions.java
@@ -34,6 +34,7 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -155,6 +156,16 @@ import org.robovm.apple.uikit.*;
          */
         @GlobalValue(symbol="kCIImageProperties", optional=true)
         public static native CFString Properties();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIImageProviderTileSize", optional=true)
+        public static native CFString ProviderTileSize();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCIImageProviderUserInfo", optional=true)
+        public static native CFString ProviderUserInfo();
     }
     /*</keys>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIKernel.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIKernel.java
@@ -34,10 +34,13 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 8.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreImage") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CIKernel/*</name>*/ 
@@ -49,22 +52,33 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CIKernel() {}
+    protected CIKernel(Handle h, long handle) { super(h, handle); }
     protected CIKernel(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
-    
+    /**
+     * @since Available in iOS 8.0 and later.
+     */
+    @Property(selector = "name")
+    public native String getName();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
-    @Method(selector = "name")
-    public native String getName();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Method(selector = "setROISelector:")
+    public native void setROISelector(Selector method);
     /**
      * @since Available in iOS 8.0 and later.
      */
     @Method(selector = "applyWithExtent:roiCallback:arguments:")
     public native CIImage apply(@ByVal CGRect extent, @Block("@ByVal (,@ByVal)") Block2<Integer, CGRect, CGRect> callback, NSArray<?> args);
+    /**
+     * @since Available in iOS 8.0 and later.
+     */
     @Method(selector = "kernelsWithString:")
-    public static native NSArray<CIKernel> createKernels(String s);
+    public static native NSArray<CIKernel> createKernels(String string);
     /**
      * @since Available in iOS 8.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIQRCodeFeature.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIQRCodeFeature.java
@@ -34,10 +34,13 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 8.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreImage") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CIQRCodeFeature/*</name>*/ 
@@ -49,6 +52,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CIQRCodeFeature() {}
+    protected CIQRCodeFeature(Handle h, long handle) { super(h, handle); }
     protected CIQRCodeFeature(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CISamplerType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CISamplerType.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.coreimage;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.corefoundation.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.opengles.*;
+import org.robovm.apple.corevideo.*;
+import org.robovm.apple.imageio.*;
+import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
+/*</imports>*/
+
+/*<javadoc>*/
+/*</javadoc>*/
+/*<annotations>*/@Library("CoreImage")/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/CISamplerType/*</name>*/ 
+    extends /*<extends>*/CocoaUtility/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/static { Bro.bind(CISamplerType.class); }/*</bind>*/
+    /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*//*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCISamplerAffineMatrix", optional=true)
+    public static native String AffineMatrix();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCISamplerWrapMode", optional=true)
+    public static native String WrapMode();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCISamplerFilterMode", optional=true)
+    public static native String FilterMode();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCISamplerWrapBlack", optional=true)
+    public static native String WrapBlack();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCISamplerWrapClamp", optional=true)
+    public static native String WrapClamp();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCISamplerFilterNearest", optional=true)
+    public static native String FilterNearest();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCISamplerFilterLinear", optional=true)
+    public static native String FilterLinear();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCISamplerColorSpace", optional=true)
+    public static native String ColorSpace();
+    /*</methods>*/
+}

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIUIParameterSet.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIUIParameterSet.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2013-2015 RoboVM AB
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,37 +38,44 @@ import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-/**
- * @since Available in iOS 8.0 and later.
- */
 /*</javadoc>*/
-/*<annotations>*/@Library("CoreImage") @NativeClass/*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class /*<name>*/CIRectangleFeature/*</name>*/ 
-    extends /*<extends>*/CIFeature/*</extends>*/ 
+/*<annotations>*/@Library("CoreImage")/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/CIUIParameterSet/*</name>*/ 
+    extends /*<extends>*/CocoaUtility/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 
-    /*<ptr>*/public static class CIRectangleFeaturePtr extends Ptr<CIRectangleFeature, CIRectangleFeaturePtr> {}/*</ptr>*/
-    /*<bind>*/static { ObjCRuntime.bind(CIRectangleFeature.class); }/*</bind>*/
+    /*<ptr>*/
+    /*</ptr>*/
+    /*<bind>*/static { Bro.bind(CIUIParameterSet.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
-    /*<constructors>*/
-    public CIRectangleFeature() {}
-    protected CIRectangleFeature(Handle h, long handle) { super(h, handle); }
-    protected CIRectangleFeature(SkipInit skipInit) { super(skipInit); }
-    /*</constructors>*/
-    /*<properties>*/
-    @Property(selector = "bounds")
-    public native @ByVal CGRect getBounds();
-    @Property(selector = "topLeft")
-    public native @ByVal CGPoint getTopLeft();
-    @Property(selector = "topRight")
-    public native @ByVal CGPoint getTopRight();
-    @Property(selector = "bottomLeft")
-    public native @ByVal CGPoint getBottomLeft();
-    @Property(selector = "bottomRight")
-    public native @ByVal CGPoint getBottomRight();
-    /*</properties>*/
+    /*<constructors>*//*</constructors>*/
+    /*<properties>*//*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
-    
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCIUIParameterSet", optional=true)
+    public static native String Set();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCIUISetBasic", optional=true)
+    public static native String Basic();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCIUISetIntermediate", optional=true)
+    public static native String Intermediate();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCIUISetAdvanced", optional=true)
+    public static native String Advanced();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCIUISetDevelopment", optional=true)
+    public static native String Development();
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIVector.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIVector.java
@@ -34,40 +34,51 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 5.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreImage") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CIVector/*</name>*/ 
     extends /*<extends>*/NSObject/*</extends>*/ 
-    /*<implements>*/implements NSCoding/*</implements>*/ {
+    /*<implements>*//*</implements>*/ {
 
     /*<ptr>*/public static class CIVectorPtr extends Ptr<CIVector, CIVectorPtr> {}/*</ptr>*/
     /*<bind>*/static { ObjCRuntime.bind(CIVector.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CIVector() {}
+    protected CIVector(Handle h, long handle) { super(h, handle); }
     protected CIVector(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithX:")
     public CIVector(@MachineSizedFloat double x) { super((SkipInit) null); initObject(init(x)); }
+    @Method(selector = "initWithX:Y:")
     public CIVector(@MachineSizedFloat double x, @MachineSizedFloat double y) { super((SkipInit) null); initObject(init(x, y)); }
+    @Method(selector = "initWithX:Y:Z:")
     public CIVector(@MachineSizedFloat double x, @MachineSizedFloat double y, @MachineSizedFloat double z) { super((SkipInit) null); initObject(init(x, y, z)); }
+    @Method(selector = "initWithX:Y:Z:W:")
     public CIVector(@MachineSizedFloat double x, @MachineSizedFloat double y, @MachineSizedFloat double z, @MachineSizedFloat double w) { super((SkipInit) null); initObject(init(x, y, z, w)); }
     /**
      * @since Available in iOS 5.0 and later.
      */
+    @Method(selector = "initWithCGPoint:")
     public CIVector(@ByVal CGPoint p) { super((SkipInit) null); initObject(init(p)); }
     /**
      * @since Available in iOS 5.0 and later.
      */
+    @Method(selector = "initWithCGRect:")
     public CIVector(@ByVal CGRect r) { super((SkipInit) null); initObject(init(r)); }
     /**
      * @since Available in iOS 5.0 and later.
      */
+    @Method(selector = "initWithCGAffineTransform:")
     public CIVector(@ByVal CGAffineTransform r) { super((SkipInit) null); initObject(init(r)); }
+    @Method(selector = "initWithString:")
     public CIVector(String representation) { super((SkipInit) null); initObject(init(representation)); }
-    public CIVector(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
 
     public CIVector(double[] values) {
@@ -91,7 +102,33 @@ import org.robovm.apple.uikit.*;
     }
 
     /*<properties>*/
-    
+    @Property(selector = "count")
+    public native @MachineSizedUInt long getCount();
+    @Property(selector = "X")
+    public native @MachineSizedFloat double getX();
+    @Property(selector = "Y")
+    public native @MachineSizedFloat double getY();
+    @Property(selector = "Z")
+    public native @MachineSizedFloat double getZ();
+    @Property(selector = "W")
+    public native @MachineSizedFloat double getW();
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
+    @Property(selector = "CGPointValue")
+    public native @ByVal CGPoint getCGPointValue();
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
+    @Property(selector = "CGRectValue")
+    public native @ByVal CGRect getCGRectValue();
+    /**
+     * @since Available in iOS 5.0 and later.
+     */
+    @Property(selector = "CGAffineTransformValue")
+    public native @ByVal CGAffineTransform getCGAffineTransformValue();
+    @Property(selector = "stringRepresentation")
+    public native String getStringRepresentation();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
@@ -124,36 +161,5 @@ import org.robovm.apple.uikit.*;
     protected native @Pointer long init(String representation);
     @Method(selector = "valueAtIndex:")
     public native @MachineSizedFloat double getValueAtIndex(@MachineSizedUInt long index);
-    @Method(selector = "count")
-    public native @MachineSizedUInt long getCount();
-    @Method(selector = "X")
-    public native @MachineSizedFloat double getX();
-    @Method(selector = "Y")
-    public native @MachineSizedFloat double getY();
-    @Method(selector = "Z")
-    public native @MachineSizedFloat double getZ();
-    @Method(selector = "W")
-    public native @MachineSizedFloat double getW();
-    /**
-     * @since Available in iOS 5.0 and later.
-     */
-    @Method(selector = "CGPointValue")
-    public native @ByVal CGPoint getCGPointValue();
-    /**
-     * @since Available in iOS 5.0 and later.
-     */
-    @Method(selector = "CGRectValue")
-    public native @ByVal CGRect getCGRectValue();
-    /**
-     * @since Available in iOS 5.0 and later.
-     */
-    @Method(selector = "CGAffineTransformValue")
-    public native @ByVal CGAffineTransform getCGAffineTransformValue();
-    @Method(selector = "stringRepresentation")
-    public native String getStringRepresentation();
-    @Method(selector = "encodeWithCoder:")
-    public native void encode(NSCoder coder);
-    @Method(selector = "initWithCoder:")
-    protected native @Pointer long init(NSCoder aDecoder);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIWarpKernel.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreimage/CIWarpKernel.java
@@ -34,10 +34,13 @@ import org.robovm.apple.opengles.*;
 import org.robovm.apple.corevideo.*;
 import org.robovm.apple.imageio.*;
 import org.robovm.apple.uikit.*;
+import org.robovm.apple.metal.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
+/**
+ * @since Available in iOS 8.0 and later.
+ */
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreImage") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CIWarpKernel/*</name>*/ 
@@ -49,6 +52,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CIWarpKernel() {}
+    protected CIWarpKernel(Handle h, long handle) { super(h, handle); }
     protected CIWarpKernel(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
@@ -56,9 +60,6 @@ import org.robovm.apple.uikit.*;
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
-    /**
-     * @since Available in iOS 8.0 and later.
-     */
     @Method(selector = "applyWithExtent:roiCallback:inputImage:arguments:")
     public native CIImage apply(@ByVal CGRect extent, @Block("@ByVal (,@ByVal)") Block2<Integer, CGRect, CGRect> callback, CIImage image, NSArray<?> args);
     /*</methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLBeacon.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLBeacon.java
@@ -47,6 +47,7 @@ import org.robovm.apple.corebluetooth.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CLBeacon() {}
+    protected CLBeacon(Handle h, long handle) { super(h, handle); }
     protected CLBeacon(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLBeaconRegion.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLBeaconRegion.java
@@ -47,9 +47,13 @@ import org.robovm.apple.corebluetooth.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CLBeaconRegion() {}
+    protected CLBeaconRegion(Handle h, long handle) { super(h, handle); }
     protected CLBeaconRegion(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithProximityUUID:identifier:")
     public CLBeaconRegion(NSUUID proximityUUID, String identifier) { super((SkipInit) null); initObject(init(proximityUUID, identifier)); }
+    @Method(selector = "initWithProximityUUID:major:identifier:")
     public CLBeaconRegion(NSUUID proximityUUID, short major, String identifier) { super((SkipInit) null); initObject(init(proximityUUID, major, identifier)); }
+    @Method(selector = "initWithProximityUUID:major:minor:identifier:")
     public CLBeaconRegion(NSUUID proximityUUID, short major, short minor, String identifier) { super((SkipInit) null); initObject(init(proximityUUID, major, minor, identifier)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLCircularRegion.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLCircularRegion.java
@@ -47,7 +47,9 @@ import org.robovm.apple.corebluetooth.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CLCircularRegion() {}
+    protected CLCircularRegion(Handle h, long handle) { super(h, handle); }
     protected CLCircularRegion(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCenter:radius:identifier:")
     public CLCircularRegion(@ByVal CLLocationCoordinate2D center, double radius, String identifier) { super((SkipInit) null); initObject(init(center, radius, identifier)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLFloor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLFloor.java
@@ -47,6 +47,7 @@ import org.robovm.apple.corebluetooth.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CLFloor() {}
+    protected CLFloor(Handle h, long handle) { super(h, handle); }
     protected CLFloor(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLGeocoder.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLGeocoder.java
@@ -47,6 +47,7 @@ import org.robovm.apple.corebluetooth.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CLGeocoder() {}
+    protected CLGeocoder(Handle h, long handle) { super(h, handle); }
     protected CLGeocoder(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLHeading.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLHeading.java
@@ -47,6 +47,7 @@ import org.robovm.apple.corebluetooth.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CLHeading() {}
+    protected CLHeading(Handle h, long handle) { super(h, handle); }
     protected CLHeading(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLLocation.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLLocation.java
@@ -47,12 +47,16 @@ import org.robovm.apple.corebluetooth.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CLLocation() {}
+    protected CLLocation(Handle h, long handle) { super(h, handle); }
     protected CLLocation(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithLatitude:longitude:")
     public CLLocation(double latitude, double longitude) { super((SkipInit) null); initObject(init(latitude, longitude)); }
+    @Method(selector = "initWithCoordinate:altitude:horizontalAccuracy:verticalAccuracy:timestamp:")
     public CLLocation(@ByVal CLLocationCoordinate2D coordinate, double altitude, double hAccuracy, double vAccuracy, NSDate timestamp) { super((SkipInit) null); initObject(init(coordinate, altitude, hAccuracy, vAccuracy, timestamp)); }
     /**
      * @since Available in iOS 4.2 and later.
      */
+    @Method(selector = "initWithCoordinate:altitude:horizontalAccuracy:verticalAccuracy:course:speed:timestamp:")
     public CLLocation(@ByVal CLLocationCoordinate2D coordinate, double altitude, double hAccuracy, double vAccuracy, double course, double speed, NSDate timestamp) { super((SkipInit) null); initObject(init(coordinate, altitude, hAccuracy, vAccuracy, course, speed, timestamp)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLLocationManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLLocationManager.java
@@ -47,6 +47,7 @@ import org.robovm.apple.corebluetooth.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CLLocationManager() {}
+    protected CLLocationManager(Handle h, long handle) { super(h, handle); }
     protected CLLocationManager(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
@@ -54,20 +55,6 @@ import org.robovm.apple.corebluetooth.*;
     public native CLLocationManagerDelegate getDelegate();
     @Property(selector = "setDelegate:", strongRef = true)
     public native void setDelegate(CLLocationManagerDelegate v);
-    /**
-     * @since Available in iOS 3.2 and later.
-     * @deprecated Deprecated in iOS 6.0.
-     */
-    @Deprecated
-    @Property(selector = "purpose")
-    public native String getPurpose();
-    /**
-     * @since Available in iOS 3.2 and later.
-     * @deprecated Deprecated in iOS 6.0.
-     */
-    @Deprecated
-    @Property(selector = "setPurpose:")
-    public native void setPurpose(String v);
     /**
      * @since Available in iOS 6.0 and later.
      */
@@ -205,13 +192,6 @@ import org.robovm.apple.corebluetooth.*;
      */
     @Method(selector = "stopMonitoringSignificantLocationChanges")
     public native void stopMonitoringSignificantLocationChanges();
-    /**
-     * @since Available in iOS 4.0 and later.
-     * @deprecated Deprecated in iOS 6.0.
-     */
-    @Deprecated
-    @Method(selector = "startMonitoringForRegion:desiredAccuracy:")
-    public native void startMonitoring(CLRegion region, double accuracy);
     /**
      * @since Available in iOS 4.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLLocationManagerDelegate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLLocationManagerDelegate.java
@@ -49,13 +49,6 @@ import org.robovm.apple.corebluetooth.*;
     /*</properties>*/
     /*<methods>*/
     /**
-     * @since Available in iOS 2.0 and later.
-     * @deprecated Deprecated in iOS 6.0.
-     */
-    @Deprecated
-    @Method(selector = "locationManager:didUpdateToLocation:fromLocation:")
-    void didUpdateToLocation(CLLocationManager manager, CLLocation newLocation, CLLocation oldLocation);
-    /**
      * @since Available in iOS 6.0 and later.
      */
     @Method(selector = "locationManager:didUpdateLocations:")
@@ -79,7 +72,7 @@ import org.robovm.apple.corebluetooth.*;
      * @since Available in iOS 7.0 and later.
      */
     @Method(selector = "locationManager:didRangeBeacons:inRegion:")
-    void didRangeBeacons(CLLocationManager manager, NSArray<?> beacons, CLBeaconRegion region);
+    void didRangeBeacons(CLLocationManager manager, NSArray<CLBeacon> beacons, CLBeaconRegion region);
     /**
      * @since Available in iOS 7.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLLocationManagerDelegateAdapter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLLocationManagerDelegateAdapter.java
@@ -51,13 +51,6 @@ import org.robovm.apple.corebluetooth.*;
     /*<members>*//*</members>*/
     /*<methods>*/
     /**
-     * @since Available in iOS 2.0 and later.
-     * @deprecated Deprecated in iOS 6.0.
-     */
-    @Deprecated
-    @NotImplemented("locationManager:didUpdateToLocation:fromLocation:")
-    public void didUpdateToLocation(CLLocationManager manager, CLLocation newLocation, CLLocation oldLocation) {}
-    /**
      * @since Available in iOS 6.0 and later.
      */
     @NotImplemented("locationManager:didUpdateLocations:")
@@ -81,7 +74,7 @@ import org.robovm.apple.corebluetooth.*;
      * @since Available in iOS 7.0 and later.
      */
     @NotImplemented("locationManager:didRangeBeacons:inRegion:")
-    public void didRangeBeacons(CLLocationManager manager, NSArray<?> beacons, CLBeaconRegion region) {}
+    public void didRangeBeacons(CLLocationManager manager, NSArray<CLBeacon> beacons, CLBeaconRegion region) {}
     /**
      * @since Available in iOS 7.0 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLPlacemark.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLPlacemark.java
@@ -46,7 +46,9 @@ import org.robovm.apple.corebluetooth.*;
     /*<bind>*/static { ObjCRuntime.bind(CLPlacemark.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
+    protected CLPlacemark(Handle h, long handle) { super(h, handle); }
     protected CLPlacemark(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithPlacemark:")
     public CLPlacemark(CLPlacemark placemark) { super((SkipInit) null); initObject(init(placemark)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLRegion.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLRegion.java
@@ -47,12 +47,14 @@ import org.robovm.apple.corebluetooth.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CLRegion() {}
+    protected CLRegion(Handle h, long handle) { super(h, handle); }
     protected CLRegion(SkipInit skipInit) { super(skipInit); }
     /**
      * @since Available in iOS 4.0 and later.
      * @deprecated Deprecated in iOS 7.0.
      */
     @Deprecated
+    @Method(selector = "initCircularRegionWithCenter:radius:identifier:")
     public CLRegion(@ByVal CLLocationCoordinate2D center, double radius, String identifier) { super((SkipInit) null); initObject(init(center, radius, identifier)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLVisit.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corelocation/CLVisit.java
@@ -47,6 +47,7 @@ import org.robovm.apple.corebluetooth.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CLVisit() {}
+    protected CLVisit(Handle h, long handle) { super(h, handle); }
     protected CLVisit(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMBufferQueueTriggerCondition.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMBufferQueueTriggerCondition.java
@@ -52,7 +52,8 @@ public enum /*<name>*/CMBufferQueueTriggerCondition/*</name>*/ implements Valued
     WhenEndOfDataReached(8L),
     WhenReset(9L),
     WhenBufferCountBecomesLessThan(10L),
-    WhenBufferCountBecomesGreaterThan(11L);
+    WhenBufferCountBecomesGreaterThan(11L),
+    WhenDurationBecomesGreaterThanOrEqualToAndBufferCountBecomesGreaterThan(12L);
     /*</values>*/
 
     /*<bind>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMMetadataBaseDataType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMMetadataBaseDataType.java
@@ -177,6 +177,18 @@ import org.robovm.apple.audiotoolbox.*;
      */
     public static final CMMetadataBaseDataType AffineTransformF64 = new CMMetadataBaseDataType("AffineTransformF64");
     /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CMMetadataBaseDataType PolygonF32 = new CMMetadataBaseDataType("PolygonF32");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CMMetadataBaseDataType PolylineF32 = new CMMetadataBaseDataType("PolylineF32");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CMMetadataBaseDataType JSON = new CMMetadataBaseDataType("JSON");
+    /**
      * @since Available in iOS 8.0 and later.
      */
     public static final CMMetadataBaseDataType QuickTimeMetadataLocation_ISO6709 = new CMMetadataBaseDataType("QuickTimeMetadataLocation_ISO6709");
@@ -186,7 +198,7 @@ import org.robovm.apple.audiotoolbox.*;
     public static final CMMetadataBaseDataType QuickTimeMetadataDirection = new CMMetadataBaseDataType("QuickTimeMetadataDirection");
     /*</constants>*/
     
-    private static /*<name>*/CMMetadataBaseDataType/*</name>*/[] values = new /*<name>*/CMMetadataBaseDataType/*</name>*/[] {/*<value_list>*/RawData, UTF8, UTF16, GIF, JPEG, PNG, BMP, Float32, Float64, SInt8, SInt16, SInt32, SInt64, UInt8, UInt16, UInt32, UInt64, PointF32, DimensionsF32, RectF32, AffineTransformF64, QuickTimeMetadataLocation_ISO6709, QuickTimeMetadataDirection/*</value_list>*/};
+    private static /*<name>*/CMMetadataBaseDataType/*</name>*/[] values = new /*<name>*/CMMetadataBaseDataType/*</name>*/[] {/*<value_list>*/RawData, UTF8, UTF16, GIF, JPEG, PNG, BMP, Float32, Float64, SInt8, SInt16, SInt32, SInt64, UInt8, UInt16, UInt32, UInt64, PointF32, DimensionsF32, RectF32, AffineTransformF64, PolygonF32, PolylineF32, JSON, QuickTimeMetadataLocation_ISO6709, QuickTimeMetadataDirection/*</value_list>*/};
     
     /*<name>*/CMMetadataBaseDataType/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -314,6 +326,21 @@ import org.robovm.apple.audiotoolbox.*;
          */
         @GlobalValue(symbol="kCMMetadataBaseDataType_AffineTransformF64", optional=true)
         public static native CFString AffineTransformF64();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMMetadataBaseDataType_PolygonF32", optional=true)
+        public static native CFString PolygonF32();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMMetadataBaseDataType_PolylineF32", optional=true)
+        public static native CFString PolylineF32();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMMetadataBaseDataType_JSON", optional=true)
+        public static native CFString JSON();
         /**
          * @since Available in iOS 8.0 and later.
          */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMMetadataFormatDescriptionKey.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMMetadataFormatDescriptionKey.java
@@ -272,6 +272,16 @@ import org.robovm.apple.audiotoolbox.*;
          */
         @GlobalValue(symbol="kCMMetadataFormatDescriptionKey_LanguageTag", optional=true)
         public static native CFString LanguageTag();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMMetadataFormatDescriptionKey_StructuralDependency", optional=true)
+        public static native CFString StructuralDependency();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMMetadataFormatDescriptionKey_SetupData", optional=true)
+        public static native CFString SetupData();
     }
     /*</keys>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMMetadataFormatDescriptionMetadataSpecification.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMMetadataFormatDescriptionMetadataSpecification.java
@@ -184,6 +184,16 @@ import org.robovm.apple.audiotoolbox.*;
          */
         @GlobalValue(symbol="kCMMetadataFormatDescriptionMetadataSpecificationKey_ExtendedLanguageTag", optional=true)
         public static native CFString ExtendedLanguageTag();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMMetadataFormatDescriptionMetadataSpecificationKey_StructuralDependency", optional=true)
+        public static native CFString StructuralDependency();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMMetadataFormatDescriptionMetadataSpecificationKey_SetupData", optional=true)
+        public static native CFString SetupData();
     }
     /*</keys>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMMetadataIdentifier.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMMetadataIdentifier.java
@@ -104,9 +104,13 @@ import org.robovm.apple.audiotoolbox.*;
      * @since Available in iOS 8.0 and later.
      */
     public static final CMMetadataIdentifier QuickTimeMetadataPreferredAffineTransform = new CMMetadataIdentifier("QuickTimeMetadataPreferredAffineTransform");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CMMetadataIdentifier QuickTimeMetadataVideoOrientation = new CMMetadataIdentifier("QuickTimeMetadataVideoOrientation");
     /*</constants>*/
     
-    private static /*<name>*/CMMetadataIdentifier/*</name>*/[] values = new /*<name>*/CMMetadataIdentifier/*</name>*/[] {/*<value_list>*/QuickTimeMetadataLocation_ISO6709, QuickTimeMetadataDirection_Facing, QuickTimeMetadataPreferredAffineTransform/*</value_list>*/};
+    private static /*<name>*/CMMetadataIdentifier/*</name>*/[] values = new /*<name>*/CMMetadataIdentifier/*</name>*/[] {/*<value_list>*/QuickTimeMetadataLocation_ISO6709, QuickTimeMetadataDirection_Facing, QuickTimeMetadataPreferredAffineTransform, QuickTimeMetadataVideoOrientation/*</value_list>*/};
     
     /*<name>*/CMMetadataIdentifier/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -243,6 +247,11 @@ import org.robovm.apple.audiotoolbox.*;
          */
         @GlobalValue(symbol="kCMMetadataIdentifier_QuickTimeMetadataPreferredAffineTransform", optional=true)
         public static native CFString QuickTimeMetadataPreferredAffineTransform();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMMetadataIdentifier_QuickTimeMetadataVideoOrientation", optional=true)
+        public static native CFString QuickTimeMetadataVideoOrientation();
         /*</values>*/
     }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMMetadataKeySpace.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMMetadataKeySpace.java
@@ -114,9 +114,13 @@ import org.robovm.apple.audiotoolbox.*;
      * @since Available in iOS 8.0 and later.
      */
     public static final CMMetadataKeySpace Icy = new CMMetadataKeySpace("Icy");
+    /**
+     * @since Available in iOS 9.3 and later.
+     */
+    public static final CMMetadataKeySpace HLSDateRange = new CMMetadataKeySpace("HLSDateRange");
     /*</constants>*/
     
-    private static /*<name>*/CMMetadataKeySpace/*</name>*/[] values = new /*<name>*/CMMetadataKeySpace/*</name>*/[] {/*<value_list>*/QuickTimeUserData, ISOUserData, QuickTimeMetadata, iTunes, ID3, Icy/*</value_list>*/};
+    private static /*<name>*/CMMetadataKeySpace/*</name>*/[] values = new /*<name>*/CMMetadataKeySpace/*</name>*/[] {/*<value_list>*/QuickTimeUserData, ISOUserData, QuickTimeMetadata, iTunes, ID3, Icy, HLSDateRange/*</value_list>*/};
     
     /*<name>*/CMMetadataKeySpace/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -169,6 +173,11 @@ import org.robovm.apple.audiotoolbox.*;
          */
         @GlobalValue(symbol="kCMMetadataKeySpace_Icy", optional=true)
         public static native CFString Icy();
+        /**
+         * @since Available in iOS 9.3 and later.
+         */
+        @GlobalValue(symbol="kCMMetadataKeySpace_HLSDateRange", optional=true)
+        public static native CFString HLSDateRange();
         /*</values>*/
     }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMSampleBufferAttachmentKey.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMSampleBufferAttachmentKey.java
@@ -167,12 +167,16 @@ import org.robovm.apple.audiotoolbox.*;
      */
     public static final CMSampleBufferAttachmentKey DroppedFrameReasonInfo = new CMSampleBufferAttachmentKey("DroppedFrameReasonInfo");
     /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CMSampleBufferAttachmentKey StillImageLensStabilizationInfo = new CMSampleBufferAttachmentKey("StillImageLensStabilizationInfo");
+    /**
      * @since Available in iOS 8.0 and later.
      */
     public static final CMSampleBufferAttachmentKey ForceKeyFrame = new CMSampleBufferAttachmentKey("ForceKeyFrame");
     /*</constants>*/
     
-    private static /*<name>*/CMSampleBufferAttachmentKey/*</name>*/[] values = new /*<name>*/CMSampleBufferAttachmentKey/*</name>*/[] {/*<value_list>*/ResetDecoderBeforeDecoding, DrainAfterDecoding, PostNotificationWhenConsumed, ResumeOutput, TransitionID, TrimDurationAtStart, TrimDurationAtEnd, SpeedMultiplier, Reverse, FillDiscontinuitiesWithSilence, EmptyMedia, PermanentEmptyMedia, DisplayEmptyMediaImmediately, EndsPreviousSampleDuration, SampleReferenceURL, SampleReferenceByteOffset, GradualDecoderRefresh, DroppedFrameReason, DroppedFrameReasonInfo, ForceKeyFrame/*</value_list>*/};
+    private static /*<name>*/CMSampleBufferAttachmentKey/*</name>*/[] values = new /*<name>*/CMSampleBufferAttachmentKey/*</name>*/[] {/*<value_list>*/ResetDecoderBeforeDecoding, DrainAfterDecoding, PostNotificationWhenConsumed, ResumeOutput, TransitionID, TrimDurationAtStart, TrimDurationAtEnd, SpeedMultiplier, Reverse, FillDiscontinuitiesWithSilence, EmptyMedia, PermanentEmptyMedia, DisplayEmptyMediaImmediately, EndsPreviousSampleDuration, SampleReferenceURL, SampleReferenceByteOffset, GradualDecoderRefresh, DroppedFrameReason, DroppedFrameReasonInfo, StillImageLensStabilizationInfo, ForceKeyFrame/*</value_list>*/};
     
     /*<name>*/CMSampleBufferAttachmentKey/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -290,6 +294,11 @@ import org.robovm.apple.audiotoolbox.*;
          */
         @GlobalValue(symbol="kCMSampleBufferAttachmentKey_DroppedFrameReasonInfo", optional=true)
         public static native CFString DroppedFrameReasonInfo();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMSampleBufferAttachmentKey_StillImageLensStabilizationInfo", optional=true)
+        public static native CFString StillImageLensStabilizationInfo();
         /**
          * @since Available in iOS 8.0 and later.
          */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMSampleBufferErrorCode.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMSampleBufferErrorCode.java
@@ -57,8 +57,8 @@ public enum /*<name>*/CMSampleBufferErrorCode/*</name>*/ implements ValuedEnum {
     InvalidSampleData(-12742L),
     InvalidMediaFormat(-12743L),
     Invalidated(-12744L),
-    DataFailed(-12745L),
-    DataCanceled(-12746L);
+    DataFailed(-16750L),
+    DataCanceled(-16751L);
     /*</values>*/
 
     /*<bind>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMTime.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMTime.java
@@ -126,6 +126,11 @@ import org.robovm.apple.audiotoolbox.*;
      */
     @GlobalValue(symbol="kCMTimeZero", optional=true)
     public static native @ByVal CMTime Zero();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMTimeMappingInvalid", optional=true)
+    public static native @ByVal CMTimeMapping MappingInvalid();
     
     /**
      * @since Available in iOS 4.0 and later.
@@ -141,7 +146,7 @@ import org.robovm.apple.audiotoolbox.*;
      * @since Available in iOS 4.0 and later.
      */
     @Bridge(symbol="CMTimeMakeWithSeconds", optional=true)
-    public static native @ByVal CMTime create(double seconds, int preferredTimeScale);
+    public static native @ByVal CMTime create(double seconds, int preferredTimescale);
     /**
      * @since Available in iOS 4.0 and later.
      */
@@ -296,5 +301,35 @@ import org.robovm.apple.audiotoolbox.*;
      */
     @Bridge(symbol="CMTimeMapDurationFromRangeToRange", optional=true)
     private static native @ByVal CMTime mapDurationFromRangeToRange(@ByVal CMTime dur, @ByVal CMTimeRange fromRange, @ByVal CMTimeRange toRange);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Bridge(symbol="CMTimeMappingMake", optional=true)
+    public static native @ByVal CMTimeMapping mappingMake(@ByVal CMTimeRange source, @ByVal CMTimeRange target);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Bridge(symbol="CMTimeMappingMakeEmpty", optional=true)
+    public static native @ByVal CMTimeMapping mappingMakeEmpty(@ByVal CMTimeRange target);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Bridge(symbol="CMTimeMappingCopyAsDictionary", optional=true)
+    public static native NSDictionary mappingCopyAsDictionary(@ByVal CMTimeMapping mapping, CFAllocator allocator);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Bridge(symbol="CMTimeMappingMakeFromDictionary", optional=true)
+    public static native @ByVal CMTimeMapping mappingMakeFromDictionary(NSDictionary dict);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Bridge(symbol="CMTimeMappingCopyDescription", optional=true)
+    public static native String mappingCopyDescription(CFAllocator allocator, @ByVal CMTimeMapping mapping);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Bridge(symbol="CMTimeMappingShow", optional=true)
+    public static native void mappingShow(@ByVal CMTimeMapping mapping);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMTimebase.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMTimebase.java
@@ -251,23 +251,51 @@ import org.robovm.apple.audiotoolbox.*;
     @Bridge(symbol="CMTimebaseCreateWithMasterTimebase", optional=true)
     protected static native OSStatus create0(CFAllocator allocator, CMTimebase masterTimebase, CMTimebase.CMTimebasePtr timebaseOut);
     /**
-     * @since Available in iOS 6.0 and later.
+     * @since Available in iOS 9.0 and later.
      */
+    @Bridge(symbol="CMTimebaseCopyMasterTimebase", optional=true)
+    protected native CMTimebase copyMasterTimebase0();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Bridge(symbol="CMTimebaseCopyMasterClock", optional=true)
+    protected native CMClock copyMasterClock0();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Bridge(symbol="CMTimebaseCopyMaster", optional=true)
+    protected native CFType copyMaster0();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Bridge(symbol="CMTimebaseCopyUltimateMasterClock", optional=true)
+    protected native CMClock copyUltimateMasterClock0();
+    /**
+     * @since Available in iOS 6.0 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     @Bridge(symbol="CMTimebaseGetMasterTimebase", optional=true)
     public native CMTimebase getMasterTimebase();
     /**
      * @since Available in iOS 6.0 and later.
+     * @deprecated Deprecated in iOS 9.0.
      */
+    @Deprecated
     @Bridge(symbol="CMTimebaseGetMasterClock", optional=true)
     public native CMClock getMasterClock();
     /**
      * @since Available in iOS 6.0 and later.
+     * @deprecated Deprecated in iOS 9.0.
      */
+    @Deprecated
     @Bridge(symbol="CMTimebaseGetMaster", optional=true)
     public native CMTimebase getMaster();
     /**
      * @since Available in iOS 6.0 and later.
+     * @deprecated Deprecated in iOS 9.0.
      */
+    @Deprecated
     @Bridge(symbol="CMTimebaseGetUltimateMasterClock", optional=true)
     public native CMClock getUltimateMasterClock();
     /**

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMVideoCodecType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMVideoCodecType.java
@@ -51,6 +51,7 @@ public enum /*<name>*/CMVideoCodecType/*</name>*/ implements ValuedEnum {
     SorensonVideo3(1398165811L),
     H263(1748121139L),
     H264(1635148593L),
+    HEVC(1752589105L),
     MPEG4Video(1836070006L),
     MPEG2Video(1836069494L),
     MPEG1Video(1836069238L),

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMVideoFormatDescription.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMVideoFormatDescription.java
@@ -103,6 +103,162 @@ import org.robovm.apple.audiotoolbox.*;
     }
     /*<methods>*/
     /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionFieldDetail_TemporalTopFirst", optional=true)
+    public static native CFString FieldDetailTemporalTopFirst();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionFieldDetail_TemporalBottomFirst", optional=true)
+    public static native CFString FieldDetailTemporalBottomFirst();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionFieldDetail_SpatialFirstLineEarly", optional=true)
+    public static native CFString FieldDetailSpatialFirstLineEarly();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionFieldDetail_SpatialFirstLineLate", optional=true)
+    public static native CFString FieldDetailSpatialFirstLineLate();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionColorPrimaries_ITU_R_709_2", optional=true)
+    public static native CFString ColorPrimaries_ITU_R_709_2();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionColorPrimaries_EBU_3213", optional=true)
+    public static native CFString ColorPrimaries_EBU_3213();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionColorPrimaries_SMPTE_C", optional=true)
+    public static native CFString ColorPrimaries_SMPTE_C();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionColorPrimaries_DCI_P3", optional=true)
+    public static native CFString ColorPrimaries_DCI_P3();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionColorPrimaries_P3_D65", optional=true)
+    public static native CFString ColorPrimaries_P3_D65();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionColorPrimaries_ITU_R_2020", optional=true)
+    public static native CFString ColorPrimaries_ITU_R_2020();
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionColorPrimaries_P22", optional=true)
+    public static native CFString ColorPrimaries_P22();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionTransferFunction_ITU_R_709_2", optional=true)
+    public static native CFString TransferFunction_ITU_R_709_2();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionTransferFunction_SMPTE_240M_1995", optional=true)
+    public static native CFString TransferFunction_SMPTE_240M_1995();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionTransferFunction_UseGamma", optional=true)
+    public static native CFString TransferFunction_UseGamma();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionTransferFunction_ITU_R_2020", optional=true)
+    public static native CFString TransferFunction_ITU_R_2020();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionTransferFunction_SMPTE_ST_428_1", optional=true)
+    public static native CFString TransferFunction_SMPTE_ST_428_1();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionYCbCrMatrix_ITU_R_709_2", optional=true)
+    public static native CFString YCbCrMatrix_ITU_R_709_2();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionYCbCrMatrix_ITU_R_601_4", optional=true)
+    public static native CFString YCbCrMatrix_ITU_R_601_4();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionYCbCrMatrix_SMPTE_240M_1995", optional=true)
+    public static native CFString YCbCrMatrix_SMPTE_240M_1995();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionYCbCrMatrix_ITU_R_2020", optional=true)
+    public static native CFString YCbCrMatrix_ITU_R_2020();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionChromaLocation_Left", optional=true)
+    public static native CFString ChromaLocationLeft();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionChromaLocation_Center", optional=true)
+    public static native CFString ChromaLocationCenter();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionChromaLocation_TopLeft", optional=true)
+    public static native CFString ChromaLocationTopLeft();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionChromaLocation_Top", optional=true)
+    public static native CFString ChromaLocationTop();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionChromaLocation_BottomLeft", optional=true)
+    public static native CFString ChromaLocationBottomLeft();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionChromaLocation_Bottom", optional=true)
+    public static native CFString ChromaLocationBottom();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMFormatDescriptionChromaLocation_DV420", optional=true)
+    public static native CFString ChromaLocationDV420();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMSampleBufferLensStabilizationInfo_Active", optional=true)
+    public static native CFString LensStabilizationInfoActive();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMSampleBufferLensStabilizationInfo_OutOfRange", optional=true)
+    public static native CFString LensStabilizationInfoOutOfRange();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMSampleBufferLensStabilizationInfo_Unavailable", optional=true)
+    public static native CFString LensStabilizationInfoUnavailable();
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @GlobalValue(symbol="kCMSampleBufferLensStabilizationInfo_Off", optional=true)
+    public static native CFString LensStabilizationInfoOff();
+    
+    /**
      * @since Available in iOS 4.0 and later.
      */
     @Bridge(symbol="CMVideoFormatDescriptionCreate", optional=true)

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMVideoFormatDescriptionExtension.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremedia/CMVideoFormatDescriptionExtension.java
@@ -384,6 +384,31 @@ import org.robovm.apple.audiotoolbox.*;
         @GlobalValue(symbol="kCMFormatDescriptionExtension_Depth", optional=true)
         public static native CFString Depth();
         /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionExtension_CleanAperture", optional=true)
+        public static native CFString CleanAperture();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionKey_CleanApertureWidth", optional=true)
+        public static native CFString CleanApertureWidth();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionKey_CleanApertureHeight", optional=true)
+        public static native CFString CleanApertureHeight();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionKey_CleanApertureHorizontalOffset", optional=true)
+        public static native CFString CleanApertureHorizontalOffset();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionKey_CleanApertureVerticalOffset", optional=true)
+        public static native CFString CleanApertureVerticalOffset();
+        /**
          * @since Available in iOS 4.0 and later.
          */
         @GlobalValue(symbol="kCMFormatDescriptionKey_CleanApertureWidthRational", optional=true)
@@ -404,6 +429,51 @@ import org.robovm.apple.audiotoolbox.*;
         @GlobalValue(symbol="kCMFormatDescriptionKey_CleanApertureVerticalOffsetRational", optional=true)
         public static native CFString CleanApertureVerticalOffsetRational();
         /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionExtension_FieldCount", optional=true)
+        public static native CFString FieldCount();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionExtension_FieldDetail", optional=true)
+        public static native CFString FieldDetail();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionExtension_PixelAspectRatio", optional=true)
+        public static native CFString PixelAspectRatio();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionKey_PixelAspectRatioHorizontalSpacing", optional=true)
+        public static native CFString PixelAspectRatioHorizontalSpacing();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionKey_PixelAspectRatioVerticalSpacing", optional=true)
+        public static native CFString PixelAspectRatioVerticalSpacing();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionExtension_ColorPrimaries", optional=true)
+        public static native CFString ColorPrimaries();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionExtension_TransferFunction", optional=true)
+        public static native CFString TransferFunction();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionExtension_GammaLevel", optional=true)
+        public static native CFString GammaLevel();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionExtension_YCbCrMatrix", optional=true)
+        public static native CFString YCbCrMatrix();
+        /**
          * @since Available in iOS 4.3 and later.
          */
         @GlobalValue(symbol="kCMFormatDescriptionExtension_FullRangeVideo", optional=true)
@@ -419,6 +489,16 @@ import org.robovm.apple.audiotoolbox.*;
         @GlobalValue(symbol="kCMFormatDescriptionExtension_BytesPerRow", optional=true)
         public static native CFString BytesPerRow();
         /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionExtension_ChromaLocationTopField", optional=true)
+        public static native CFString ChromaLocationTopField();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionExtension_ChromaLocationBottomField", optional=true)
+        public static native CFString ChromaLocationBottomField();
+        /**
          * @since Available in iOS 4.0 and later.
          */
         @GlobalValue(symbol="kCMFormatDescriptionConformsToMPEG2VideoProfile", optional=true)
@@ -433,6 +513,11 @@ import org.robovm.apple.audiotoolbox.*;
          */
         @GlobalValue(symbol="kCMFormatDescriptionExtension_SpatialQuality", optional=true)
         public static native CFString SpatialQuality();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCMFormatDescriptionExtension_VerbatimImageDescription", optional=true)
+        public static native CFString VerbatimImageDescription();
         /**
          * @since Available in iOS 4.0 and later.
          */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIClient.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIClient.java
@@ -83,6 +83,11 @@ import org.robovm.apple.coremidi.MIDIPort.MIDIPortPtr;
     @Bridge(symbol="MIDIClientCreate", optional=true)
     protected static native MIDIError create(String name, FunctionPtr notifyProc, @Pointer long notifyRefCon, MIDIClient.MIDIClientPtr outClient);
     /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Bridge(symbol="MIDIClientCreateWithBlock", optional=true)
+    protected static native MIDIError create(String name, MIDIClient.MIDIClientPtr outClient, @Block VoidBlock1<MIDINotification> notifyBlock);
+    /**
      * @since Available in iOS 4.2 and later.
      */
     @Bridge(symbol="MIDIClientDispose", optional=true)

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDINetworkConnection.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDINetworkConnection.java
@@ -46,6 +46,7 @@ import org.robovm.apple.corefoundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public MIDINetworkConnection() {}
+    protected MIDINetworkConnection(Handle h, long handle) { super(h, handle); }
     protected MIDINetworkConnection(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDINetworkHost.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDINetworkHost.java
@@ -46,6 +46,7 @@ import org.robovm.apple.corefoundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public MIDINetworkHost() {}
+    protected MIDINetworkHost(Handle h, long handle) { super(h, handle); }
     protected MIDINetworkHost(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDINetworkSession.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDINetworkSession.java
@@ -46,6 +46,7 @@ import org.robovm.apple.corefoundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public MIDINetworkSession() {}
+    protected MIDINetworkSession(Handle h, long handle) { super(h, handle); }
     protected MIDINetworkSession(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIObject.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIObject.java
@@ -142,7 +142,7 @@ import org.robovm.apple.corefoundation.*;
      * @since Available in iOS 4.2 and later.
      */
     @Bridge(symbol="MIDIObjectSetDictionaryProperty", optional=true)
-    public native MIDIError setDictionaryProperty(String propertyID, NSDictionary data);
+    public native MIDIError setDictionaryProperty(String propertyID, NSDictionary dict);
     /**
      * @since Available in iOS 4.2 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIPort.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremidi/MIDIPort.java
@@ -106,6 +106,11 @@ import org.robovm.apple.coremidi.MIDIEndpoint.MIDIEndpointPtr;
     @Bridge(symbol="MIDIInputPortCreate", optional=true)
     protected static native MIDIError createInputPort(MIDIClient client, String portName, FunctionPtr readProc, @Pointer long refCon, MIDIPort.MIDIPortPtr outPort);
     /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Bridge(symbol="MIDIInputPortCreateWithBlock", optional=true)
+    protected static native MIDIError createInputPort(MIDIClient client, String portName, MIDIPort.MIDIPortPtr outPort, @Block VoidBlock2<MIDIPacketList, Long> readBlock);
+    /**
      * @since Available in iOS 4.2 and later.
      */
     @Bridge(symbol="MIDIOutputPortCreate", optional=true)
@@ -125,5 +130,10 @@ import org.robovm.apple.coremidi.MIDIEndpoint.MIDIEndpointPtr;
      */
     @Bridge(symbol="MIDIPortDisconnectSource", optional=true)
     public native MIDIError disconnectSource(MIDIEndpoint source);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Bridge(symbol="MIDIDestinationCreateWithBlock", optional=true)
+    protected static native MIDIError createDestination(MIDIClient client, String name, MIDIEndpoint.MIDIEndpointPtr outDest, @Block VoidBlock2<MIDIPacketList, Long> readBlock);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMAccelerometerData.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMAccelerometerData.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMAccelerometerData() {}
+    protected CMAccelerometerData(Handle h, long handle) { super(h, handle); }
     protected CMAccelerometerData(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMAltimeter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMAltimeter.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMAltimeter() {}
+    protected CMAltimeter(Handle h, long handle) { super(h, handle); }
     protected CMAltimeter(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMAltitudeData.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMAltitudeData.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMAltitudeData() {}
+    protected CMAltitudeData(Handle h, long handle) { super(h, handle); }
     protected CMAltitudeData(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMAttitude.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMAttitude.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMAttitude() {}
+    protected CMAttitude(Handle h, long handle) { super(h, handle); }
     protected CMAttitude(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMDeviceMotion.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMDeviceMotion.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMDeviceMotion() {}
+    protected CMDeviceMotion(Handle h, long handle) { super(h, handle); }
     protected CMDeviceMotion(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMGyroData.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMGyroData.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMGyroData() {}
+    protected CMGyroData(Handle h, long handle) { super(h, handle); }
     protected CMGyroData(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMLogItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMLogItem.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMLogItem() {}
+    protected CMLogItem(Handle h, long handle) { super(h, handle); }
     protected CMLogItem(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMMagnetometerData.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMMagnetometerData.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMMagnetometerData() {}
+    protected CMMagnetometerData(Handle h, long handle) { super(h, handle); }
     protected CMMagnetometerData(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMMotionActivity.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMMotionActivity.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMMotionActivity() {}
+    protected CMMotionActivity(Handle h, long handle) { super(h, handle); }
     protected CMMotionActivity(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMMotionActivityManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMMotionActivityManager.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMMotionActivityManager() {}
+    protected CMMotionActivityManager(Handle h, long handle) { super(h, handle); }
     protected CMMotionActivityManager(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMMotionManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMMotionManager.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMMotionManager() {}
+    protected CMMotionManager(Handle h, long handle) { super(h, handle); }
     protected CMMotionManager(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMPedometer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMPedometer.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMPedometer() {}
+    protected CMPedometer(Handle h, long handle) { super(h, handle); }
     protected CMPedometer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMPedometerData.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMPedometerData.java
@@ -45,6 +45,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMPedometerData() {}
+    protected CMPedometerData(Handle h, long handle) { super(h, handle); }
     protected CMPedometerData(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
@@ -70,6 +71,11 @@ import org.robovm.apple.foundation.*;
      */
     @Property(selector = "currentCadence")
     public native NSNumber getCurrentCadence();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Property(selector = "averageActivePace")
+    public native NSNumber getAverageActivePace();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMPedometerEvent.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMPedometerEvent.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2013-2015 RoboVM AB
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,23 +34,23 @@ import org.robovm.apple.foundation.*;
 
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreMotion") @NativeClass/*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class /*<name>*/CMRecordedAccelerometerData/*</name>*/ 
-    extends /*<extends>*/CMAccelerometerData/*</extends>*/ 
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/CMPedometerEvent/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
     /*<implements>*//*</implements>*/ {
 
-    /*<ptr>*/public static class CMRecordedAccelerometerDataPtr extends Ptr<CMRecordedAccelerometerData, CMRecordedAccelerometerDataPtr> {}/*</ptr>*/
-    /*<bind>*/static { ObjCRuntime.bind(CMRecordedAccelerometerData.class); }/*</bind>*/
+    /*<ptr>*/public static class CMPedometerEventPtr extends Ptr<CMPedometerEvent, CMPedometerEventPtr> {}/*</ptr>*/
+    /*<bind>*/static { ObjCRuntime.bind(CMPedometerEvent.class); }/*</bind>*/
     /*<constants>*//*</constants>*/
     /*<constructors>*/
-    public CMRecordedAccelerometerData() {}
-    protected CMRecordedAccelerometerData(Handle h, long handle) { super(h, handle); }
-    protected CMRecordedAccelerometerData(SkipInit skipInit) { super(skipInit); }
+    public CMPedometerEvent() {}
+    protected CMPedometerEvent(Handle h, long handle) { super(h, handle); }
+    protected CMPedometerEvent(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
-    @Property(selector = "identifier")
-    public native long getIdentifier();
-    @Property(selector = "startDate")
-    public native NSDate getStartDate();
+    @Property(selector = "date")
+    public native NSDate getDate();
+    @Property(selector = "type")
+    public native CMPedometerEventType getType();
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMPedometerEventType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMPedometerEventType.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2013-2015 RoboVM AB
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,27 +33,29 @@ import org.robovm.apple.foundation.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*/@Library("CoreMotion") @NativeClass/*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ class /*<name>*/CMRecordedAccelerometerData/*</name>*/ 
-    extends /*<extends>*/CMAccelerometerData/*</extends>*/ 
-    /*<implements>*//*</implements>*/ {
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/CMPedometerEventType/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Pause(0L),
+    Resume(1L);
+    /*</values>*/
 
-    /*<ptr>*/public static class CMRecordedAccelerometerDataPtr extends Ptr<CMRecordedAccelerometerData, CMRecordedAccelerometerDataPtr> {}/*</ptr>*/
-    /*<bind>*/static { ObjCRuntime.bind(CMRecordedAccelerometerData.class); }/*</bind>*/
+    /*<bind>*/
+    /*</bind>*/
     /*<constants>*//*</constants>*/
-    /*<constructors>*/
-    public CMRecordedAccelerometerData() {}
-    protected CMRecordedAccelerometerData(Handle h, long handle) { super(h, handle); }
-    protected CMRecordedAccelerometerData(SkipInit skipInit) { super(skipInit); }
-    /*</constructors>*/
-    /*<properties>*/
-    @Property(selector = "identifier")
-    public native long getIdentifier();
-    @Property(selector = "startDate")
-    public native NSDate getStartDate();
-    /*</properties>*/
-    /*<members>*//*</members>*/
-    /*<methods>*/
-    
-    /*</methods>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/CMPedometerEventType/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/CMPedometerEventType/*</name>*/ valueOf(long n) {
+        for (/*<name>*/CMPedometerEventType/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/CMPedometerEventType/*</name>*/.class.getName());
+    }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMSensorDataList.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMSensorDataList.java
@@ -31,9 +31,7 @@ import org.robovm.apple.foundation.*;
 /*</imports>*/
 
 /*<javadoc>*/
-/**
- * @since Available in iOS 2.0 and later.
- */
+
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreMotion") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CMSensorDataList/*</name>*/ 
@@ -45,6 +43,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMSensorDataList() {}
+    protected CMSensorDataList(Handle h, long handle) { super(h, handle); }
     protected CMSensorDataList(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMSensorRecorder.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMSensorRecorder.java
@@ -31,9 +31,7 @@ import org.robovm.apple.foundation.*;
 /*</imports>*/
 
 /*<javadoc>*/
-/**
- * @since Available in iOS 2.0 and later.
- */
+
 /*</javadoc>*/
 /*<annotations>*/@Library("CoreMotion") @NativeClass/*</annotations>*/
 /*<visibility>*/public/*</visibility>*/ class /*<name>*/CMSensorRecorder/*</name>*/ 
@@ -45,6 +43,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMSensorRecorder() {}
+    protected CMSensorRecorder(Handle h, long handle) { super(h, handle); }
     protected CMSensorRecorder(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
@@ -52,12 +51,10 @@ import org.robovm.apple.foundation.*;
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
-    @Method(selector = "accelerometerDataSince:")
-    public native CMSensorDataList getAccelerometerDataSince(long identifier);
-    @Method(selector = "accelerometerDataFrom:to:")
+    @Method(selector = "accelerometerDataFromDate:toDate:")
     public native CMSensorDataList getAccelerometerDataBetween(NSDate fromDate, NSDate toDate);
-    @Method(selector = "recordAccelerometerFor:")
-    public native void recordAccelerometerFor(double duration);
+    @Method(selector = "recordAccelerometerForDuration:")
+    public native void recordAccelerometerForDuration(double duration);
     @Method(selector = "isAccelerometerRecordingAvailable")
     public static native boolean isAccelerometerRecordingAvailable();
     @Method(selector = "isAuthorizedForRecording")

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMStepCounter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coremotion/CMStepCounter.java
@@ -47,6 +47,7 @@ import org.robovm.apple.foundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CMStepCounter() {}
+    protected CMStepCounter(Handle h, long handle) { super(h, handle); }
     protected CMStepCounter(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coreservices/CFStreamNetworkServiceType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coreservices/CFStreamNetworkServiceType.java
@@ -100,6 +100,10 @@ import org.robovm.apple.corefoundation.*;
      */
     public static final CFStreamNetworkServiceType Background = new CFStreamNetworkServiceType("Background");
     /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final CFStreamNetworkServiceType CallSignaling = new CFStreamNetworkServiceType("CallSignaling");
+    /**
      * @since Available in iOS 4.0 and later.
      * @deprecated Deprecated in iOS 9.0.
      */
@@ -107,7 +111,7 @@ import org.robovm.apple.corefoundation.*;
     public static final CFStreamNetworkServiceType VoIP = new CFStreamNetworkServiceType("VoIP");
     /*</constants>*/
     
-    private static /*<name>*/CFStreamNetworkServiceType/*</name>*/[] values = new /*<name>*/CFStreamNetworkServiceType/*</name>*/[] {/*<value_list>*/Video, Voice, Background, VoIP/*</value_list>*/};
+    private static /*<name>*/CFStreamNetworkServiceType/*</name>*/[] values = new /*<name>*/CFStreamNetworkServiceType/*</name>*/[] {/*<value_list>*/Video, Voice, Background, CallSignaling, VoIP/*</value_list>*/};
     
     /*<name>*/CFStreamNetworkServiceType/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -145,6 +149,11 @@ import org.robovm.apple.corefoundation.*;
          */
         @GlobalValue(symbol="kCFStreamNetworkServiceTypeBackground", optional=true)
         public static native CFString Background();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCFStreamNetworkServiceTypeCallSignaling", optional=true)
+        public static native CFString CallSignaling();
         /**
          * @since Available in iOS 4.0 and later.
          * @deprecated Deprecated in iOS 9.0.

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTCall.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTCall.java
@@ -46,19 +46,11 @@ import org.robovm.apple.corefoundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CTCall() {}
+    protected CTCall(Handle h, long handle) { super(h, handle); }
     protected CTCall(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
-    /**
-     * @since Available in iOS 4.0 and later.
-     */
-    @Property(selector = "callState")
-    public native CTCallState getCallState();
-    /**
-     * @since Available in iOS 4.0 and later.
-     */
-    @Property(selector = "callID")
-    public native String getCallID();
+    
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTCallCenter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTCallCenter.java
@@ -46,24 +46,11 @@ import org.robovm.apple.corefoundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CTCallCenter() {}
+    protected CTCallCenter(Handle h, long handle) { super(h, handle); }
     protected CTCallCenter(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/
-    /**
-     * @since Available in iOS 4.0 and later.
-     */
-    @Property(selector = "currentCalls")
-    public native NSSet<CTCall> getCurrentCalls();
-    /**
-     * @since Available in iOS 4.0 and later.
-     */
-    @Property(selector = "callEventHandler")
-    public native @Block VoidBlock1<CTCall> getCallEventHandler();
-    /**
-     * @since Available in iOS 4.0 and later.
-     */
-    @Property(selector = "setCallEventHandler:")
-    public native void setCallEventHandler(@Block VoidBlock1<CTCall> v);
+    
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTCallState.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTCallState.java
@@ -88,25 +88,10 @@ import org.robovm.apple.corefoundation.*;
     /*</marshalers>*/
 
     /*<constants>*/
-    /**
-     * @since Available in iOS 4.0 and later.
-     */
-    public static final CTCallState Dialing = new CTCallState("Dialing");
-    /**
-     * @since Available in iOS 4.0 and later.
-     */
-    public static final CTCallState Incoming = new CTCallState("Incoming");
-    /**
-     * @since Available in iOS 4.0 and later.
-     */
-    public static final CTCallState Connected = new CTCallState("Connected");
-    /**
-     * @since Available in iOS 4.0 and later.
-     */
-    public static final CTCallState Disconnected = new CTCallState("Disconnected");
+    
     /*</constants>*/
     
-    private static /*<name>*/CTCallState/*</name>*/[] values = new /*<name>*/CTCallState/*</name>*/[] {/*<value_list>*/Dialing, Incoming, Connected, Disconnected/*</value_list>*/};
+    private static /*<name>*/CTCallState/*</name>*/[] values = new /*<name>*/CTCallState/*</name>*/[] {/*<value_list>*//*</value_list>*/};
     
     /*<name>*/CTCallState/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -129,26 +114,7 @@ import org.robovm.apple.corefoundation.*;
     	static { Bro.bind(Values.class); }
 
         /*<values>*/
-        /**
-         * @since Available in iOS 4.0 and later.
-         */
-        @GlobalValue(symbol="CTCallStateDialing", optional=true)
-        public static native NSString Dialing();
-        /**
-         * @since Available in iOS 4.0 and later.
-         */
-        @GlobalValue(symbol="CTCallStateIncoming", optional=true)
-        public static native NSString Incoming();
-        /**
-         * @since Available in iOS 4.0 and later.
-         */
-        @GlobalValue(symbol="CTCallStateConnected", optional=true)
-        public static native NSString Connected();
-        /**
-         * @since Available in iOS 4.0 and later.
-         */
-        @GlobalValue(symbol="CTCallStateDisconnected", optional=true)
-        public static native NSString Disconnected();
+    
         /*</values>*/
     }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTCarrier.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTCarrier.java
@@ -46,6 +46,7 @@ import org.robovm.apple.corefoundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CTCarrier() {}
+    protected CTCarrier(Handle h, long handle) { super(h, handle); }
     protected CTCarrier(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTSubscriber.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTSubscriber.java
@@ -59,6 +59,7 @@ import org.robovm.apple.corefoundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CTSubscriber() {}
+    protected CTSubscriber(Handle h, long handle) { super(h, handle); }
     protected CTSubscriber(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTSubscriberInfo.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTSubscriberInfo.java
@@ -46,6 +46,7 @@ import org.robovm.apple.corefoundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CTSubscriberInfo() {}
+    protected CTSubscriberInfo(Handle h, long handle) { super(h, handle); }
     protected CTSubscriberInfo(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTTelephonyNetworkInfo.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretelephony/CTTelephonyNetworkInfo.java
@@ -56,6 +56,7 @@ import org.robovm.apple.corefoundation.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CTTelephonyNetworkInfo() {}
+    protected CTTelephonyNetworkInfo(Handle h, long handle) { super(h, handle); }
     protected CTTelephonyNetworkInfo(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTAttributedStringAttribute.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTAttributedStringAttribute.java
@@ -91,6 +91,14 @@ import org.robovm.apple.uikit.*;
 
     /*<constants>*/
     /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final CTAttributedStringAttribute RubyAnnotationSizeFactor = new CTAttributedStringAttribute("RubyAnnotationSizeFactor");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final CTAttributedStringAttribute RubyAnnotationScaleToFit = new CTAttributedStringAttribute("RubyAnnotationScaleToFit");
+    /**
      * @since Available in iOS 3.2 and later.
      */
     public static final CTAttributedStringAttribute Font = new CTAttributedStringAttribute("Font");
@@ -110,6 +118,10 @@ import org.robovm.apple.uikit.*;
      * @since Available in iOS 3.2 and later.
      */
     public static final CTAttributedStringAttribute ForegroundColor = new CTAttributedStringAttribute("ForegroundColor");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final CTAttributedStringAttribute BackgroundColor = new CTAttributedStringAttribute("BackgroundColor");
     /**
      * @since Available in iOS 3.2 and later.
      */
@@ -139,12 +151,18 @@ import org.robovm.apple.uikit.*;
      */
     public static final CTAttributedStringAttribute VerticalForms = new CTAttributedStringAttribute("VerticalForms");
     /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final CTAttributedStringAttribute HorizontalInVerticalForms = new CTAttributedStringAttribute("HorizontalInVerticalForms");
+    /**
      * @since Available in iOS 3.2 and later.
      */
     public static final CTAttributedStringAttribute GlyphInfo = new CTAttributedStringAttribute("GlyphInfo");
     /**
      * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
      */
+    @Deprecated
     public static final CTAttributedStringAttribute CharacterShape = new CTAttributedStringAttribute("CharacterShape");
     /**
      * @since Available in iOS 7.0 and later.
@@ -176,7 +194,7 @@ import org.robovm.apple.uikit.*;
     public static final CTAttributedStringAttribute RubyAnnotation = new CTAttributedStringAttribute("RubyAnnotation");
     /*</constants>*/
     
-    private static /*<name>*/CTAttributedStringAttribute/*</name>*/[] values = new /*<name>*/CTAttributedStringAttribute/*</name>*/[] {/*<value_list>*/Font, ForegroundColorFromContext, Kern, Ligature, ForegroundColor, ParagraphStyle, StrokeWidth, StrokeColor, UnderlineStyle, Superscript, UnderlineColor, VerticalForms, GlyphInfo, CharacterShape, Language, RunDelegate, BaselineClass, BaselineInfo, BaselineReferenceInfo, WritingDirection, RubyAnnotation/*</value_list>*/};
+    private static /*<name>*/CTAttributedStringAttribute/*</name>*/[] values = new /*<name>*/CTAttributedStringAttribute/*</name>*/[] {/*<value_list>*/RubyAnnotationSizeFactor, RubyAnnotationScaleToFit, Font, ForegroundColorFromContext, Kern, Ligature, ForegroundColor, BackgroundColor, ParagraphStyle, StrokeWidth, StrokeColor, UnderlineStyle, Superscript, UnderlineColor, VerticalForms, HorizontalInVerticalForms, GlyphInfo, CharacterShape, Language, RunDelegate, BaselineClass, BaselineInfo, BaselineReferenceInfo, WritingDirection, RubyAnnotation/*</value_list>*/};
     
     /*<name>*/CTAttributedStringAttribute/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -199,6 +217,16 @@ import org.robovm.apple.uikit.*;
     	static { Bro.bind(Values.class); }
 
         /*<values>*/
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCTRubyAnnotationSizeFactorAttributeName", optional=true)
+        public static native CFString RubyAnnotationSizeFactor();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCTRubyAnnotationScaleToFitAttributeName", optional=true)
+        public static native CFString RubyAnnotationScaleToFit();
         /**
          * @since Available in iOS 3.2 and later.
          */
@@ -224,6 +252,11 @@ import org.robovm.apple.uikit.*;
          */
         @GlobalValue(symbol="kCTForegroundColorAttributeName", optional=true)
         public static native CFString ForegroundColor();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCTBackgroundColorAttributeName", optional=true)
+        public static native CFString BackgroundColor();
         /**
          * @since Available in iOS 3.2 and later.
          */
@@ -260,13 +293,20 @@ import org.robovm.apple.uikit.*;
         @GlobalValue(symbol="kCTVerticalFormsAttributeName", optional=true)
         public static native CFString VerticalForms();
         /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCTHorizontalInVerticalFormsAttributeName", optional=true)
+        public static native CFString HorizontalInVerticalForms();
+        /**
          * @since Available in iOS 3.2 and later.
          */
         @GlobalValue(symbol="kCTGlyphInfoAttributeName", optional=true)
         public static native CFString GlyphInfo();
         /**
          * @since Available in iOS 3.2 and later.
+         * @deprecated Deprecated in iOS 9.0.
          */
+        @Deprecated
         @GlobalValue(symbol="kCTCharacterShapeAttributeName", optional=true)
         public static native CFString CharacterShape();
         /**

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTCharacterCollection.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTCharacterCollection.java
@@ -40,11 +40,41 @@ import org.robovm.apple.uikit.*;
 /*<annotations>*/@Marshaler(ValuedEnum.AsUnsignedShortMarshaler.class)/*</annotations>*/
 public enum /*<name>*/CTCharacterCollection/*</name>*/ implements ValuedEnum {
     /*<values>*/
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     IdentityMapping(0L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     AdobeCNS1(1L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     AdobeGB1(2L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     AdobeJapan1(3L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     AdobeJapan2(4L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     AdobeKorea1(5L);
     /*</values>*/
 

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTFont.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTFont.java
@@ -345,7 +345,7 @@ import org.robovm.apple.uikit.*;
      * @since Available in iOS 3.2 and later.
      */
     @Bridge(symbol="CTFontCreatePathForGlyph", optional=true)
-    public native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) CGPath createPath(short glyph, CGAffineTransform transform);
+    public native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) CGPath createPath(short glyph, CGAffineTransform matrix);
     /**
      * @since Available in iOS 3.2 and later.
      */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTFontManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTFontManager.java
@@ -94,6 +94,16 @@ import org.robovm.apple.uikit.*;
     public static native NSString RegisteredFontsChangedNotification();
     
     /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Bridge(symbol="CTFontManagerCopyAvailablePostScriptNames", optional=true)
+    public static native CFArray copyAvailablePostScriptNames();
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Bridge(symbol="CTFontManagerCopyAvailableFontFamilyNames", optional=true)
+    public static native CFArray copyAvailableFontFamilyNames();
+    /**
      * @since Available in iOS 7.0 and later.
      */
     @Bridge(symbol="CTFontManagerCreateFontDescriptorsFromURL", optional=true)

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTFontOrientation.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTFontOrientation.java
@@ -40,8 +40,23 @@ import org.robovm.apple.uikit.*;
 /*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedUIntMarshaler.class)/*</annotations>*/
 public enum /*<name>*/CTFontOrientation/*</name>*/ implements ValuedEnum {
     /*<values>*/
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     Default(0L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     Horizontal(1L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     Vertical(2L);
     /*</values>*/
 

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTFontTableOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTFontTableOptions.java
@@ -41,13 +41,10 @@ import org.robovm.apple.uikit.*;
 public final class /*<name>*/CTFontTableOptions/*</name>*/ extends Bits</*<name>*/CTFontTableOptions/*</name>*/> {
     /*<values>*/
     public static final CTFontTableOptions None = new CTFontTableOptions(0L);
-    public static final CTFontTableOptions NoOptions = new CTFontTableOptions(0L);
     /**
      * @since Available in iOS 3.2 and later.
-     * @deprecated Deprecated in iOS 6.0.
      */
-    @Deprecated
-    public static final CTFontTableOptions ExcludeSynthetic = new CTFontTableOptions(1L);
+    public static final CTFontTableOptions NoOptions = new CTFontTableOptions(0L);
     /*</values>*/
 
     /*<bind>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTFontUIFontType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTFontUIFontType.java
@@ -40,61 +40,285 @@ import org.robovm.apple.uikit.*;
 /*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedUIntMarshaler.class)/*</annotations>*/
 public enum /*<name>*/CTFontUIFontType/*</name>*/ implements ValuedEnum {
     /*<values>*/
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontNone(-1L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontUser(0L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontUserFixedPitch(1L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontSystem(2L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontEmphasizedSystem(3L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontSmallSystem(4L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontSmallEmphasizedSystem(5L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontMiniSystem(6L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontMiniEmphasizedSystem(7L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontViews(8L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontApplication(9L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontLabel(10L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontMenuTitle(11L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontMenuItem(12L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontMenuItemMark(13L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontMenuItemCmdKey(14L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontWindowTitle(15L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontPushButton(16L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontUtilityWindowTitle(17L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontAlertHeader(18L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontSystemDetail(19L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontEmphasizedSystemDetail(20L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontToolbar(21L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontSmallToolbar(22L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontMessage(23L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontPalette(24L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontToolTip(25L),
+    /**
+     * @since Available in iOS 6.0 and later.
+     */
     UIFontControlContent(26L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     NoFontType(-1L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     UserFontType(0L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     UserFixedPitchFontType(1L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     SystemFontType(2L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     EmphasizedSystemFontType(3L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     SmallSystemFontType(4L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     SmallEmphasizedSystemFontType(5L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     MiniSystemFontType(6L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     MiniEmphasizedSystemFontType(7L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     ViewsFontType(8L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     ApplicationFontType(9L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     LabelFontType(10L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     MenuTitleFontType(11L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     MenuItemFontType(12L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     MenuItemMarkFontType(13L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     MenuItemCmdKeyFontType(14L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     WindowTitleFontType(15L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     PushButtonFontType(16L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     UtilityWindowTitleFontType(17L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     AlertHeaderFontType(18L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     SystemDetailFontType(19L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     EmphasizedSystemDetailFontType(20L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     ToolbarFontType(21L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     SmallToolbarFontType(22L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     MessageFontType(23L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     PaletteFontType(24L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     ToolTipFontType(25L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     ControlContentFontType(26L);
     /*</values>*/
 

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTLine.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTLine.java
@@ -127,7 +127,7 @@ import org.robovm.apple.uikit.*;
      * @since Available in iOS 3.2 and later.
      */
     @Bridge(symbol="CTLineCreateWithAttributedString", optional=true)
-    public static native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) CTLine create(NSAttributedString string);
+    public static native @org.robovm.rt.bro.annotation.Marshaler(CFType.NoRetainMarshaler.class) CTLine create(NSAttributedString attrString);
     /**
      * @since Available in iOS 3.2 and later.
      */
@@ -193,5 +193,10 @@ import org.robovm.apple.uikit.*;
      */
     @Bridge(symbol="CTLineGetOffsetForStringIndex", optional=true)
     protected native @MachineSizedFloat double getOffset(@MachineSizedSInt long charIndex, MachineSizedFloatPtr secondaryOffset);
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    @Bridge(symbol="CTLineEnumerateCaretOffsets", optional=true)
+    public native void enumerateCaretOffsets(@Block VoidBlock4<Double, Long, Boolean, BooleanPtr> block);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTParagraphStyle.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTParagraphStyle.java
@@ -114,11 +114,6 @@ import org.robovm.apple.uikit.*;
         getValueForSpecifier(CTParagraphStyleSpecifier.MinimumLineHeight, MachineSizedFloatPtr.sizeOf(), ptr.as(VoidPtr.class));
         return ptr.get();
     }
-    public double getLineSpacing() {
-        MachineSizedFloatPtr ptr = new MachineSizedFloatPtr();
-        getValueForSpecifier(CTParagraphStyleSpecifier.LineSpacing, MachineSizedFloatPtr.sizeOf(), ptr.as(VoidPtr.class));
-        return ptr.get();
-    }
     public double getParagraphSpacing() {
         MachineSizedFloatPtr ptr = new MachineSizedFloatPtr();
         getValueForSpecifier(CTParagraphStyleSpecifier.ParagraphSpacing, MachineSizedFloatPtr.sizeOf(), ptr.as(VoidPtr.class));

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTParagraphStyleSpecifier.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTParagraphStyleSpecifier.java
@@ -50,7 +50,6 @@ public enum /*<name>*/CTParagraphStyleSpecifier/*</name>*/ implements ValuedEnum
     LineHeightMultiple(7L),
     MaximumLineHeight(8L),
     MinimumLineHeight(9L),
-    LineSpacing(10L),
     ParagraphSpacing(11L),
     ParagraphSpacingBefore(12L),
     BaseWritingDirection(13L),

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTRubyAnnotation.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTRubyAnnotation.java
@@ -76,6 +76,11 @@ import org.robovm.apple.uikit.*;
     @Bridge(symbol="CTRubyAnnotationCreate", optional=true)
     private static native CTRubyAnnotation create(CTRubyAlignment alignment, CTRubyOverhang overhang, @MachineSizedFloat double sizeFactor, CFString.CFStringPtr text);
     /**
+     * @since Available in iOS 10.0 and later.
+     */
+    @Bridge(symbol="CTRubyAnnotationCreateWithAttributes", optional=true)
+    public static native CTRubyAnnotation createWithAttributes(CTRubyAlignment alignment, CTRubyOverhang overhang, CTRubyPosition position, String string, NSDictionary attributes);
+    /**
      * @since Available in iOS 8.0 and later.
      */
     @Bridge(symbol="CTRubyAnnotationCreateCopy", optional=true)

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTTextAlignment.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTTextAlignment.java
@@ -40,10 +40,35 @@ import org.robovm.apple.uikit.*;
 /*<annotations>*/@Marshaler(ValuedEnum.AsUnsignedByteMarshaler.class)/*</annotations>*/
 public enum /*<name>*/CTTextAlignment/*</name>*/ implements ValuedEnum {
     /*<values>*/
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     Left(0L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     Right(1L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     Center(2L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     Justified(3L),
+    /**
+     * @since Available in iOS 3.2 and later.
+     * @deprecated Deprecated in iOS 9.0.
+     */
+    @Deprecated
     Natural(4L);
     /*</values>*/
 

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTTypesetterOptions.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CTTypesetterOptions.java
@@ -112,27 +112,6 @@ import org.robovm.apple.uikit.*;
 
     /**
      * @since Available in iOS 3.2 and later.
-     * @deprecated Deprecated in iOS 6.0.
-     */
-    @Deprecated
-    public boolean isBidiProcessingDisabled() {
-        if (has(Keys.DisableBidiProcessing())) {
-            CFBoolean val = get(Keys.DisableBidiProcessing(), CFBoolean.class);
-            return val.booleanValue();
-        }
-        return false;
-    }
-    /**
-     * @since Available in iOS 3.2 and later.
-     * @deprecated Deprecated in iOS 6.0.
-     */
-    @Deprecated
-    public CTTypesetterOptions setBidiProcessingDisabled(boolean bidiProcessingDisabled) {
-        set(Keys.DisableBidiProcessing(), CFBoolean.valueOf(bidiProcessingDisabled));
-        return this;
-    }
-    /**
-     * @since Available in iOS 3.2 and later.
      */
     public int getEmbeddingLevel() {
         if (has(Keys.ForcedEmbeddingLevel())) {
@@ -154,13 +133,6 @@ import org.robovm.apple.uikit.*;
     @Library("CoreText")
     public static class Keys {
         static { Bro.bind(Keys.class); }
-        /**
-         * @since Available in iOS 3.2 and later.
-         * @deprecated Deprecated in iOS 6.0.
-         */
-        @Deprecated
-        @GlobalValue(symbol="kCTTypesetterOptionDisableBidiProcessing", optional=true)
-        public static native CFString DisableBidiProcessing();
         /**
          * @since Available in iOS 3.2 and later.
          */

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CoreTextVersionNumber.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/coretext/CoreTextVersionNumber.java
@@ -54,6 +54,8 @@ import org.robovm.apple.uikit.*;
     public static final int Version10_8 = 0x00050000;
     public static final int Version10_9 = 0x00060000;
     public static final int Version10_10 = 0x00070000;
+    public static final int Version10_11 = 0x00080000;
+    public static final int Version10_12 = 0x00090000;
     /*</constants>*/
     /*<constructors>*//*</constructors>*/
     /*<properties>*//*</properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVImageBufferColorPrimaries.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVImageBufferColorPrimaries.java
@@ -106,9 +106,21 @@ import org.robovm.apple.metal.*;
      * @since Available in iOS 6.0 and later.
      */
     public static final CVImageBufferColorPrimaries P22 = new CVImageBufferColorPrimaries("P22");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CVImageBufferColorPrimaries DCI_P3 = new CVImageBufferColorPrimaries("DCI_P3");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CVImageBufferColorPrimaries P3_D65 = new CVImageBufferColorPrimaries("P3_D65");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CVImageBufferColorPrimaries ITU_R_2020 = new CVImageBufferColorPrimaries("ITU_R_2020");
     /*</constants>*/
     
-    private static /*<name>*/CVImageBufferColorPrimaries/*</name>*/[] values = new /*<name>*/CVImageBufferColorPrimaries/*</name>*/[] {/*<value_list>*/ITU_R_709_2, EBU_3213, SMPTE_C, P22/*</value_list>*/};
+    private static /*<name>*/CVImageBufferColorPrimaries/*</name>*/[] values = new /*<name>*/CVImageBufferColorPrimaries/*</name>*/[] {/*<value_list>*/ITU_R_709_2, EBU_3213, SMPTE_C, P22, DCI_P3, P3_D65, ITU_R_2020/*</value_list>*/};
     
     /*<name>*/CVImageBufferColorPrimaries/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -151,6 +163,21 @@ import org.robovm.apple.metal.*;
          */
         @GlobalValue(symbol="kCVImageBufferColorPrimaries_P22", optional=true)
         public static native CFString P22();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCVImageBufferColorPrimaries_DCI_P3", optional=true)
+        public static native CFString DCI_P3();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCVImageBufferColorPrimaries_P3_D65", optional=true)
+        public static native CFString P3_D65();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCVImageBufferColorPrimaries_ITU_R_2020", optional=true)
+        public static native CFString ITU_R_2020();
         /*</values>*/
     }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVImageBufferTransferFunction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVImageBufferTransferFunction.java
@@ -102,9 +102,17 @@ import org.robovm.apple.metal.*;
      * @since Available in iOS 4.0 and later.
      */
     public static final CVImageBufferTransferFunction UseGamma = new CVImageBufferTransferFunction("UseGamma");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CVImageBufferTransferFunction ITU_R_2020 = new CVImageBufferTransferFunction("ITU_R_2020");
+    /**
+     * @since Available in iOS 10.0 and later.
+     */
+    public static final CVImageBufferTransferFunction SMPTE_ST_428_1 = new CVImageBufferTransferFunction("SMPTE_ST_428_1");
     /*</constants>*/
     
-    private static /*<name>*/CVImageBufferTransferFunction/*</name>*/[] values = new /*<name>*/CVImageBufferTransferFunction/*</name>*/[] {/*<value_list>*/ITU_R_709_2, SMPTE_240M_1995, UseGamma/*</value_list>*/};
+    private static /*<name>*/CVImageBufferTransferFunction/*</name>*/[] values = new /*<name>*/CVImageBufferTransferFunction/*</name>*/[] {/*<value_list>*/ITU_R_709_2, SMPTE_240M_1995, UseGamma, ITU_R_2020, SMPTE_ST_428_1/*</value_list>*/};
     
     /*<name>*/CVImageBufferTransferFunction/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -142,6 +150,16 @@ import org.robovm.apple.metal.*;
          */
         @GlobalValue(symbol="kCVImageBufferTransferFunction_UseGamma", optional=true)
         public static native CFString UseGamma();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCVImageBufferTransferFunction_ITU_R_2020", optional=true)
+        public static native CFString ITU_R_2020();
+        /**
+         * @since Available in iOS 10.0 and later.
+         */
+        @GlobalValue(symbol="kCVImageBufferTransferFunction_SMPTE_ST_428_1", optional=true)
+        public static native CFString SMPTE_ST_428_1();
         /*</values>*/
     }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVImageBufferYCbCrMatrix.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVImageBufferYCbCrMatrix.java
@@ -102,9 +102,21 @@ import org.robovm.apple.metal.*;
      * @since Available in iOS 4.0 and later.
      */
     public static final CVImageBufferYCbCrMatrix SMPTE_240M_1995 = new CVImageBufferYCbCrMatrix("SMPTE_240M_1995");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CVImageBufferYCbCrMatrix DCI_P3 = new CVImageBufferYCbCrMatrix("DCI_P3");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CVImageBufferYCbCrMatrix P3_D65 = new CVImageBufferYCbCrMatrix("P3_D65");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CVImageBufferYCbCrMatrix ITU_R_2020 = new CVImageBufferYCbCrMatrix("ITU_R_2020");
     /*</constants>*/
     
-    private static /*<name>*/CVImageBufferYCbCrMatrix/*</name>*/[] values = new /*<name>*/CVImageBufferYCbCrMatrix/*</name>*/[] {/*<value_list>*/ITU_R_709_2, ITU_R_601_4, SMPTE_240M_1995/*</value_list>*/};
+    private static /*<name>*/CVImageBufferYCbCrMatrix/*</name>*/[] values = new /*<name>*/CVImageBufferYCbCrMatrix/*</name>*/[] {/*<value_list>*/ITU_R_709_2, ITU_R_601_4, SMPTE_240M_1995, DCI_P3, P3_D65, ITU_R_2020/*</value_list>*/};
     
     /*<name>*/CVImageBufferYCbCrMatrix/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -142,6 +154,21 @@ import org.robovm.apple.metal.*;
          */
         @GlobalValue(symbol="kCVImageBufferYCbCrMatrix_SMPTE_240M_1995", optional=true)
         public static native CFString SMPTE_240M_1995();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCVImageBufferYCbCrMatrix_DCI_P3", optional=true)
+        public static native CFString DCI_P3();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCVImageBufferYCbCrMatrix_P3_D65", optional=true)
+        public static native CFString P3_D65();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCVImageBufferYCbCrMatrix_ITU_R_2020", optional=true)
+        public static native CFString ITU_R_2020();
         /*</values>*/
     }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVPixelBufferAttribute.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVPixelBufferAttribute.java
@@ -154,9 +154,13 @@ import org.robovm.apple.metal.*;
      * @since Available in iOS 8.0 and later.
      */
     public static final CVPixelBufferAttribute MetalCompatibility = new CVPixelBufferAttribute("MetalCompatibility");
+    /**
+     * @since Available in iOS 9.0 and later.
+     */
+    public static final CVPixelBufferAttribute OpenGLESTextureCacheCompatibility = new CVPixelBufferAttribute("OpenGLESTextureCacheCompatibility");
     /*</constants>*/
     
-    private static /*<name>*/CVPixelBufferAttribute/*</name>*/[] values = new /*<name>*/CVPixelBufferAttribute/*</name>*/[] {/*<value_list>*/PixelFormatType, MemoryAllocator, Width, Height, ExtendedPixelsLeft, ExtendedPixelsTop, ExtendedPixelsRight, ExtendedPixelsBottom, BytesPerRowAlignment, CGBitmapContextCompatibility, CGImageCompatibility, OpenGLCompatibility, PlaneAlignment, IOSurfaceProperties, OpenGLESCompatibility, MetalCompatibility/*</value_list>*/};
+    private static /*<name>*/CVPixelBufferAttribute/*</name>*/[] values = new /*<name>*/CVPixelBufferAttribute/*</name>*/[] {/*<value_list>*/PixelFormatType, MemoryAllocator, Width, Height, ExtendedPixelsLeft, ExtendedPixelsTop, ExtendedPixelsRight, ExtendedPixelsBottom, BytesPerRowAlignment, CGBitmapContextCompatibility, CGImageCompatibility, OpenGLCompatibility, PlaneAlignment, IOSurfaceProperties, OpenGLESCompatibility, MetalCompatibility, OpenGLESTextureCacheCompatibility/*</value_list>*/};
     
     /*<name>*/CVPixelBufferAttribute/*</name>*/ (String getterName) {
         super(Values.class, getterName);
@@ -259,6 +263,11 @@ import org.robovm.apple.metal.*;
          */
         @GlobalValue(symbol="kCVPixelBufferMetalCompatibilityKey", optional=true)
         public static native CFString MetalCompatibility();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCVPixelBufferOpenGLESTextureCacheCompatibilityKey", optional=true)
+        public static native CFString OpenGLESTextureCacheCompatibility();
         /*</values>*/
     }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVPixelBufferPool.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVPixelBufferPool.java
@@ -98,6 +98,11 @@ import org.robovm.apple.metal.*;
      */
     @GlobalValue(symbol="kCVPixelBufferPoolFreeBufferNotification", optional=true)
     public static native NSString FreeBufferNotification();
+    /**
+     * @since Available in iOS 4.0 and later.
+     */
+    @GlobalValue(symbol="kCVPixelBufferPoolFreeBufferNotification", optional=true)
+    public static native void FreeBufferNotification(NSString v);
     
     /**
      * @since Available in iOS 4.0 and later.
@@ -129,5 +134,7 @@ import org.robovm.apple.metal.*;
      */
     @Bridge(symbol="CVPixelBufferPoolCreatePixelBufferWithAuxAttributes", optional=true)
     private static native CVReturn createPixelBuffer(CFAllocator allocator, CVPixelBufferPool pixelBufferPool, CVPixelBufferPoolAuxiliaryAttributes auxAttributes, CVPixelBuffer.CVPixelBufferPtr pixelBufferOut);
+    @Bridge(symbol="CVPixelBufferPoolFlush", optional=true)
+    public native void flush(CVPixelBufferPoolFlushFlags options);
     /*</methods>*/
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVPixelBufferPoolFlushFlags.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVPixelBufferPoolFlushFlags.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2013-2015 RoboVM AB
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,28 +38,10 @@ import org.robovm.apple.metal.*;
 
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-public enum /*<name>*/CVReturn/*</name>*/ implements ValuedEnum {
+public final class /*<name>*/CVPixelBufferPoolFlushFlags/*</name>*/ extends Bits</*<name>*/CVPixelBufferPoolFlushFlags/*</name>*/> {
     /*<values>*/
-    Success(0L),
-    First(-6660L),
-    Error(-6660L),
-    InvalidArgument(-6661L),
-    AllocationFailed(-6662L),
-    Unsupported(-6663L),
-    InvalidDisplay(-6670L),
-    DisplayLinkAlreadyRunning(-6671L),
-    DisplayLinkNotRunning(-6672L),
-    DisplayLinkCallbacksNotSet(-6673L),
-    InvalidPixelFormat(-6680L),
-    InvalidSize(-6681L),
-    InvalidPixelBufferAttributes(-6682L),
-    PixelBufferNotOpenGLCompatible(-6683L),
-    PixelBufferNotMetalCompatible(-6684L),
-    WouldExceedAllocationThreshold(-6689L),
-    PoolAllocationFailed(-6690L),
-    InvalidPoolAttributes(-6691L),
-    Retry(-6692L),
-    Last(-6699L);
+    public static final CVPixelBufferPoolFlushFlags None = new CVPixelBufferPoolFlushFlags(0L);
+    public static final CVPixelBufferPoolFlushFlags ExcessBuffers = new CVPixelBufferPoolFlushFlags(1L);
     /*</values>*/
 
     /*<bind>*/
@@ -67,17 +49,17 @@ public enum /*<name>*/CVReturn/*</name>*/ implements ValuedEnum {
     /*<constants>*//*</constants>*/
     /*<methods>*//*</methods>*/
 
-    private final long n;
+    private static final /*<name>*/CVPixelBufferPoolFlushFlags/*</name>*/[] values = _values(/*<name>*/CVPixelBufferPoolFlushFlags/*</name>*/.class);
 
-    private /*<name>*/CVReturn/*</name>*/(long n) { this.n = n; }
-    public long value() { return n; }
-    public static /*<name>*/CVReturn/*</name>*/ valueOf(long n) {
-        for (/*<name>*/CVReturn/*</name>*/ v : values()) {
-            if (v.n == n) {
-                return v;
-            }
-        }
-        throw new IllegalArgumentException("No constant with value " + n + " found in " 
-            + /*<name>*/CVReturn/*</name>*/.class.getName());
+    public /*<name>*/CVPixelBufferPoolFlushFlags/*</name>*/(long value) { super(value); }
+    private /*<name>*/CVPixelBufferPoolFlushFlags/*</name>*/(long value, long mask) { super(value, mask); }
+    protected /*<name>*/CVPixelBufferPoolFlushFlags/*</name>*/ wrap(long value, long mask) {
+        return new /*<name>*/CVPixelBufferPoolFlushFlags/*</name>*/(value, mask);
+    }
+    protected /*<name>*/CVPixelBufferPoolFlushFlags/*</name>*/[] _values() {
+        return values;
+    }
+    public static /*<name>*/CVPixelBufferPoolFlushFlags/*</name>*/[] values() {
+        return values.clone();
     }
 }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVPixelFormatDescription.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVPixelFormatDescription.java
@@ -652,6 +652,26 @@ import org.robovm.apple.metal.*;
         @GlobalValue(symbol="kCVPixelFormatContainsRGB", optional=true)
         public static native CFString ContainsRGB();
         /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCVPixelFormatComponentRange", optional=true)
+        public static native CFString ComponentRange();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCVPixelFormatComponentRange_VideoRange", optional=true)
+        public static native CFString ComponentRange_VideoRange();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCVPixelFormatComponentRange_FullRange", optional=true)
+        public static native CFString ComponentRange_FullRange();
+        /**
+         * @since Available in iOS 9.0 and later.
+         */
+        @GlobalValue(symbol="kCVPixelFormatComponentRange_WideRange", optional=true)
+        public static native CFString ComponentRange_WideRange();
+        /**
          * @since Available in iOS 4.0 and later.
          */
         @GlobalValue(symbol="kCVPixelFormatPlanes", optional=true)

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVPixelFormatType.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVPixelFormatType.java
@@ -82,12 +82,17 @@ public enum /*<name>*/CVPixelFormatType/*</name>*/ implements ValuedEnum {
     _422YpCbCr8FullRange(2037741158L),
     OneComponent8(1278226488L),
     TwoComponent8(843264056L),
+    _30RGBLEPackedWideGamut(1999843442L),
     OneComponent16Half(1278226536L),
     OneComponent32Float(1278226534L),
     TwoComponent16Half(843264104L),
     TwoComponent32Float(843264102L),
     _64RGBAHalf(1380411457L),
-    _128RGBAFloat(1380410945L);
+    _128RGBAFloat(1380410945L),
+    _14Bayer_GRBG(1735549492L),
+    _14Bayer_RGGB(1919379252L),
+    _14Bayer_BGGR(1650943796L),
+    _14Bayer_GBRG(1734505012L);
     /*</values>*/
 
     public static class AsListMarshaler {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVTimeStamp.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVTimeStamp.java
@@ -45,10 +45,7 @@ import org.robovm.apple.metal.*;
     /*<ptr>*/public static class CVTimeStampPtr extends Ptr<CVTimeStamp, CVTimeStampPtr> {}/*</ptr>*/
     /*<bind>*/
     /*</bind>*/
-    /*<constants>*/
-    public static final int VideoHostTimeValid = 3;
-    public static final int IsInterlaced = 196608;
-    /*</constants>*/
+    /*<constants>*//*</constants>*/
     /*<constructors>*/
     public CVTimeStamp() {}
     public CVTimeStamp(int version, int videoTimeScale, long videoTime, long hostTime, double rateScalar, long videoRefreshPeriod, CVSMPTETime smpteTime, CVTimeStampFlags flags, long reserved) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVTimeStampFlags.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/corevideo/CVTimeStampFlags.java
@@ -48,6 +48,8 @@ public final class /*<name>*/CVTimeStampFlags/*</name>*/ extends Bits</*<name>*/
     public static final CVTimeStampFlags RateScalarValid = new CVTimeStampFlags(16L);
     public static final CVTimeStampFlags TopField = new CVTimeStampFlags(65536L);
     public static final CVTimeStampFlags BottomField = new CVTimeStampFlags(131072L);
+    public static final CVTimeStampFlags VideoHostTimeValid = new CVTimeStampFlags(3L);
+    public static final CVTimeStampFlags IsInterlaced = new CVTimeStampFlags(196608L);
     /*</values>*/
 
     /*<bind>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSAttributedString.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSAttributedString.java
@@ -55,8 +55,11 @@ import org.robovm.apple.dispatch.*;
     public NSAttributedString() {}
     protected NSAttributedString(Handle h, long handle) { super(h, handle); }
     protected NSAttributedString(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithString:")
     public NSAttributedString(String str) { super((SkipInit) null); initObject(init(str)); }
+    @Method(selector = "initWithString:attributes:")
     public NSAttributedString(String str, NSDictionary<NSString, ?> attrs) { super((SkipInit) null); initObject(init(str, attrs)); }
+    @Method(selector = "initWithAttributedString:")
     public NSAttributedString(NSAttributedString attrStr) { super((SkipInit) null); initObject(init(attrStr)); }
     /*</constructors>*/
     public NSAttributedString(String str, NSAttributedStringAttributes attrs) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSBundle.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSBundle.java
@@ -75,6 +75,7 @@ import org.robovm.apple.dispatch.*;
     /**
      * @since Available in iOS 4.0 and later.
      */
+    @Method(selector = "initWithURL:")
     public NSBundle(NSURL url) { super((SkipInit) null); initObject(init(url)); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSBundleResourceRequest.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSBundleResourceRequest.java
@@ -69,7 +69,9 @@ import org.robovm.apple.dispatch.*;
     protected NSBundleResourceRequest() {}
     protected NSBundleResourceRequest(Handle h, long handle) { super(h, handle); }
     protected NSBundleResourceRequest(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithTags:")
     public NSBundleResourceRequest(@org.robovm.rt.bro.annotation.Marshaler(NSSet.AsStringSetMarshaler.class) Set<String> tags) { super((SkipInit) null); initObject(init(tags)); }
+    @Method(selector = "initWithTags:bundle:")
     public NSBundleResourceRequest(@org.robovm.rt.bro.annotation.Marshaler(NSSet.AsStringSetMarshaler.class) Set<String> tags, NSBundle bundle) { super((SkipInit) null); initObject(init(tags, bundle)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSCachedURLResponse.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSCachedURLResponse.java
@@ -53,7 +53,9 @@ import org.robovm.apple.dispatch.*;
     public NSCachedURLResponse() {}
     protected NSCachedURLResponse(Handle h, long handle) { super(h, handle); }
     protected NSCachedURLResponse(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithResponse:data:")
     public NSCachedURLResponse(NSURLResponse response, NSData data) { super((SkipInit) null); initObject(init(response, data)); }
+    @Method(selector = "initWithResponse:data:userInfo:storagePolicy:")
     public NSCachedURLResponse(NSURLResponse response, NSData data, NSDictionary<?, ?> userInfo, NSURLCacheStoragePolicy storagePolicy) { super((SkipInit) null); initObject(init(response, data, userInfo, storagePolicy)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSCalendar.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSCalendar.java
@@ -67,6 +67,7 @@ import org.robovm.apple.dispatch.*;
     protected NSCalendar() {}
     protected NSCalendar(Handle h, long handle) { super(h, handle); }
     protected NSCalendar(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCalendarIdentifier:")
     public NSCalendar(NSCalendarIdentifier ident) { super((SkipInit) null); initObject(init(ident)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSCharacterSet.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSCharacterSet.java
@@ -56,6 +56,7 @@ import org.robovm.apple.dispatch.*;
     @Deprecated protected NSCharacterSet(long handle) { super(handle); }
     protected NSCharacterSet(Handle h, long handle) { super(h, handle); }
     protected NSCharacterSet(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public NSCharacterSet(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     public NSCharacterSet(@ByVal NSRange aRange) { super((Handle) null, create(aRange)); retain(getHandle()); }
     public NSCharacterSet(String aString) { super((Handle) null, create(aString)); retain(getHandle()); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSComparisonPredicate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSComparisonPredicate.java
@@ -55,8 +55,11 @@ import org.robovm.apple.dispatch.*;
     public NSComparisonPredicate() {}
     protected NSComparisonPredicate(Handle h, long handle) { super(h, handle); }
     protected NSComparisonPredicate(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithLeftExpression:rightExpression:modifier:type:options:")
     public NSComparisonPredicate(NSExpression lhs, NSExpression rhs, NSComparisonPredicateModifier modifier, NSPredicateOperatorType type, NSComparisonPredicateOptions options) { super((SkipInit) null); initObject(init(lhs, rhs, modifier, type, options)); }
+    @Method(selector = "initWithLeftExpression:rightExpression:customSelector:")
     public NSComparisonPredicate(NSExpression lhs, NSExpression rhs, Selector selector) { super((SkipInit) null); initObject(init(lhs, rhs, selector)); }
+    @Method(selector = "initWithCoder:")
     public NSComparisonPredicate(NSCoder coder) { super((SkipInit) null); initObject(init(coder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSCompoundPredicate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSCompoundPredicate.java
@@ -55,7 +55,9 @@ import org.robovm.apple.dispatch.*;
     public NSCompoundPredicate() {}
     protected NSCompoundPredicate(Handle h, long handle) { super(h, handle); }
     protected NSCompoundPredicate(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithType:subpredicates:")
     public NSCompoundPredicate(NSCompoundPredicateType type, NSArray<NSPredicate> subpredicates) { super((SkipInit) null); initObject(init(type, subpredicates)); }
+    @Method(selector = "initWithCoder:")
     public NSCompoundPredicate(NSCoder coder) { super((SkipInit) null); initObject(initWithCoder$(coder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSConditionLock.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSConditionLock.java
@@ -53,6 +53,7 @@ import org.robovm.apple.dispatch.*;
     public NSConditionLock() {}
     protected NSConditionLock(Handle h, long handle) { super(h, handle); }
     protected NSConditionLock(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCondition:")
     public NSConditionLock(@MachineSizedSInt long condition) { super((SkipInit) null); initObject(init(condition)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSData.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSData.java
@@ -54,6 +54,7 @@ import org.robovm.apple.dispatch.*;
     public NSData() {}
     protected NSData(Handle h, long handle) { super(h, handle); }
     protected NSData(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithData:")
     public NSData(NSData data) { super((SkipInit) null); initObject(init(data)); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDataDetector.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDataDetector.java
@@ -54,6 +54,7 @@ import org.robovm.apple.dispatch.*;
     /*<constructors>*/
     protected NSDataDetector(Handle h, long handle) { super(h, handle); }
     protected NSDataDetector(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithTypes:error:")
     public NSDataDetector(NSTextCheckingType checkingTypes) throws NSErrorException {
        super((SkipInit) null);
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDate.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDate.java
@@ -69,6 +69,7 @@ import org.robovm.apple.dispatch.*;
     public NSDate() {}
     protected NSDate(Handle h, long handle) { super(h, handle); }
     protected NSDate(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithTimeIntervalSince1970:")
     public NSDate(double secs) { super((SkipInit) null); initObject(init(secs)); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDateInterval.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDateInterval.java
@@ -55,8 +55,11 @@ import org.robovm.apple.dispatch.*;
     public NSDateInterval() {}
     protected NSDateInterval(Handle h, long handle) { super(h, handle); }
     protected NSDateInterval(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public NSDateInterval(NSCoder coder) { super((SkipInit) null); initObject(init(coder)); }
+    @Method(selector = "initWithStartDate:duration:")
     public NSDateInterval(NSDate startDate, double duration) { super((SkipInit) null); initObject(init(startDate, duration)); }
+    @Method(selector = "initWithStartDate:endDate:")
     public NSDateInterval(NSDate startDate, NSDate endDate) { super((SkipInit) null); initObject(init(startDate, endDate)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDecimalNumber.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDecimalNumber.java
@@ -52,9 +52,13 @@ import org.robovm.apple.dispatch.*;
     /*<constructors>*/
     protected NSDecimalNumber(Handle h, long handle) { super(h, handle); }
     protected NSDecimalNumber(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithMantissa:exponent:isNegative:")
     public NSDecimalNumber(long mantissa, short exponent, boolean flag) { super((SkipInit) null); initObject(init(mantissa, exponent, flag)); }
+    @Method(selector = "initWithDecimal:")
     public NSDecimalNumber(@ByVal NSDecimal dcm) { super((SkipInit) null); initObject(init(dcm)); }
+    @Method(selector = "initWithString:")
     public NSDecimalNumber(String numberValue) { super((SkipInit) null); initObject(init(numberValue)); }
+    @Method(selector = "initWithString:locale:")
     public NSDecimalNumber(String numberValue, NSLocale locale) { super((SkipInit) null); initObject(init(numberValue, locale)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDecimalNumberHandler.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDecimalNumberHandler.java
@@ -52,7 +52,9 @@ import org.robovm.apple.dispatch.*;
     /*<constructors>*/
     protected NSDecimalNumberHandler(Handle h, long handle) { super(h, handle); }
     protected NSDecimalNumberHandler(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithRoundingMode:scale:raiseOnExactness:raiseOnOverflow:raiseOnUnderflow:raiseOnDivideByZero:")
     public NSDecimalNumberHandler(NSRoundingMode roundingMode, short scale, boolean exact, boolean overflow, boolean underflow, boolean divideByZero) { super((SkipInit) null); initObject(init(roundingMode, scale, exact, overflow, underflow, divideByZero)); }
+    @Method(selector = "initWithCoder:")
     public NSDecimalNumberHandler(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDimension.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSDimension.java
@@ -55,6 +55,7 @@ import org.robovm.apple.dispatch.*;
     public NSDimension() {}
     protected NSDimension(Handle h, long handle) { super(h, handle); }
     protected NSDimension(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithSymbol:converter:")
     public NSDimension(String symbol, NSUnitConverter converter) { super((SkipInit) null); initObject(init(symbol, converter)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSError.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSError.java
@@ -102,6 +102,7 @@ import org.robovm.apple.dispatch.*;
     /*<constructors>*/
     protected NSError(Handle h, long handle) { super(h, handle); }
     protected NSError(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithDomain:code:userInfo:")
     public NSError(String domain, @MachineSizedSInt long code, NSErrorUserInfo dict) { super((SkipInit) null); initObject(init(domain, code, dict)); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSException.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSException.java
@@ -48,7 +48,9 @@ import org.robovm.apple.security.*;
     /*<constructors>*/
     protected NSException(Handle h, long handle) { super(h, handle); }
     protected NSException(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithName:reason:userInfo:")
     public NSException(String aName, String aReason, NSDictionary<?, ?> aUserInfo) { super((SkipInit) null); initObject(init(aName, aReason, aUserInfo)); }
+    @Method(selector = "initWithCoder:")
     public NSException(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSExpression.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSExpression.java
@@ -56,7 +56,9 @@ import org.robovm.apple.dispatch.*;
     @Deprecated protected NSExpression(long handle) { super(handle); }
     protected NSExpression(Handle h, long handle) { super(h, handle); }
     protected NSExpression(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithExpressionType:")
     public NSExpression(NSExpressionType type) { super((SkipInit) null); initObject(init(type)); }
+    @Method(selector = "initWithCoder:")
     public NSExpression(NSCoder coder) { super((SkipInit) null); initObject(init(coder)); }
     /**
      * @since Available in iOS 4.0 and later.

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFileCoordinator.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFileCoordinator.java
@@ -55,6 +55,7 @@ import org.robovm.apple.dispatch.*;
     public NSFileCoordinator() {}
     protected NSFileCoordinator(Handle h, long handle) { super(h, handle); }
     protected NSFileCoordinator(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithFilePresenter:")
     public NSFileCoordinator(NSFilePresenter filePresenterOrNil) { super((SkipInit) null); initObject(init(filePresenterOrNil)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFileHandle.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFileHandle.java
@@ -103,8 +103,11 @@ import org.robovm.apple.dispatch.*;
     public NSFileHandle() {}
     protected NSFileHandle(Handle h, long handle) { super(h, handle); }
     protected NSFileHandle(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithFileDescriptor:closeOnDealloc:")
     public NSFileHandle(int fd, boolean closeopt) { super((SkipInit) null); initObject(init(fd, closeopt)); }
+    @Method(selector = "initWithCoder:")
     public NSFileHandle(NSCoder coder) { super((SkipInit) null); initObject(init(coder)); }
+    @Method(selector = "initWithFileDescriptor:")
     public NSFileHandle(int fd) { super((SkipInit) null); initObject(init(fd)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFileWrapper.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFileWrapper.java
@@ -58,6 +58,7 @@ import org.robovm.apple.dispatch.*;
     /**
      * @since Available in iOS 4.0 and later.
      */
+    @Method(selector = "initWithURL:options:error:")
     public NSFileWrapper(NSURL url, NSFileWrapperReadingOptions options) throws NSErrorException {
        super((SkipInit) null);
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();
@@ -65,12 +66,16 @@ import org.robovm.apple.dispatch.*;
        if (ptr.get() != null) { throw new NSErrorException(ptr.get()); }
        initObject(handle);
     }
+    @Method(selector = "initDirectoryWithFileWrappers:")
     public NSFileWrapper(@org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringMapMarshaler.class) Map<String, NSFileWrapper> childrenByPreferredName) { super((SkipInit) null); initObject(init(childrenByPreferredName)); }
+    @Method(selector = "initRegularFileWithContents:")
     public NSFileWrapper(NSData contents) { super((SkipInit) null); initObject(init(contents)); }
     /**
      * @since Available in iOS 4.0 and later.
      */
+    @Method(selector = "initSymbolicLinkWithDestinationURL:")
     public NSFileWrapper(NSURL url) { super((SkipInit) null); initObject(init(url)); }
+    @Method(selector = "initWithCoder:")
     public NSFileWrapper(NSCoder inCoder) { super((SkipInit) null); initObject(init(inCoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFormatter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSFormatter.java
@@ -53,6 +53,7 @@ import org.robovm.apple.dispatch.*;
     public NSFormatter() {}
     protected NSFormatter(Handle h, long handle) { super(h, handle); }
     protected NSFormatter(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public NSFormatter(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSHTTPCookie.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSHTTPCookie.java
@@ -53,6 +53,7 @@ import org.robovm.apple.dispatch.*;
     public NSHTTPCookie() {}
     protected NSHTTPCookie(Handle h, long handle) { super(h, handle); }
     protected NSHTTPCookie(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithProperties:")
     public NSHTTPCookie(NSHTTPCookieAttributes properties) { super((SkipInit) null); initObject(init(properties)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSHTTPURLResponse.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSHTTPURLResponse.java
@@ -56,6 +56,7 @@ import org.robovm.apple.dispatch.*;
     /**
      * @since Available in iOS 5.0 and later.
      */
+    @Method(selector = "initWithURL:statusCode:HTTPVersion:headerFields:")
     public NSHTTPURLResponse(NSURL url, @MachineSizedSInt long statusCode, String HTTPVersion, @org.robovm.rt.bro.annotation.Marshaler(NSDictionary.AsStringStringMapMarshaler.class) Map<String, String> headerFields) { super((SkipInit) null); initObject(init(url, statusCode, HTTPVersion, headerFields)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSHashTable.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSHashTable.java
@@ -114,7 +114,9 @@ import org.robovm.apple.foundation.NSSet.SetAdapter;
     public NSHashTable() {}
     protected NSHashTable(Handle h, long handle) { super(h, handle); }
     protected NSHashTable(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithOptions:capacity:")
     public NSHashTable(NSHashTableOptions options, @MachineSizedUInt long initialCapacity) { super((SkipInit) null); initObject(init(options, initialCapacity)); }
+    @Method(selector = "initWithCoder:")
     public NSHashTable(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSIndexPath.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSIndexPath.java
@@ -53,6 +53,7 @@ import org.robovm.apple.dispatch.*;
     public NSIndexPath() {}
     protected NSIndexPath(Handle h, long handle) { super(h, handle); }
     protected NSIndexPath(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithIndex:")
     public NSIndexPath(@MachineSizedUInt long index) { super((SkipInit) null); initObject(init(index)); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSIndexSet.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSIndexSet.java
@@ -53,8 +53,11 @@ import org.robovm.apple.dispatch.*;
     public NSIndexSet() {}
     protected NSIndexSet(Handle h, long handle) { super(h, handle); }
     protected NSIndexSet(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithIndexesInRange:")
     public NSIndexSet(@ByVal NSRange range) { super((SkipInit) null); initObject(init(range)); }
+    @Method(selector = "initWithIndexSet:")
     public NSIndexSet(NSIndexSet indexSet) { super((SkipInit) null); initObject(init(indexSet)); }
+    @Method(selector = "initWithIndex:")
     public NSIndexSet(@MachineSizedUInt long value) { super((SkipInit) null); initObject(init(value)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSInputStream.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSInputStream.java
@@ -53,11 +53,14 @@ import org.robovm.apple.dispatch.*;
     public NSInputStream() {}
     protected NSInputStream(Handle h, long handle) { super(h, handle); }
     protected NSInputStream(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithData:")
     public NSInputStream(NSData data) { super((SkipInit) null); initObject(init(data)); }
     /**
      * @since Available in iOS 4.0 and later.
      */
+    @Method(selector = "initWithURL:")
     public NSInputStream(NSURL url) { super((SkipInit) null); initObject(init(url)); }
+    @Method(selector = "initWithFileAtPath:")
     public NSInputStream(String path) { super((SkipInit) null); initObject(init(path)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSInvocationOperation.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSInvocationOperation.java
@@ -55,7 +55,9 @@ import org.robovm.apple.dispatch.*;
     public NSInvocationOperation() {}
     protected NSInvocationOperation(Handle h, long handle) { super(h, handle); }
     protected NSInvocationOperation(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithTarget:selector:object:")
     public NSInvocationOperation(NSObject target, Selector sel, NSObject arg) { super((SkipInit) null); initObject(init(target, sel, arg)); }
+    @Method(selector = "initWithInvocation:")
     public NSInvocationOperation(NSInvocation inv) { super((SkipInit) null); initObject(init(inv)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSItemProvider.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSItemProvider.java
@@ -55,7 +55,9 @@ import org.robovm.apple.dispatch.*;
     public NSItemProvider() {}
     protected NSItemProvider(Handle h, long handle) { super(h, handle); }
     protected NSItemProvider(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithItem:typeIdentifier:")
     public NSItemProvider(NSObject item, String typeIdentifier) { super((SkipInit) null); initObject(init(item, typeIdentifier)); }
+    @Method(selector = "initWithContentsOfURL:")
     public NSItemProvider(NSURL fileURL) { super((SkipInit) null); initObject(init(fileURL)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSKeyedArchiver.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSKeyedArchiver.java
@@ -53,6 +53,7 @@ import org.robovm.apple.dispatch.*;
     public NSKeyedArchiver() {}
     protected NSKeyedArchiver(Handle h, long handle) { super(h, handle); }
     protected NSKeyedArchiver(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initForWritingWithMutableData:")
     public NSKeyedArchiver(NSMutableData data) { super((SkipInit) null); initObject(init(data)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSKeyedUnarchiver.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSKeyedUnarchiver.java
@@ -53,6 +53,7 @@ import org.robovm.apple.dispatch.*;
     public NSKeyedUnarchiver() {}
     protected NSKeyedUnarchiver(Handle h, long handle) { super(h, handle); }
     protected NSKeyedUnarchiver(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initForReadingWithData:")
     public NSKeyedUnarchiver(NSData data) { super((SkipInit) null); initObject(init(data)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSLinguisticTagger.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSLinguisticTagger.java
@@ -58,6 +58,7 @@ import org.robovm.apple.dispatch.*;
     /**
      * @since Available in iOS 5.0 and later.
      */
+    @Method(selector = "initWithTagSchemes:options:")
     public NSLinguisticTagger(@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<NSLinguisticTagScheme> tagSchemes, NSLinguisticTaggerOptions opts) { super((SkipInit) null); initObject(init(tagSchemes, opts)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSLocale.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSLocale.java
@@ -66,6 +66,7 @@ import org.robovm.apple.dispatch.*;
     /*<constructors>*/
     protected NSLocale(Handle h, long handle) { super(h, handle); }
     protected NSLocale(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithLocaleIdentifier:")
     public NSLocale(String string) { super((SkipInit) null); initObject(init(string)); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMachPort.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMachPort.java
@@ -53,10 +53,12 @@ import org.robovm.apple.dispatch.*;
     public NSMachPort() {}
     protected NSMachPort(Handle h, long handle) { super(h, handle); }
     protected NSMachPort(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithMachPort:")
     public NSMachPort(int machPort) { super((SkipInit) null); initObject(init(machPort)); }
     /**
      * @since Available in iOS 2.0 and later.
      */
+    @Method(selector = "initWithMachPort:options:")
     public NSMachPort(int machPort, NSMachPortRights f) { super((SkipInit) null); initObject(init(machPort, f)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMapTable.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMapTable.java
@@ -179,7 +179,9 @@ import org.robovm.apple.foundation.NSObject.SkipInit;
     public NSMapTable() {}
     protected NSMapTable(Handle h, long handle) { super(h, handle); }
     protected NSMapTable(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithKeyOptions:valueOptions:capacity:")
     public NSMapTable(NSMapTableOptions keyOptions, NSMapTableOptions valueOptions, @MachineSizedUInt long initialCapacity) { super((SkipInit) null); initObject(init(keyOptions, valueOptions, initialCapacity)); }
+    @Method(selector = "initWithCoder:")
     public NSMapTable(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMeasurement.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMeasurement.java
@@ -55,6 +55,7 @@ import org.robovm.apple.dispatch.*;
     protected NSMeasurement() {}
     protected NSMeasurement(Handle h, long handle) { super(h, handle); }
     protected NSMeasurement(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithDoubleValue:unit:")
     public NSMeasurement(double doubleValue, T unit) { super((SkipInit) null); initObject(init(doubleValue, unit)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMutableArray.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMutableArray.java
@@ -92,6 +92,7 @@ import org.robovm.apple.dispatch.*;
     public NSMutableArray() {}
     protected NSMutableArray(Handle h, long handle) { super(h, handle); }
     protected NSMutableArray(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCapacity:")
     public NSMutableArray(@MachineSizedUInt long numItems) { super((SkipInit) null); initObject(init(numItems)); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMutableData.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMutableData.java
@@ -53,6 +53,7 @@ import org.robovm.apple.dispatch.*;
     public NSMutableData() {}
     protected NSMutableData(Handle h, long handle) { super(h, handle); }
     protected NSMutableData(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCapacity:")
     public NSMutableData(@MachineSizedUInt long capacity) { super((SkipInit) null); initObject(init(capacity)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMutableDictionary.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMutableDictionary.java
@@ -52,6 +52,7 @@ import org.robovm.apple.dispatch.*;
     /*<constructors>*/
     protected NSMutableDictionary(Handle h, long handle) { super(h, handle); }
     protected NSMutableDictionary(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCapacity:")
     public NSMutableDictionary(@MachineSizedUInt long numItems) { super((SkipInit) null); initObject(init(numItems)); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMutableOrderedSet.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMutableOrderedSet.java
@@ -112,6 +112,7 @@ import org.robovm.apple.dispatch.*;
     public NSMutableOrderedSet() {}
     protected NSMutableOrderedSet(Handle h, long handle) { super(h, handle); }
     protected NSMutableOrderedSet(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCapacity:")
     public NSMutableOrderedSet(@MachineSizedUInt long numItems) { super((SkipInit) null); initObject(init(numItems)); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMutableSet.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMutableSet.java
@@ -92,6 +92,7 @@ import org.robovm.apple.dispatch.*;
     public NSMutableSet() {}
     protected NSMutableSet(Handle h, long handle) { super(h, handle); }
     protected NSMutableSet(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCapacity:")
     public NSMutableSet(@MachineSizedUInt long numItems) { super((SkipInit) null); initObject(init(numItems)); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMutableString.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSMutableString.java
@@ -53,6 +53,7 @@ import org.robovm.apple.dispatch.*;
     public NSMutableString() {}
     protected NSMutableString(Handle h, long handle) { super(h, handle); }
     protected NSMutableString(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCapacity:")
     public NSMutableString(@MachineSizedUInt long capacity) { super((SkipInit) null); initObject(init(capacity)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSNetService.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSNetService.java
@@ -53,7 +53,9 @@ import org.robovm.apple.dispatch.*;
     public NSNetService() {}
     protected NSNetService(Handle h, long handle) { super(h, handle); }
     protected NSNetService(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithDomain:type:name:port:")
     public NSNetService(String domain, String type, String name, int port) { super((SkipInit) null); initObject(init(domain, type, name, port)); }
+    @Method(selector = "initWithDomain:type:name:")
     public NSNetService(String domain, String type, String name) { super((SkipInit) null); initObject(init(domain, type, name)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSNotification.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSNotification.java
@@ -55,7 +55,9 @@ import org.robovm.apple.dispatch.*;
     /**
      * @since Available in iOS 4.0 and later.
      */
+    @Method(selector = "initWithName:object:userInfo:")
     public NSNotification(NSString name, NSObject object, NSDictionary<?, ?> userInfo) { super((SkipInit) null); initObject(init(name, object, userInfo)); }
+    @Method(selector = "initWithCoder:")
     public NSNotification(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     public NSNotification(String name, NSObject object, NSDictionary<?, ?> userInfo) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSNotificationQueue.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSNotificationQueue.java
@@ -52,6 +52,7 @@ import org.robovm.apple.dispatch.*;
     /*<constructors>*/
     protected NSNotificationQueue(Handle h, long handle) { super(h, handle); }
     protected NSNotificationQueue(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithNotificationCenter:")
     public NSNotificationQueue(NSNotificationCenter notificationCenter) { super((SkipInit) null); initObject(init(notificationCenter)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSOrthography.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSOrthography.java
@@ -88,7 +88,9 @@ import org.robovm.apple.dispatch.*;
     /**
      * @since Available in iOS 4.0 and later.
      */
+    @Method(selector = "initWithDominantScript:languageMap:")
     public NSOrthography(String script, @org.robovm.rt.bro.annotation.Marshaler(NSOrthography.LanguageMapMarshaler.class) Map<String, List<String>> map) { super((SkipInit) null); initObject(init(script, map)); }
+    @Method(selector = "initWithCoder:")
     public NSOrthography(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSOutputStream.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSOutputStream.java
@@ -52,11 +52,14 @@ import org.robovm.apple.dispatch.*;
     /*<constructors>*/
     protected NSOutputStream(Handle h, long handle) { super(h, handle); }
     protected NSOutputStream(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initToMemory")
     public NSOutputStream() { super((SkipInit) null); initObject(init()); }
     /**
      * @since Available in iOS 4.0 and later.
      */
+    @Method(selector = "initWithURL:append:")
     public NSOutputStream(NSURL url, boolean shouldAppend) { super((SkipInit) null); initObject(init(url, shouldAppend)); }
+    @Method(selector = "initToFileAtPath:append:")
     public NSOutputStream(String path, boolean shouldAppend) { super((SkipInit) null); initObject(init(path, shouldAppend)); }
     /*</constructors>*/
     public NSOutputStream(byte[] bytes) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSPort.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSPort.java
@@ -64,6 +64,7 @@ import org.robovm.apple.dispatch.*;
     public NSPort() {}
     protected NSPort(Handle h, long handle) { super(h, handle); }
     protected NSPort(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public NSPort(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSProgress.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSProgress.java
@@ -55,6 +55,7 @@ import org.robovm.apple.dispatch.*;
     public NSProgress() {}
     protected NSProgress(Handle h, long handle) { super(h, handle); }
     protected NSProgress(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithParent:userInfo:")
     public NSProgress(NSProgress parentProgressOrNil, NSProgressUserInfo userInfoOrNil) { super((SkipInit) null); initObject(init(parentProgressOrNil, userInfoOrNil)); }
     public NSProgress(long unitCount) { super((Handle) null, create(unitCount)); retain(getHandle()); }
     /**

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSRegularExpression.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSRegularExpression.java
@@ -54,6 +54,7 @@ import org.robovm.apple.dispatch.*;
     /*<constructors>*/
     protected NSRegularExpression(Handle h, long handle) { super(h, handle); }
     protected NSRegularExpression(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithPattern:options:error:")
     public NSRegularExpression(String pattern, NSRegularExpressionOptions options) throws NSErrorException {
        super((SkipInit) null);
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSScanner.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSScanner.java
@@ -53,6 +53,7 @@ import org.robovm.apple.dispatch.*;
     public NSScanner() {}
     protected NSScanner(Handle h, long handle) { super(h, handle); }
     protected NSScanner(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithString:")
     public NSScanner(String string) { super((SkipInit) null); initObject(init(string)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSSortDescriptor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSSortDescriptor.java
@@ -62,12 +62,16 @@ import org.robovm.apple.dispatch.*;
     public NSSortDescriptor() {}
     protected NSSortDescriptor(Handle h, long handle) { super(h, handle); }
     protected NSSortDescriptor(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithKey:ascending:")
     public NSSortDescriptor(String key, boolean ascending) { super((SkipInit) null); initObject(init(key, ascending)); }
+    @Method(selector = "initWithKey:ascending:selector:")
     public NSSortDescriptor(String key, boolean ascending, Selector selector) { super((SkipInit) null); initObject(init(key, ascending, selector)); }
+    @Method(selector = "initWithCoder:")
     public NSSortDescriptor(NSCoder coder) { super((SkipInit) null); initObject(initWithCoder$(coder)); }
     /**
      * @since Available in iOS 4.0 and later.
      */
+    @Method(selector = "initWithKey:ascending:comparator:")
     public NSSortDescriptor(String key, boolean ascending, @Block Block2<NSObject, NSObject, NSComparisonResult> cmptr) { super((SkipInit) null); initObject(init(key, ascending, cmptr)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSThread.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSThread.java
@@ -83,10 +83,12 @@ import org.robovm.apple.dispatch.*;
     /**
      * @since Available in iOS 2.0 and later.
      */
+    @Method(selector = "initWithTarget:selector:object:")
     public NSThread(NSObject target, Selector selector, NSObject argument) { super((SkipInit) null); initObject(init(target, selector, argument)); }
     /**
      * @since Available in iOS 10.0 and later.
      */
+    @Method(selector = "initWithBlock:")
     public NSThread(@Block Runnable block) { super((SkipInit) null); initObject(init(block)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSTimeZone.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSTimeZone.java
@@ -67,7 +67,9 @@ import org.robovm.apple.dispatch.*;
     public NSTimeZone() {}
     protected NSTimeZone(Handle h, long handle) { super(h, handle); }
     protected NSTimeZone(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithName:")
     public NSTimeZone(String tzName) { super((SkipInit) null); initObject(init(tzName)); }
+    @Method(selector = "initWithName:data:")
     public NSTimeZone(String tzName, NSData aData) { super((SkipInit) null); initObject(init(tzName, aData)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSTimer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSTimer.java
@@ -68,7 +68,9 @@ import org.robovm.apple.dispatch.*;
     /**
      * @since Available in iOS 10.0 and later.
      */
+    @Method(selector = "initWithFireDate:interval:repeats:block:")
     public NSTimer(NSDate date, double interval, boolean repeats, @Block VoidBlock1<NSTimer> block) { super((SkipInit) null); initObject(init(date, interval, repeats, block)); }
+    @Method(selector = "initWithFireDate:interval:target:selector:userInfo:repeats:")
     public NSTimer(NSDate fireDate, double timeInterval, NSObject target, Selector selector, NSObject userInfo, boolean repeats) { super((SkipInit) null); initObject(init(fireDate, timeInterval, target, selector, userInfo, repeats)); }
     /*</constructors>*/
     public NSTimer(NSDate fireDate, double timeInterval, VoidBlock1<NSTimer> run, boolean repeats) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURL.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURL.java
@@ -63,16 +63,21 @@ import org.robovm.apple.foundation.NSError.NSErrorPtr;
      * @deprecated Deprecated in iOS 9.0.
      */
     @Deprecated
+    @Method(selector = "initWithScheme:host:path:")
     public NSURL(String scheme, String host, String path) { super((SkipInit) null); initObject(init(scheme, host, path)); }
+    @Method(selector = "initWithString:")
     public NSURL(String URLString) { super((SkipInit) null); initObject(init(URLString)); }
+    @Method(selector = "initWithString:relativeToURL:")
     public NSURL(String URLString, NSURL baseURL) { super((SkipInit) null); initObject(init(URLString, baseURL)); }
     /**
      * @since Available in iOS 9.0 and later.
      */
+    @Method(selector = "initWithDataRepresentation:relativeToURL:")
     public NSURL(NSData data, NSURL baseURL) { super((SkipInit) null); initObject(init(data, baseURL)); }
     /**
      * @since Available in iOS 4.0 and later.
      */
+    @Method(selector = "initByResolvingBookmarkData:options:relativeToURL:bookmarkDataIsStale:error:")
     public NSURL(NSData bookmarkData, NSURLBookmarkResolutionOptions options, NSURL relativeURL, BooleanPtr isStale) throws NSErrorException {
        super((SkipInit) null);
        NSError.NSErrorPtr ptr = new NSError.NSErrorPtr();

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLAuthenticationChallenge.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLAuthenticationChallenge.java
@@ -53,7 +53,9 @@ import org.robovm.apple.dispatch.*;
     public NSURLAuthenticationChallenge() {}
     protected NSURLAuthenticationChallenge(Handle h, long handle) { super(h, handle); }
     protected NSURLAuthenticationChallenge(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithProtectionSpace:proposedCredential:previousFailureCount:failureResponse:error:sender:")
     public NSURLAuthenticationChallenge(NSURLProtectionSpace space, NSURLCredential credential, @MachineSizedSInt long previousFailureCount, NSURLResponse response, NSError error, NSURLAuthenticationChallengeSender sender) { super((SkipInit) null); initObject(init(space, credential, previousFailureCount, response, error, sender)); }
+    @Method(selector = "initWithAuthenticationChallenge:sender:")
     public NSURLAuthenticationChallenge(NSURLAuthenticationChallenge challenge, NSURLAuthenticationChallengeSender sender) { super((SkipInit) null); initObject(init(challenge, sender)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLCache.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLCache.java
@@ -53,6 +53,7 @@ import org.robovm.apple.dispatch.*;
     public NSURLCache() {}
     protected NSURLCache(Handle h, long handle) { super(h, handle); }
     protected NSURLCache(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithMemoryCapacity:diskCapacity:diskPath:")
     public NSURLCache(@MachineSizedUInt long memoryCapacity, @MachineSizedUInt long diskCapacity, String path) { super((SkipInit) null); initObject(init(memoryCapacity, diskCapacity, path)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLConnection.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLConnection.java
@@ -60,12 +60,14 @@ import org.robovm.apple.newsstandkit.NKAssetDownload;
      * @deprecated Deprecated in iOS 9.0.
      */
     @Deprecated
+    @Method(selector = "initWithRequest:delegate:startImmediately:")
     public NSURLConnection(NSURLRequest request, NSURLConnectionDelegate delegate, boolean startImmediately) { super((SkipInit) null); initObject(init(request, delegate, startImmediately)); }
     /**
      * @since Available in iOS 2.0 and later.
      * @deprecated Deprecated in iOS 9.0.
      */
     @Deprecated
+    @Method(selector = "initWithRequest:delegate:")
     public NSURLConnection(NSURLRequest request, NSURLConnectionDelegate delegate) { super((SkipInit) null); initObject(init(request, delegate)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLCredential.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLCredential.java
@@ -54,16 +54,19 @@ import org.robovm.apple.dispatch.*;
     protected NSURLCredential(Handle h, long handle) { super(h, handle); }
     protected NSURLCredential(SkipInit skipInit) { super(skipInit); }
     @WeaklyLinked
+    @Method(selector = "initWithUser:password:persistence:")
     public NSURLCredential(String user, String password, NSURLCredentialPersistence persistence) { super((SkipInit) null); initObject(init(user, password, persistence)); }
     /**
      * @since Available in iOS 3.0 and later.
      */
     @WeaklyLinked
+    @Method(selector = "initWithIdentity:certificates:persistence:")
     public NSURLCredential(SecIdentity identity, @org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<SecCertificate> certArray, NSURLCredentialPersistence persistence) { super((SkipInit) null); initObject(init(identity, certArray, persistence)); }
     /**
      * @since Available in iOS 3.0 and later.
      */
     @WeaklyLinked
+    @Method(selector = "initWithTrust:")
     public NSURLCredential(SecTrust trust) { super((SkipInit) null); initObject(init(trust)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLProtocol.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLProtocol.java
@@ -53,10 +53,12 @@ import org.robovm.apple.dispatch.*;
     public NSURLProtocol() {}
     protected NSURLProtocol(Handle h, long handle) { super(h, handle); }
     protected NSURLProtocol(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithRequest:cachedResponse:client:")
     public NSURLProtocol(NSURLRequest request, NSCachedURLResponse cachedResponse, NSURLProtocolClient client) { super((SkipInit) null); initObject(init(request, cachedResponse, client)); }
     /**
      * @since Available in iOS 8.0 and later.
      */
+    @Method(selector = "initWithTask:cachedResponse:client:")
     public NSURLProtocol(NSURLSessionTask task, NSCachedURLResponse cachedResponse, NSURLProtocolClient client) { super((SkipInit) null); initObject(init(task, cachedResponse, client)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLRequest.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLRequest.java
@@ -53,7 +53,9 @@ import org.robovm.apple.dispatch.*;
     public NSURLRequest() {}
     protected NSURLRequest(Handle h, long handle) { super(h, handle); }
     protected NSURLRequest(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithURL:")
     public NSURLRequest(NSURL URL) { super((SkipInit) null); initObject(init(URL)); }
+    @Method(selector = "initWithURL:cachePolicy:timeoutInterval:")
     public NSURLRequest(NSURL URL, NSURLRequestCachePolicy cachePolicy, double timeoutInterval) { super((SkipInit) null); initObject(init(URL, cachePolicy, timeoutInterval)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLResponse.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSURLResponse.java
@@ -55,6 +55,7 @@ import org.robovm.apple.dispatch.*;
     public NSURLResponse() {}
     protected NSURLResponse(Handle h, long handle) { super(h, handle); }
     protected NSURLResponse(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithURL:MIMEType:expectedContentLength:textEncodingName:")
     public NSURLResponse(NSURL URL, String MIMEType, @MachineSizedSInt long length, String name) { super((SkipInit) null); initObject(init(URL, MIMEType, length, name)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSUnit.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSUnit.java
@@ -55,6 +55,7 @@ import org.robovm.apple.dispatch.*;
     public NSUnit() {}
     protected NSUnit(Handle h, long handle) { super(h, handle); }
     protected NSUnit(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithSymbol:")
     public NSUnit(String symbol) { super((SkipInit) null); initObject(init(symbol)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSUnitConverterLinear.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSUnitConverterLinear.java
@@ -55,7 +55,9 @@ import org.robovm.apple.dispatch.*;
     public NSUnitConverterLinear() {}
     protected NSUnitConverterLinear(Handle h, long handle) { super(h, handle); }
     protected NSUnitConverterLinear(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoefficient:")
     public NSUnitConverterLinear(double coefficient) { super((SkipInit) null); initObject(init(coefficient)); }
+    @Method(selector = "initWithCoefficient:constant:")
     public NSUnitConverterLinear(double coefficient, double constant) { super((SkipInit) null); initObject(init(coefficient, constant)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSUserActivity.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSUserActivity.java
@@ -55,6 +55,7 @@ import org.robovm.apple.dispatch.*;
     protected NSUserActivity() {}
     protected NSUserActivity(Handle h, long handle) { super(h, handle); }
     protected NSUserActivity(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithActivityType:")
     public NSUserActivity(String activityType) { super((SkipInit) null); initObject(init(activityType)); }
     /*</constructors>*/
     public NSUserActivity(NSUserActivityType activityType) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSValue.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSValue.java
@@ -57,6 +57,7 @@ import org.robovm.apple.scenekit.SCNVector4;
     /*<constructors>*/
     protected NSValue(Handle h, long handle) { super(h, handle); }
     protected NSValue(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public NSValue(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSXMLParser.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/foundation/NSXMLParser.java
@@ -53,11 +53,14 @@ import org.robovm.apple.dispatch.*;
     public NSXMLParser() {}
     protected NSXMLParser(Handle h, long handle) { super(h, handle); }
     protected NSXMLParser(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithContentsOfURL:")
     public NSXMLParser(NSURL url) { super((SkipInit) null); initObject(init(url)); }
+    @Method(selector = "initWithData:")
     public NSXMLParser(NSData data) { super((SkipInit) null); initObject(init(data)); }
     /**
      * @since Available in iOS 5.0 and later.
      */
+    @Method(selector = "initWithStream:")
     public NSXMLParser(NSInputStream stream) { super((SkipInit) null); initObject(init(stream)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSDataAsset.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSDataAsset.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     protected NSDataAsset() {}
     protected NSDataAsset(Handle h, long handle) { super(h, handle); }
     protected NSDataAsset(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithName:")
     public NSDataAsset(String name) { super((SkipInit) null); initObject(init(name)); }
+    @Method(selector = "initWithName:bundle:")
     public NSDataAsset(String name, NSBundle bundle) { super((SkipInit) null); initObject(init(name, bundle)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutManager.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSLayoutManager.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public NSLayoutManager() {}
     protected NSLayoutManager(Handle h, long handle) { super(h, handle); }
     protected NSLayoutManager(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public NSLayoutManager(NSCoder coder) { super((SkipInit) null); initObject(init(coder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSShadow.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSShadow.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public NSShadow() {}
     protected NSShadow(Handle h, long handle) { super(h, handle); }
     protected NSShadow(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public NSShadow(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextAttachment.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextAttachment.java
@@ -58,7 +58,9 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 7.0 and later.
      */
+    @Method(selector = "initWithData:ofType:")
     public NSTextAttachment(NSData contentData, String uti) { super((SkipInit) null); initObject(init(contentData, uti)); }
+    @Method(selector = "initWithCoder:")
     public NSTextAttachment(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextContainer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextContainer.java
@@ -56,7 +56,9 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 7.0 and later.
      */
+    @Method(selector = "initWithSize:")
     public NSTextContainer(@ByVal CGSize size) { super((SkipInit) null); initObject(init(size)); }
+    @Method(selector = "initWithCoder:")
     public NSTextContainer(NSCoder coder) { super((SkipInit) null); initObject(init(coder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextTab.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/NSTextTab.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     public NSTextTab() {}
     protected NSTextTab(Handle h, long handle) { super(h, handle); }
     protected NSTextTab(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithTextAlignment:location:options:")
     public NSTextTab(NSTextAlignment alignment, @MachineSizedFloat double loc, NSTextTabOptions options) { super((SkipInit) null); initObject(init(alignment, loc, options)); }
+    @Method(selector = "initWithCoder:")
     public NSTextTab(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomAction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomAction.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIAccessibilityCustomAction() {}
     protected UIAccessibilityCustomAction(Handle h, long handle) { super(h, handle); }
     protected UIAccessibilityCustomAction(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithName:target:selector:")
     public UIAccessibilityCustomAction(String name, NSObject target, Selector selector) { super((SkipInit) null); initObject(init(name, target, selector)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomRotor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomRotor.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIAccessibilityCustomRotor() {}
     protected UIAccessibilityCustomRotor(Handle h, long handle) { super(h, handle); }
     protected UIAccessibilityCustomRotor(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithName:itemSearchBlock:")
     public UIAccessibilityCustomRotor(String name, FunctionPtr itemSearchBlock) { super((SkipInit) null); initObject(init(name, itemSearchBlock)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomRotorItemResult.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityCustomRotorItemResult.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIAccessibilityCustomRotorItemResult() {}
     protected UIAccessibilityCustomRotorItemResult(Handle h, long handle) { super(h, handle); }
     protected UIAccessibilityCustomRotorItemResult(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithTargetElement:targetRange:")
     public UIAccessibilityCustomRotorItemResult(NSObject targetElement, UITextRange targetRange) { super((SkipInit) null); initObject(init(targetElement, targetRange)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityElement.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAccessibilityElement.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIAccessibilityElement() {}
     protected UIAccessibilityElement(Handle h, long handle) { super(h, handle); }
     protected UIAccessibilityElement(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithAccessibilityContainer:")
     public UIAccessibilityElement(UIAccessibilityContainer container) { super((SkipInit) null); initObject(init(container)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityIndicatorView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityIndicatorView.java
@@ -53,8 +53,11 @@ import org.robovm.apple.corelocation.*;
     public UIActivityIndicatorView() {}
     protected UIActivityIndicatorView(Handle h, long handle) { super(h, handle); }
     protected UIActivityIndicatorView(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithActivityIndicatorStyle:")
     public UIActivityIndicatorView(UIActivityIndicatorViewStyle style) { super((SkipInit) null); initObject(init(style)); }
+    @Method(selector = "initWithFrame:")
     public UIActivityIndicatorView(@ByVal CGRect frame) { super((SkipInit) null); initObject(init(frame)); }
+    @Method(selector = "initWithCoder:")
     public UIActivityIndicatorView(NSCoder coder) { super((SkipInit) null); initObject(init(coder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityItemProvider.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityItemProvider.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     protected UIActivityItemProvider() {}
     protected UIActivityItemProvider(Handle h, long handle) { super(h, handle); }
     protected UIActivityItemProvider(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithPlaceholderItem:")
     public UIActivityItemProvider(NSObject placeholderItem) { super((SkipInit) null); initObject(init(placeholderItem)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIActivityViewController.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     protected UIActivityViewController() {}
     protected UIActivityViewController(Handle h, long handle) { super(h, handle); }
     protected UIActivityViewController(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithActivityItems:applicationActivities:")
     public UIActivityViewController(NSArray<?> activityItems, NSArray<UIActivity> applicationActivities) { super((SkipInit) null); initObject(init(activityItems, applicationActivities)); }
     /*</constructors>*/
     public UIActivityViewController(List<?> activityItems, NSArray<UIActivity> applicationActivities) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAlertView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAlertView.java
@@ -55,7 +55,9 @@ import org.robovm.apple.corelocation.*;
     public UIAlertView() {}
     protected UIAlertView(Handle h, long handle) { super(h, handle); }
     protected UIAlertView(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithFrame:")
     public UIAlertView(@ByVal CGRect frame) { super((SkipInit) null); initObject(init(frame)); }
+    @Method(selector = "initWithCoder:")
     public UIAlertView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationShortcutItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplicationShortcutItem.java
@@ -52,7 +52,9 @@ import org.robovm.apple.corelocation.*;
     /*<constructors>*/
     protected UIApplicationShortcutItem(Handle h, long handle) { super(h, handle); }
     protected UIApplicationShortcutItem(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithType:localizedTitle:localizedSubtitle:icon:userInfo:")
     public UIApplicationShortcutItem(String type, String localizedTitle, String localizedSubtitle, UIApplicationShortcutIcon icon, NSDictionary<?, ?> userInfo) { super((SkipInit) null); initObject(init(type, localizedTitle, localizedSubtitle, icon, userInfo)); }
+    @Method(selector = "initWithType:localizedTitle:")
     public UIApplicationShortcutItem(String type, String localizedTitle) { super((SkipInit) null); initObject(init(type, localizedTitle)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAttachmentBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIAttachmentBehavior.java
@@ -53,9 +53,13 @@ import org.robovm.apple.corelocation.*;
     public UIAttachmentBehavior() {}
     protected UIAttachmentBehavior(Handle h, long handle) { super(h, handle); }
     protected UIAttachmentBehavior(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithItem:attachedToAnchor:")
     public UIAttachmentBehavior(UIDynamicItem item, @ByVal CGPoint point) { super((SkipInit) null); initObject(init(item, point)); }
+    @Method(selector = "initWithItem:offsetFromCenter:attachedToAnchor:")
     public UIAttachmentBehavior(UIDynamicItem item, @ByVal UIOffset offset, @ByVal CGPoint point) { super((SkipInit) null); initObject(init(item, offset, point)); }
+    @Method(selector = "initWithItem:attachedToItem:")
     public UIAttachmentBehavior(UIDynamicItem item1, UIDynamicItem item2) { super((SkipInit) null); initObject(init(item1, item2)); }
+    @Method(selector = "initWithItem:offsetFromCenter:attachedToItem:offsetFromCenter:")
     public UIAttachmentBehavior(UIDynamicItem item1, @ByVal UIOffset offset1, UIDynamicItem item2, @ByVal UIOffset offset2) { super((SkipInit) null); initObject(init(item1, offset1, item2, offset2)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBarButtonItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBarButtonItem.java
@@ -123,14 +123,20 @@ import org.robovm.apple.corelocation.*;
     public UIBarButtonItem() {}
     protected UIBarButtonItem(Handle h, long handle) { super(h, handle); }
     protected UIBarButtonItem(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UIBarButtonItem(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    @Method(selector = "initWithImage:style:target:action:")
     public UIBarButtonItem(UIImage image, UIBarButtonItemStyle style, NSObject target, Selector action) { super((SkipInit) null); initObject(init(image, style, target, action)); }
     /**
      * @since Available in iOS 5.0 and later.
      */
+    @Method(selector = "initWithImage:landscapeImagePhone:style:target:action:")
     public UIBarButtonItem(UIImage image, UIImage landscapeImagePhone, UIBarButtonItemStyle style, NSObject target, Selector action) { super((SkipInit) null); initObject(init(image, landscapeImagePhone, style, target, action)); }
+    @Method(selector = "initWithTitle:style:target:action:")
     public UIBarButtonItem(String title, UIBarButtonItemStyle style, NSObject target, Selector action) { super((SkipInit) null); initObject(init(title, style, target, action)); }
+    @Method(selector = "initWithBarButtonSystemItem:target:action:")
     public UIBarButtonItem(UIBarButtonSystemItem systemItem, NSObject target, Selector action) { super((SkipInit) null); initObject(init(systemItem, target, action)); }
+    @Method(selector = "initWithCustomView:")
     public UIBarButtonItem(UIView customView) { super((SkipInit) null); initObject(init(customView)); }
     /*</constructors>*/
 

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBarButtonItemGroup.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBarButtonItemGroup.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     public UIBarButtonItemGroup() {}
     protected UIBarButtonItemGroup(Handle h, long handle) { super(h, handle); }
     protected UIBarButtonItemGroup(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithBarButtonItems:representativeItem:")
     public UIBarButtonItemGroup(NSArray<UIBarButtonItem> barButtonItems, UIBarButtonItem representativeItem) { super((SkipInit) null); initObject(init(barButtonItems, representativeItem)); }
+    @Method(selector = "initWithCoder:")
     public UIBarButtonItemGroup(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBarItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBarItem.java
@@ -55,6 +55,7 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     public UIBarItem() {}
     protected UIBarItem(Handle h, long handle) { super(h, handle); }
     protected UIBarItem(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UIBarItem(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBezierPath.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIBezierPath.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIBezierPath() {}
     protected UIBezierPath(Handle h, long handle) { super(h, handle); }
     protected UIBezierPath(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UIBezierPath(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionView.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     public UICollectionView() {}
     protected UICollectionView(Handle h, long handle) { super(h, handle); }
     protected UICollectionView(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithFrame:collectionViewLayout:")
     public UICollectionView(@ByVal CGRect frame, UICollectionViewLayout layout) { super((SkipInit) null); initObject(init(frame, layout)); }
+    @Method(selector = "initWithCoder:")
     public UICollectionView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewController.java
@@ -53,8 +53,11 @@ import org.robovm.apple.corelocation.*;
     public UICollectionViewController() {}
     protected UICollectionViewController(Handle h, long handle) { super(h, handle); }
     protected UICollectionViewController(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCollectionViewLayout:")
     public UICollectionViewController(UICollectionViewLayout layout) { super((SkipInit) null); initObject(init(layout)); }
+    @Method(selector = "initWithNibName:bundle:")
     public UICollectionViewController(String nibNameOrNil, NSBundle nibBundleOrNil) { super((SkipInit) null); initObject(init(nibNameOrNil, nibBundleOrNil)); }
+    @Method(selector = "initWithCoder:")
     public UICollectionViewController(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewLayout.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewLayout.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UICollectionViewLayout() {}
     protected UICollectionViewLayout(Handle h, long handle) { super(h, handle); }
     protected UICollectionViewLayout(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UICollectionViewLayout(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewTransitionLayout.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollectionViewTransitionLayout.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     protected UICollectionViewTransitionLayout() {}
     protected UICollectionViewTransitionLayout(Handle h, long handle) { super(h, handle); }
     protected UICollectionViewTransitionLayout(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCurrentLayout:nextLayout:")
     public UICollectionViewTransitionLayout(UICollectionViewLayout currentLayout, UICollectionViewLayout newLayout) { super((SkipInit) null); initObject(init(currentLayout, newLayout)); }
+    @Method(selector = "initWithCoder:")
     public UICollectionViewTransitionLayout(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollisionBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICollisionBehavior.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UICollisionBehavior() {}
     protected UICollisionBehavior(Handle h, long handle) { super(h, handle); }
     protected UICollisionBehavior(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithItems:")
     public UICollisionBehavior(List<UIDynamicItem> items) { super((SkipInit) null); initObject(init(items)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIColor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIColor.java
@@ -53,11 +53,14 @@ import org.robovm.apple.corelocation.*;
     public UIColor() {}
     protected UIColor(Handle h, long handle) { super(h, handle); }
     protected UIColor(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithRed:green:blue:alpha:")
     public UIColor(@MachineSizedFloat double red, @MachineSizedFloat double green, @MachineSizedFloat double blue, @MachineSizedFloat double alpha) { super((SkipInit) null); initObject(init(red, green, blue, alpha)); }
+    @Method(selector = "initWithCGColor:")
     public UIColor(CGColor cgColor) { super((SkipInit) null); initObject(init(cgColor)); }
     /**
      * @since Available in iOS 5.0 and later.
      */
+    @Method(selector = "initWithCIColor:")
     public UIColor(CIColor ciColor) { super((SkipInit) null); initObject(init(ciColor)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICubicTimingParameters.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UICubicTimingParameters.java
@@ -53,8 +53,11 @@ import org.robovm.apple.corelocation.*;
     public UICubicTimingParameters() {}
     protected UICubicTimingParameters(Handle h, long handle) { super(h, handle); }
     protected UICubicTimingParameters(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UICubicTimingParameters(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    @Method(selector = "initWithAnimationCurve:")
     public UICubicTimingParameters(UIViewAnimationCurve curve) { super((SkipInit) null); initObject(init(curve)); }
+    @Method(selector = "initWithControlPoint1:controlPoint2:")
     public UICubicTimingParameters(@ByVal CGPoint point1, @ByVal CGPoint point2) { super((SkipInit) null); initObject(init(point1, point2)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocument.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocument.java
@@ -66,6 +66,7 @@ import org.robovm.apple.corelocation.*;
     public UIDocument() {}
     protected UIDocument(Handle h, long handle) { super(h, handle); }
     protected UIDocument(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithFileURL:")
     public UIDocument(NSURL url) { super((SkipInit) null); initObject(init(url)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocumentMenuViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocumentMenuViewController.java
@@ -53,8 +53,11 @@ import org.robovm.apple.corelocation.*;
     public UIDocumentMenuViewController() {}
     protected UIDocumentMenuViewController(Handle h, long handle) { super(h, handle); }
     protected UIDocumentMenuViewController(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithDocumentTypes:inMode:")
     public UIDocumentMenuViewController(@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> allowedUTIs, UIDocumentPickerMode mode) { super((SkipInit) null); initObject(init(allowedUTIs, mode)); }
+    @Method(selector = "initWithURL:inMode:")
     public UIDocumentMenuViewController(NSURL url, UIDocumentPickerMode mode) { super((SkipInit) null); initObject(init(url, mode)); }
+    @Method(selector = "initWithCoder:")
     public UIDocumentMenuViewController(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocumentPickerViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDocumentPickerViewController.java
@@ -53,8 +53,11 @@ import org.robovm.apple.corelocation.*;
     public UIDocumentPickerViewController() {}
     protected UIDocumentPickerViewController(Handle h, long handle) { super(h, handle); }
     protected UIDocumentPickerViewController(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithDocumentTypes:inMode:")
     public UIDocumentPickerViewController(@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsStringListMarshaler.class) List<String> allowedUTIs, UIDocumentPickerMode mode) { super((SkipInit) null); initObject(init(allowedUTIs, mode)); }
+    @Method(selector = "initWithCoder:")
     public UIDocumentPickerViewController(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    @Method(selector = "initWithURL:inMode:")
     public UIDocumentPickerViewController(NSURL url, UIDocumentPickerMode mode) { super((SkipInit) null); initObject(init(url, mode)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDynamicAnimator.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDynamicAnimator.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     public UIDynamicAnimator() {}
     protected UIDynamicAnimator(Handle h, long handle) { super(h, handle); }
     protected UIDynamicAnimator(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithReferenceView:")
     public UIDynamicAnimator(UIView view) { super((SkipInit) null); initObject(init(view)); }
+    @Method(selector = "initWithCollectionViewLayout:")
     public UIDynamicAnimator(UICollectionViewLayout layout) { super((SkipInit) null); initObject(init(layout)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDynamicItemBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDynamicItemBehavior.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIDynamicItemBehavior() {}
     protected UIDynamicItemBehavior(Handle h, long handle) { super(h, handle); }
     protected UIDynamicItemBehavior(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithItems:")
     public UIDynamicItemBehavior(List<UIDynamicItem> items) { super((SkipInit) null); initObject(init(items)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDynamicItemGroup.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIDynamicItemGroup.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIDynamicItemGroup() {}
     protected UIDynamicItemGroup(Handle h, long handle) { super(h, handle); }
     protected UIDynamicItemGroup(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithItems:")
     public UIDynamicItemGroup(@org.robovm.rt.bro.annotation.Marshaler(NSArray.AsListMarshaler.class) List<UIDynamicItem> items) { super((SkipInit) null); initObject(init(items)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFontDescriptor.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIFontDescriptor.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     public UIFontDescriptor() {}
     protected UIFontDescriptor(Handle h, long handle) { super(h, handle); }
     protected UIFontDescriptor(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UIFontDescriptor(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    @Method(selector = "initWithFontAttributes:")
     public UIFontDescriptor(UIFontDescriptorAttributes attributes) { super((SkipInit) null); initObject(init(attributes)); }
     public UIFontDescriptor(String fontName, @MachineSizedFloat double size) { super((Handle) null, create(fontName, size)); retain(getHandle()); }
     public UIFontDescriptor(String fontName, @ByVal CGAffineTransform matrix) { super((Handle) null, create(fontName, matrix)); retain(getHandle()); }

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGestureRecognizer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGestureRecognizer.java
@@ -112,6 +112,7 @@ import org.robovm.apple.corelocation.*;
     public UIGestureRecognizer() {}
     protected UIGestureRecognizer(Handle h, long handle) { super(h, handle); }
     protected UIGestureRecognizer(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithTarget:action:")
     public UIGestureRecognizer(NSObject target, Selector action) { super((SkipInit) null); initObject(init(target, action)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsImageRenderer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsImageRenderer.java
@@ -53,8 +53,11 @@ import org.robovm.apple.corelocation.*;
     public UIGraphicsImageRenderer() {}
     protected UIGraphicsImageRenderer(Handle h, long handle) { super(h, handle); }
     protected UIGraphicsImageRenderer(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithSize:")
     public UIGraphicsImageRenderer(@ByVal CGSize size) { super((SkipInit) null); initObject(init(size)); }
+    @Method(selector = "initWithSize:format:")
     public UIGraphicsImageRenderer(@ByVal CGSize size, UIGraphicsImageRendererFormat format) { super((SkipInit) null); initObject(init(size, format)); }
+    @Method(selector = "initWithBounds:format:")
     public UIGraphicsImageRenderer(@ByVal CGRect bounds, UIGraphicsImageRendererFormat format) { super((SkipInit) null); initObject(init(bounds, format)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsPDFRenderer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsPDFRenderer.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIGraphicsPDFRenderer() {}
     protected UIGraphicsPDFRenderer(Handle h, long handle) { super(h, handle); }
     protected UIGraphicsPDFRenderer(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithBounds:format:")
     public UIGraphicsPDFRenderer(@ByVal CGRect bounds, UIGraphicsPDFRendererFormat format) { super((SkipInit) null); initObject(init(bounds, format)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsRenderer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGraphicsRenderer.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     public UIGraphicsRenderer() {}
     protected UIGraphicsRenderer(Handle h, long handle) { super(h, handle); }
     protected UIGraphicsRenderer(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithBounds:")
     public UIGraphicsRenderer(@ByVal CGRect bounds) { super((SkipInit) null); initObject(init(bounds)); }
+    @Method(selector = "initWithBounds:format:")
     public UIGraphicsRenderer(@ByVal CGRect bounds, UIGraphicsRendererFormat format) { super((SkipInit) null); initObject(init(bounds, format)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGravityBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIGravityBehavior.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIGravityBehavior() {}
     protected UIGravityBehavior(Handle h, long handle) { super(h, handle); }
     protected UIGravityBehavior(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithItems:")
     public UIGravityBehavior(List<UIDynamicItem> items) { super((SkipInit) null); initObject(init(items)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImage.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImage.java
@@ -77,25 +77,31 @@ import org.robovm.apple.corelocation.*;
     public UIImage() {}
     protected UIImage(Handle h, long handle) { super(h, handle); }
     protected UIImage(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithData:")
     public UIImage(NSData data) { super((SkipInit) null); initObject(init(data)); }
     /**
      * @since Available in iOS 6.0 and later.
      */
+    @Method(selector = "initWithData:scale:")
     public UIImage(NSData data, @MachineSizedFloat double scale) { super((SkipInit) null); initObject(init(data, scale)); }
+    @Method(selector = "initWithCGImage:")
     public UIImage(CGImage cgImage) { super((SkipInit) null); initObject(init(cgImage)); }
     /**
      * @since Available in iOS 4.0 and later.
      */
+    @Method(selector = "initWithCGImage:scale:orientation:")
     public UIImage(CGImage cgImage, @MachineSizedFloat double scale, UIImageOrientation orientation) { super((SkipInit) null); initObject(init(cgImage, scale, orientation)); }
     /**
      * @since Available in iOS 5.0 and later.
      */
     @WeaklyLinked
+    @Method(selector = "initWithCIImage:")
     public UIImage(CIImage ciImage) { super((SkipInit) null); initObject(init(ciImage)); }
     /**
      * @since Available in iOS 6.0 and later.
      */
     @WeaklyLinked
+    @Method(selector = "initWithCIImage:scale:orientation:")
     public UIImage(CIImage ciImage, @MachineSizedFloat double scale, UIImageOrientation orientation) { super((SkipInit) null); initObject(init(ciImage, scale, orientation)); }
     /*</constructors>*/
     public UIImage(File file) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImageAsset.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImageAsset.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIImageAsset() {}
     protected UIImageAsset(Handle h, long handle) { super(h, handle); }
     protected UIImageAsset(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UIImageAsset(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImageView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImageView.java
@@ -53,10 +53,12 @@ import org.robovm.apple.corelocation.*;
     public UIImageView() {}
     protected UIImageView(Handle h, long handle) { super(h, handle); }
     protected UIImageView(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithImage:")
     public UIImageView(UIImage image) { super((SkipInit) null); initObject(init(image)); }
     /**
      * @since Available in iOS 3.0 and later.
      */
+    @Method(selector = "initWithImage:highlightedImage:")
     public UIImageView(UIImage image, UIImage highlightedImage) { super((SkipInit) null); initObject(init(image, highlightedImage)); }
     /*</constructors>*/
     public UIImageView(CGRect frame) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImpactFeedbackGenerator.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIImpactFeedbackGenerator.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIImpactFeedbackGenerator() {}
     protected UIImpactFeedbackGenerator(Handle h, long handle) { super(h, handle); }
     protected UIImpactFeedbackGenerator(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithStyle:")
     public UIImpactFeedbackGenerator(UIImpactFeedbackStyle style) { super((SkipInit) null); initObject(init(style)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIInputView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIInputView.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     public UIInputView() {}
     protected UIInputView(Handle h, long handle) { super(h, handle); }
     protected UIInputView(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithFrame:inputViewStyle:")
     public UIInputView(@ByVal CGRect frame, UIInputViewStyle inputViewStyle) { super((SkipInit) null); initObject(init(frame, inputViewStyle)); }
+    @Method(selector = "initWithCoder:")
     public UIInputView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIInterpolatingMotionEffect.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIInterpolatingMotionEffect.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     public UIInterpolatingMotionEffect() {}
     protected UIInterpolatingMotionEffect(Handle h, long handle) { super(h, handle); }
     protected UIInterpolatingMotionEffect(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithKeyPath:type:")
     public UIInterpolatingMotionEffect(String keyPath, UIInterpolatingMotionEffectType type) { super((SkipInit) null); initObject(init(keyPath, type)); }
+    @Method(selector = "initWithCoder:")
     public UIInterpolatingMotionEffect(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIKeyCommand.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIKeyCommand.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIKeyCommand() {}
     protected UIKeyCommand(Handle h, long handle) { super(h, handle); }
     protected UIKeyCommand(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UIKeyCommand(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     public UIKeyCommand(String input, UIKeyModifierFlags modifierFlags, Selector action) { super((Handle) null, create(input, modifierFlags, action)); retain(getHandle()); }
     /**

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILayoutGuide.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILayoutGuide.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UILayoutGuide() {}
     protected UILayoutGuide(Handle h, long handle) { super(h, handle); }
     protected UILayoutGuide(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UILayoutGuide(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILocalNotification.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UILocalNotification.java
@@ -55,6 +55,7 @@ import org.robovm.apple.corelocation.*;
     public UILocalNotification() {}
     protected UILocalNotification(Handle h, long handle) { super(h, handle); }
     protected UILocalNotification(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UILocalNotification(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMarkupTextPrintFormatter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMarkupTextPrintFormatter.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIMarkupTextPrintFormatter() {}
     protected UIMarkupTextPrintFormatter(Handle h, long handle) { super(h, handle); }
     protected UIMarkupTextPrintFormatter(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithMarkupText:")
     public UIMarkupTextPrintFormatter(String markupText) { super((SkipInit) null); initObject(init(markupText)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMenuItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMenuItem.java
@@ -104,6 +104,7 @@ import org.robovm.apple.corelocation.*;
     public UIMenuItem() {}
     protected UIMenuItem(Handle h, long handle) { super(h, handle); }
     protected UIMenuItem(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithTitle:action:")
     public UIMenuItem(String title, Selector action) { super((SkipInit) null); initObject(init(title, action)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMotionEffect.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIMotionEffect.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIMotionEffect() {}
     protected UIMotionEffect(Handle h, long handle) { super(h, handle); }
     protected UIMotionEffect(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UIMotionEffect(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINavigationController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINavigationController.java
@@ -56,7 +56,9 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 5.0 and later.
      */
+    @Method(selector = "initWithNavigationBarClass:toolbarClass:")
     public UINavigationController(Class<? extends UINavigationBar> navigationBarClass, Class<? extends UIToolbar> toolbarClass) { super((SkipInit) null); initObject(init(navigationBarClass, toolbarClass)); }
+    @Method(selector = "initWithRootViewController:")
     public UINavigationController(UIViewController rootViewController) { super((SkipInit) null); initObject(init(rootViewController)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINavigationItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UINavigationItem.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     public UINavigationItem() {}
     protected UINavigationItem(Handle h, long handle) { super(h, handle); }
     protected UINavigationItem(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithTitle:")
     public UINavigationItem(String title) { super((SkipInit) null); initObject(init(title)); }
+    @Method(selector = "initWithCoder:")
     public UINavigationItem(NSCoder coder) { super((SkipInit) null); initObject(init(coder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPageViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPageViewController.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     public UIPageViewController() {}
     protected UIPageViewController(Handle h, long handle) { super(h, handle); }
     protected UIPageViewController(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithTransitionStyle:navigationOrientation:options:")
     public UIPageViewController(UIPageViewControllerTransitionStyle style, UIPageViewControllerNavigationOrientation navigationOrientation, UIPageViewControllerOptions options) { super((SkipInit) null); initObject(init(style, navigationOrientation, options)); }
+    @Method(selector = "initWithCoder:")
     public UIPageViewController(NSCoder coder) { super((SkipInit) null); initObject(init(coder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPopoverController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPopoverController.java
@@ -55,6 +55,7 @@ import org.robovm.apple.corelocation.*;
     public UIPopoverController() {}
     protected UIPopoverController(Handle h, long handle) { super(h, handle); }
     protected UIPopoverController(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithContentViewController:")
     public UIPopoverController(UIViewController viewController) { super((SkipInit) null); initObject(init(viewController)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPresentationController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPresentationController.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     protected UIPresentationController() {}
     protected UIPresentationController(Handle h, long handle) { super(h, handle); }
     protected UIPresentationController(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithPresentedViewController:presentingViewController:")
     public UIPresentationController(UIViewController presentedViewController, UIViewController presentingViewController) { super((SkipInit) null); initObject(init(presentedViewController, presentingViewController)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewInteraction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPreviewInteraction.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     protected UIPreviewInteraction() {}
     protected UIPreviewInteraction(Handle h, long handle) { super(h, handle); }
     protected UIPreviewInteraction(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithView:")
     public UIPreviewInteraction(UIView view) { super((SkipInit) null); initObject(init(view)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrintInfo.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPrintInfo.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIPrintInfo() {}
     protected UIPrintInfo(Handle h, long handle) { super(h, handle); }
     protected UIPrintInfo(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UIPrintInfo(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     public UIPrintInfo(NSDictionary<?, ?> dictionary) { super((Handle) null, create(dictionary)); retain(getHandle()); }
     /*</constructors>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIProgressView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIProgressView.java
@@ -53,8 +53,11 @@ import org.robovm.apple.corelocation.*;
     public UIProgressView() {}
     protected UIProgressView(Handle h, long handle) { super(h, handle); }
     protected UIProgressView(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithFrame:")
     public UIProgressView(@ByVal CGRect frame) { super((SkipInit) null); initObject(init(frame)); }
+    @Method(selector = "initWithCoder:")
     public UIProgressView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    @Method(selector = "initWithProgressViewStyle:")
     public UIProgressView(UIProgressViewStyle style) { super((SkipInit) null); initObject(init(style)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPushBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIPushBehavior.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UIPushBehavior() {}
     protected UIPushBehavior(Handle h, long handle) { super(h, handle); }
     protected UIPushBehavior(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithItems:mode:")
     public UIPushBehavior(List<UIDynamicItem> items, UIPushBehaviorMode mode) { super((SkipInit) null); initObject(init(items, mode)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIReferenceLibraryViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIReferenceLibraryViewController.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     protected UIReferenceLibraryViewController() {}
     protected UIReferenceLibraryViewController(Handle h, long handle) { super(h, handle); }
     protected UIReferenceLibraryViewController(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithTerm:")
     public UIReferenceLibraryViewController(String term) { super((SkipInit) null); initObject(init(term)); }
+    @Method(selector = "initWithCoder:")
     public UIReferenceLibraryViewController(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIRegion.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIRegion.java
@@ -53,8 +53,11 @@ import org.robovm.apple.corelocation.*;
     public UIRegion() {}
     protected UIRegion(Handle h, long handle) { super(h, handle); }
     protected UIRegion(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithRadius:")
     public UIRegion(@MachineSizedFloat double radius) { super((SkipInit) null); initObject(init(radius)); }
+    @Method(selector = "initWithSize:")
     public UIRegion(@ByVal CGSize size) { super((SkipInit) null); initObject(init(size)); }
+    @Method(selector = "initWithCoder:")
     public UIRegion(NSCoder decoder) { super((SkipInit) null); initObject(init(decoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchBar.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchBar.java
@@ -55,7 +55,9 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     public UISearchBar() {}
     protected UISearchBar(Handle h, long handle) { super(h, handle); }
     protected UISearchBar(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithFrame:")
     public UISearchBar(@ByVal CGRect frame) { super((SkipInit) null); initObject(init(frame)); }
+    @Method(selector = "initWithCoder:")
     public UISearchBar(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchContainerViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchContainerViewController.java
@@ -51,6 +51,7 @@ import org.robovm.apple.corelocation.*;
     public UISearchContainerViewController() {}
     protected UISearchContainerViewController(Handle h, long handle) { super(h, handle); }
     protected UISearchContainerViewController(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithSearchController:")
     public UISearchContainerViewController(UISearchController searchController) { super((SkipInit) null); initObject(init(searchController)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchController.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UISearchController() {}
     protected UISearchController(Handle h, long handle) { super(h, handle); }
     protected UISearchController(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithSearchResultsController:")
     public UISearchController(UIViewController searchResultsController) { super((SkipInit) null); initObject(init(searchResultsController)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchDisplayController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISearchDisplayController.java
@@ -55,6 +55,7 @@ import org.robovm.apple.corelocation.*;
     public UISearchDisplayController() {}
     protected UISearchDisplayController(Handle h, long handle) { super(h, handle); }
     protected UISearchDisplayController(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithSearchBar:contentsController:")
     public UISearchDisplayController(UISearchBar searchBar, UIViewController viewController) { super((SkipInit) null); initObject(init(searchBar, viewController)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISegmentedControl.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISegmentedControl.java
@@ -57,6 +57,7 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     public UISegmentedControl() {}
     protected UISegmentedControl(Handle h, long handle) { super(h, handle); }
     protected UISegmentedControl(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithItems:")
     public UISegmentedControl(NSArray<?> items) { super((SkipInit) null); initObject(init(items)); }
     /*</constructors>*/
     public UISegmentedControl(CGRect frame) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISimpleTextPrintFormatter.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISimpleTextPrintFormatter.java
@@ -53,10 +53,12 @@ import org.robovm.apple.corelocation.*;
     public UISimpleTextPrintFormatter() {}
     protected UISimpleTextPrintFormatter(Handle h, long handle) { super(h, handle); }
     protected UISimpleTextPrintFormatter(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithText:")
     public UISimpleTextPrintFormatter(String text) { super((SkipInit) null); initObject(init(text)); }
     /**
      * @since Available in iOS 7.0 and later.
      */
+    @Method(selector = "initWithAttributedText:")
     public UISimpleTextPrintFormatter(NSAttributedString attributedText) { super((SkipInit) null); initObject(init(attributedText)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISnapBehavior.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISnapBehavior.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UISnapBehavior() {}
     protected UISnapBehavior(Handle h, long handle) { super(h, handle); }
     protected UISnapBehavior(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithItem:snapToPoint:")
     public UISnapBehavior(UIDynamicItem item, @ByVal CGPoint point) { super((SkipInit) null); initObject(init(item, point)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISpringTimingParameters.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISpringTimingParameters.java
@@ -53,9 +53,13 @@ import org.robovm.apple.corelocation.*;
     public UISpringTimingParameters() {}
     protected UISpringTimingParameters(Handle h, long handle) { super(h, handle); }
     protected UISpringTimingParameters(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UISpringTimingParameters(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    @Method(selector = "initWithDampingRatio:initialVelocity:")
     public UISpringTimingParameters(@MachineSizedFloat double ratio, @ByVal CGVector velocity) { super((SkipInit) null); initObject(init(ratio, velocity)); }
+    @Method(selector = "initWithMass:stiffness:damping:initialVelocity:")
     public UISpringTimingParameters(@MachineSizedFloat double mass, @MachineSizedFloat double stiffness, @MachineSizedFloat double damping, @ByVal CGVector velocity) { super((SkipInit) null); initObject(init(mass, stiffness, damping, velocity)); }
+    @Method(selector = "initWithDampingRatio:")
     public UISpringTimingParameters(@MachineSizedFloat double ratio) { super((SkipInit) null); initObject(init(ratio)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStackView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStackView.java
@@ -53,8 +53,11 @@ import org.robovm.apple.corelocation.*;
     public UIStackView() {}
     protected UIStackView(Handle h, long handle) { super(h, handle); }
     protected UIStackView(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithFrame:")
     public UIStackView(@ByVal CGRect frame) { super((SkipInit) null); initObject(init(frame)); }
+    @Method(selector = "initWithCoder:")
     public UIStackView(NSCoder coder) { super((SkipInit) null); initObject(init(coder)); }
+    @Method(selector = "initWithArrangedSubviews:")
     public UIStackView(NSArray<UIView> views) { super((SkipInit) null); initObject(init(views)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStoryboardSegue.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIStoryboardSegue.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     protected UIStoryboardSegue() {}
     protected UIStoryboardSegue(Handle h, long handle) { super(h, handle); }
     protected UIStoryboardSegue(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithIdentifier:source:destination:")
     public UIStoryboardSegue(String identifier, UIViewController source, UIViewController destination) { super((SkipInit) null); initObject(init(identifier, source, destination)); }
     /**
      * @since Available in iOS 6.0 and later.

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISwitch.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UISwitch.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     public UISwitch() {}
     protected UISwitch(Handle h, long handle) { super(h, handle); }
     protected UISwitch(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithFrame:")
     public UISwitch(@ByVal CGRect frame) { super((SkipInit) null); initObject(init(frame)); }
+    @Method(selector = "initWithCoder:")
     public UISwitch(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITabBarItem.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITabBarItem.java
@@ -53,12 +53,16 @@ import org.robovm.apple.corelocation.*;
     public UITabBarItem() {}
     protected UITabBarItem(Handle h, long handle) { super(h, handle); }
     protected UITabBarItem(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UITabBarItem(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
+    @Method(selector = "initWithTitle:image:tag:")
     public UITabBarItem(String title, UIImage image, @MachineSizedSInt long tag) { super((SkipInit) null); initObject(init(title, image, tag)); }
     /**
      * @since Available in iOS 7.0 and later.
      */
+    @Method(selector = "initWithTitle:image:selectedImage:")
     public UITabBarItem(String title, UIImage image, UIImage selectedImage) { super((SkipInit) null); initObject(init(title, image, selectedImage)); }
+    @Method(selector = "initWithTabBarSystemItem:tag:")
     public UITabBarItem(UITabBarSystemItem systemItem, @MachineSizedSInt long tag) { super((SkipInit) null); initObject(init(systemItem, tag)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableView.java
@@ -63,7 +63,9 @@ import org.robovm.apple.corelocation.*;
     public UITableView() {}
     protected UITableView(Handle h, long handle) { super(h, handle); }
     protected UITableView(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithFrame:style:")
     public UITableView(@ByVal CGRect frame, UITableViewStyle style) { super((SkipInit) null); initObject(init(frame, style)); }
+    @Method(selector = "initWithCoder:")
     public UITableView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     public UITableView(CGRect frame) {

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewCell.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewCell.java
@@ -56,7 +56,9 @@ import org.robovm.apple.corelocation.*;
     /**
      * @since Available in iOS 3.0 and later.
      */
+    @Method(selector = "initWithStyle:reuseIdentifier:")
     public UITableViewCell(UITableViewCellStyle style, String reuseIdentifier) { super((SkipInit) null); initObject(init(style, reuseIdentifier)); }
+    @Method(selector = "initWithCoder:")
     public UITableViewCell(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewController.java
@@ -53,8 +53,11 @@ import org.robovm.apple.corelocation.*;
     public UITableViewController() {}
     protected UITableViewController(Handle h, long handle) { super(h, handle); }
     protected UITableViewController(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithStyle:")
     public UITableViewController(UITableViewStyle style) { super((SkipInit) null); initObject(init(style)); }
+    @Method(selector = "initWithNibName:bundle:")
     public UITableViewController(String nibNameOrNil, NSBundle nibBundleOrNil) { super((SkipInit) null); initObject(init(nibNameOrNil, nibBundleOrNil)); }
+    @Method(selector = "initWithCoder:")
     public UITableViewController(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewHeaderFooterView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITableViewHeaderFooterView.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     public UITableViewHeaderFooterView() {}
     protected UITableViewHeaderFooterView(Handle h, long handle) { super(h, handle); }
     protected UITableViewHeaderFooterView(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithReuseIdentifier:")
     public UITableViewHeaderFooterView(String reuseIdentifier) { super((SkipInit) null); initObject(init(reuseIdentifier)); }
+    @Method(selector = "initWithCoder:")
     public UITableViewHeaderFooterView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputStringTokenizer.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextInputStringTokenizer.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UITextInputStringTokenizer() {}
     protected UITextInputStringTokenizer(Handle h, long handle) { super(h, handle); }
     protected UITextInputStringTokenizer(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithTextInput:")
     public UITextInputStringTokenizer(UITextInput textInput) { super((SkipInit) null); initObject(init(textInput)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITextView.java
@@ -84,7 +84,9 @@ import org.robovm.apple.coremedia.CMTextMarkupAttributes;
     /**
      * @since Available in iOS 7.0 and later.
      */
+    @Method(selector = "initWithFrame:textContainer:")
     public UITextView(@ByVal CGRect frame, NSTextContainer textContainer) { super((SkipInit) null); initObject(init(frame, textContainer)); }
+    @Method(selector = "initWithCoder:")
     public UITextView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITraitCollection.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UITraitCollection.java
@@ -53,6 +53,7 @@ import org.robovm.apple.corelocation.*;
     public UITraitCollection() {}
     protected UITraitCollection(Handle h, long handle) { super(h, handle); }
     protected UITraitCollection(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UITraitCollection(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /**
      * @since Available in iOS 10.0 and later.

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationAction.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationAction.java
@@ -55,6 +55,7 @@ import org.robovm.apple.corelocation.*;
     public UIUserNotificationAction() {}
     protected UIUserNotificationAction(Handle h, long handle) { super(h, handle); }
     protected UIUserNotificationAction(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UIUserNotificationAction(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationCategory.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIUserNotificationCategory.java
@@ -55,6 +55,7 @@ import org.robovm.apple.corelocation.*;
     public UIUserNotificationCategory() {}
     protected UIUserNotificationCategory(Handle h, long handle) { super(h, handle); }
     protected UIUserNotificationCategory(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithCoder:")
     public UIUserNotificationCategory(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIView.java
@@ -54,7 +54,9 @@ import org.robovm.apple.corelocation.*;
     @Deprecated protected UIView(long handle) { super(handle); }
     protected UIView(Handle h, long handle) { super(h, handle); }
     protected UIView(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithFrame:")
     public UIView(@ByVal CGRect frame) { super((SkipInit) null); initObject(init(frame)); }
+    @Method(selector = "initWithCoder:")
     public UIView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewController.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewController.java
@@ -70,7 +70,9 @@ import org.robovm.apple.mediaplayer.MPMoviePlayerViewController;
     @Deprecated protected UIViewController(long handle) { super(handle); }
     protected UIViewController(Handle h, long handle) { super(h, handle); }
     protected UIViewController(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithNibName:bundle:")
     public UIViewController(String nibNameOrNil, NSBundle nibBundleOrNil) { super((SkipInit) null); initObject(init(nibNameOrNil, nibBundleOrNil)); }
+    @Method(selector = "initWithCoder:")
     public UIViewController(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewPropertyAnimator.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIViewPropertyAnimator.java
@@ -53,9 +53,13 @@ import org.robovm.apple.corelocation.*;
     public UIViewPropertyAnimator() {}
     protected UIViewPropertyAnimator(Handle h, long handle) { super(h, handle); }
     protected UIViewPropertyAnimator(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithDuration:timingParameters:")
     public UIViewPropertyAnimator(double duration, UITimingCurveProvider parameters) { super((SkipInit) null); initObject(init(duration, parameters)); }
+    @Method(selector = "initWithDuration:curve:animations:")
     public UIViewPropertyAnimator(double duration, UIViewAnimationCurve curve, @Block Runnable animations) { super((SkipInit) null); initObject(init(duration, curve, animations)); }
+    @Method(selector = "initWithDuration:controlPoint1:controlPoint2:animations:")
     public UIViewPropertyAnimator(double duration, @ByVal CGPoint point1, @ByVal CGPoint point2, @Block Runnable animations) { super((SkipInit) null); initObject(init(duration, point1, point2, animations)); }
+    @Method(selector = "initWithDuration:dampingRatio:animations:")
     public UIViewPropertyAnimator(double duration, @MachineSizedFloat double ratio, @Block Runnable animations) { super((SkipInit) null); initObject(init(duration, ratio, animations)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIVisualEffectView.java
+++ b/compiler/cocoatouch/src/main/java/org/robovm/apple/uikit/UIVisualEffectView.java
@@ -53,7 +53,9 @@ import org.robovm.apple.corelocation.*;
     public UIVisualEffectView() {}
     protected UIVisualEffectView(Handle h, long handle) { super(h, handle); }
     protected UIVisualEffectView(SkipInit skipInit) { super(skipInit); }
+    @Method(selector = "initWithEffect:")
     public UIVisualEffectView(UIVisualEffect effect) { super((SkipInit) null); initObject(init(effect)); }
+    @Method(selector = "initWithCoder:")
     public UIVisualEffectView(NSCoder aDecoder) { super((SkipInit) null); initObject(init(aDecoder)); }
     /*</constructors>*/
     /*<properties>*/

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/objc/ObjCMemberPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/objc/ObjCMemberPlugin.java
@@ -16,21 +16,9 @@
  */
 package org.robovm.compiler.plugin.objc;
 
-import static org.robovm.compiler.Annotations.*;
-import static soot.Modifier.*;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
-
 import org.apache.commons.lang3.StringUtils;
 import org.robovm.compiler.Annotations;
-import org.robovm.compiler.Annotations.Visibility;
+import org.robovm.compiler.Annotations.*;
 import org.robovm.compiler.CompilerException;
 import org.robovm.compiler.MarshalerLookup.MarshalSite;
 import org.robovm.compiler.MarshalerLookup.MarshalerMethod;
@@ -41,11 +29,11 @@ import org.robovm.compiler.config.Config;
 import org.robovm.compiler.plugin.AbstractCompilerPlugin;
 import org.robovm.compiler.plugin.CompilerPlugin;
 import org.robovm.compiler.util.generic.SootMethodType;
-
 import soot.Body;
 import soot.BooleanType;
 import soot.DoubleType;
 import soot.FloatType;
+import soot.IntType;
 import soot.Local;
 import soot.LongType;
 import soot.Modifier;
@@ -69,6 +57,9 @@ import soot.jimple.IntConstant;
 import soot.jimple.InvokeExpr;
 import soot.jimple.InvokeStmt;
 import soot.jimple.Jimple;
+import soot.jimple.JimpleBody;
+import soot.jimple.NopStmt;
+import soot.jimple.NullConstant;
 import soot.jimple.StaticInvokeExpr;
 import soot.jimple.Stmt;
 import soot.jimple.StringConstant;
@@ -76,6 +67,18 @@ import soot.tagkit.AnnotationStringElem;
 import soot.tagkit.AnnotationTag;
 import soot.tagkit.SignatureTag;
 import soot.util.Chain;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.robovm.compiler.Annotations.*;
+import static soot.Modifier.*;
 
 /**
  * {@link CompilerPlugin} which transforms Objective-C methods and properties to @Bridge
@@ -92,9 +95,11 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
     public static final String IBOUTLET = "L" + OBJC_ANNOTATIONS_PACKAGE + "/IBOutlet;";
     public static final String IBOUTLETCOLLECTION = "L" + OBJC_ANNOTATIONS_PACKAGE + "/IBOutletCollection;";
     public static final String NATIVE_CLASS = "L" + OBJC_ANNOTATIONS_PACKAGE + "/NativeClass;";
+    public static final String CUSTOM_CLASS = "L" + OBJC_ANNOTATIONS_PACKAGE + "/CustomClass;";
     public static final String NATIVE_PROTOCOL_PROXY = "L" + OBJC_ANNOTATIONS_PACKAGE + "/NativeProtocolProxy;";
     public static final String TYPE_ENCODING = "L" + OBJC_ANNOTATIONS_PACKAGE + "/TypeEncoding;";
     public static final String SELECTOR = "org.robovm.objc.Selector";
+    public static final String NATIVE_OBJECT = "org.robovm.rt.bro.NativeObject";
     public static final String OBJC_SUPER = "org.robovm.objc.ObjCSuper";
     public static final String OBJC_CLASS = "org.robovm.objc.ObjCClass";
     public static final String OBJC_OBJECT = "org.robovm.objc.ObjCObject";
@@ -109,6 +114,7 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
 
     private boolean initialized = false;
     private Config config;
+    private SootClass org_robovm_rt_bro_NativeObject = null;
     private SootClass org_robovm_objc_ObjCClass = null;
     private SootClass org_robovm_objc_ObjCSuper = null;
     private SootClass org_robovm_objc_ObjCObject = null;
@@ -130,6 +136,12 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
     private SootMethodRef org_robovm_objc_ObjCObject_updateStrongRef = null;
     private SootMethodRef org_robovm_objc_ObjCExtensions_updateStrongRef = null;
     private SootMethodRef org_robovm_objc_Selector_register = null;
+    private SootMethodRef org_robovm_objc_ObjCObject_getPeerObject = null;
+    private SootMethodRef org_robovm_rt_bro_NativeObject_setHandle = null;
+    private SootMethodRef org_robovm_rt_bro_NativeObject_getHandle = null;
+    private SootMethodRef org_robovm_apple_foundation_NSObject_forceSkipInit = null;
+    private SootClass java_lang_NoSuchMethodError = null;
+    private SootMethodRef java_lang_NoSuchMethodError_init = null;
 
     static SootMethod getOrCreateStaticInitializer(SootClass sootClass) {
         for (SootMethod m : sootClass.getMethods()) {
@@ -177,6 +189,23 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
         copyAnnotations(annotatedMethod, m, extensions);
         
         createGenericSignatureForMsgSend(annotatedMethod, m, paramTypes, extensions);
+
+        return m;
+    }
+
+    @SuppressWarnings("unchecked")
+    private SootMethod getMsgSendInitMethod(String selectorName, SootMethod method) {
+
+        List<Type> paramTypes = new ArrayList<>();
+        paramTypes.add(LongType.v());
+        paramTypes.add(org_robovm_objc_Selector.getType());
+        paramTypes.addAll(method.getParameterTypes());
+        SootMethod m = new SootMethod("$cb$" + selectorName.replace(':', '$'),
+                paramTypes, LongType.v(), STATIC | PRIVATE);
+        copyAnnotations(method, m, false);
+        Annotations.addRuntimeVisibleParameterAnnotation(m, 0, Annotations.POINTER);
+        Annotations.addRuntimeVisibleAnnotation(m, Annotations.POINTER);
+        createGenericSignatureForMsgSend(method, m, paramTypes, false);
 
         return m;
     }
@@ -357,6 +386,7 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
         org_robovm_objc_ObjCObject = r.resolveClass(OBJC_OBJECT, SootClass.HIERARCHY);
         org_robovm_objc_ObjCExtensions = r.resolveClass(OBJC_EXTENSIONS, SootClass.HIERARCHY);
         // These only have to be DANGLING
+        org_robovm_rt_bro_NativeObject = r.makeClassRef(NATIVE_OBJECT);
         org_robovm_objc_ObjCClass = r.makeClassRef(OBJC_CLASS);
         org_robovm_objc_ObjCSuper = r.makeClassRef(OBJC_SUPER);
         org_robovm_objc_ObjCRuntime = r.makeClassRef(OBJC_RUNTIME);
@@ -416,6 +446,38 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
                                 java_lang_Object.getType(),
                                 java_lang_Object.getType()),
                         VoidType.v(), true);
+        org_robovm_objc_ObjCObject_getPeerObject =
+                Scene.v().makeMethodRef(
+                        org_robovm_objc_ObjCObject,
+                        "getPeerObject",
+                        Arrays.<Type> asList(LongType.v()),
+                        this.org_robovm_objc_ObjCObject.getType(), true);
+        org_robovm_rt_bro_NativeObject_setHandle =
+                Scene.v().makeMethodRef(
+                        org_robovm_rt_bro_NativeObject,
+                        "setHandle",
+                        Arrays.<Type> asList(
+                                LongType.v()),
+                        VoidType.v(), false);
+        org_robovm_rt_bro_NativeObject_getHandle =
+                Scene.v().makeMethodRef(
+                        org_robovm_rt_bro_NativeObject,
+                        "getHandle",
+                        Collections.<Type>emptyList(),
+                        LongType.v(), false);
+        org_robovm_apple_foundation_NSObject_forceSkipInit =
+                Scene.v().makeMethodRef(
+                        org_robovm_apple_foundation_NSObject,
+                        "forceSkipInit",
+                        Collections.<Type>emptyList(),
+                        VoidType.v(), false);
+        java_lang_NoSuchMethodError = r.makeClassRef("java.lang.NoSuchMethodError");
+        java_lang_NoSuchMethodError_init =
+                Scene.v().makeMethodRef(
+                        java_lang_NoSuchMethodError,
+                        "<init>",
+                        Arrays.<Type> asList(java_lang_String.getType()),
+                        VoidType.v(), false);
         initialized = true;
     }
 
@@ -500,16 +562,25 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
         init(config);
         SootClass sootClass = clazz.getSootClass();
         boolean extensions = false;
+        boolean customClass = hasAnnotation(sootClass, CUSTOM_CLASS);
         if (!sootClass.isInterface()
                 && (isObjCObject(sootClass) || (extensions = isObjCExtensions(sootClass)))) {
 
             Set<String> selectors = new TreeSet<>();
             Set<String> overridables = new HashSet<>();
+            Set<String> initializers = new HashSet<>();
             for (SootMethod method : sootClass.getMethods()) {
                 if (!"<clinit>".equals(method.getName()) && !"<init>".equals(method.getName())) {
                     transformMethod(config, clazz, sootClass, method, selectors, overridables, extensions);
+                } else if (customClass && "<init>".equals(method.getName())) {
+                    transformConstructor(sootClass, method, initializers);
                 }
             }
+
+            if (customClass) {
+                transformParentConstructors(sootClass, initializers);
+            }
+
             addBindCall(sootClass);
             if (!extensions) {
                 addObjCClassField(sootClass);
@@ -542,6 +613,266 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
         }
         return b;
     }
+
+
+    private void transformConstructor(SootClass sootClass, SootMethod constructor, Set<String> initializers) {
+        initializers.add(constructor.getSubSignature());
+
+        AnnotationTag annotation = getAnnotation(constructor, METHOD);
+        if (annotation == null) {
+            SootMethod superConstructor = findOverridenMethodWithAnnotation(sootClass, constructor, METHOD);
+            if (superConstructor != null)
+                annotation = getAnnotation(superConstructor, METHOD);
+        }
+
+        if (annotation == null) {
+            // this constructor doesn't have annotation attached
+            return;
+        }
+
+        // Determine the selector
+        String selectorName = readStringElem(annotation, "selector", "").trim();
+        if (selectorName.length() == 0) {
+            // TODO: warning here
+            return;
+        }
+
+
+        //
+        createConstructorCallback(sootClass, constructor, selectorName);
+    }
+
+    private void transformParentConstructors(SootClass sootClass, Set<String> initializers) {
+        // get default constructor
+        SootMethod defaultConstructor;
+        try {
+            defaultConstructor = sootClass.getMethod("<init>", Collections.<Type>emptyList(), VoidType.v());
+        } catch (RuntimeException e) {
+            // Soot throws RuntimeException if method not found
+            defaultConstructor = null;
+        }
+
+        // move through subclasses
+        SootClass supercls = sootClass.getSuperclass();
+        while (!supercls.getType().equals(this.org_robovm_objc_ObjCObject.getType())) {
+            for (SootMethod method : supercls.getMethods()) {
+                 if (!"<init>".equals(method.getName()))
+                     continue;
+
+                // check if such constructor already been processed
+                if (initializers.contains(method.getSubSignature()))
+                    continue;
+                initializers.add(method.getSubSignature());
+
+                // check if there is native method information attached
+                AnnotationTag annotation = getAnnotation(method, METHOD);
+                if (annotation == null) {
+                    SootMethod superConstructor = findOverridenMethodWithAnnotation(supercls, method, METHOD);
+                    if (superConstructor != null)
+                        annotation = getAnnotation(superConstructor, METHOD);
+                }
+
+                // there is no method annotation attached which means there is no way to create callback
+                if (annotation == null)
+                    continue;
+
+                // Determine the selector
+                String selectorName = readStringElem(annotation, "selector", "").trim();
+                if (selectorName.length() == 0) {
+                    // TODO: warning here
+                    continue;
+                }
+
+                // convert constructor
+                if (defaultConstructor != null)
+                    createParentConstructorCallback(sootClass, defaultConstructor, method, selectorName);
+                else
+                    createParentConstructorExceptionCallback(sootClass, method, selectorName);
+            }
+
+            supercls = supercls.getSuperclass();
+        }
+    }
+
+
+    private void createConstructorCallback(SootClass sootClass, SootMethod constructor, String selectorName) {
+        Jimple jimple = Jimple.v();
+
+        SootMethod callbackMethod = this.getMsgSendInitMethod(selectorName, constructor);
+        sootClass.addMethod(callbackMethod);
+
+        addCallbackAnnotation(callbackMethod);
+        addBindSelectorAnnotation(callbackMethod, selectorName);
+
+        JimpleBody jimpleBody = jimple.newBody(callbackMethod);
+        callbackMethod.setActiveBody(jimpleBody);
+        Body body = callbackMethod.getActiveBody();
+        PatchingChain<Unit> units = body.getUnits();
+
+        // pick parameters first using small hack
+        jimpleBody.insertIdentityStmts();
+        ArrayList<Local> args = new ArrayList<>(jimpleBody.getLocals());
+
+        Local self = jimple.newLocal("$self", LongType.v());
+        body.getLocals().add(self);
+        units.add(jimple.newIdentityStmt(self, jimple.newParameterRef(LongType.v(), 0)));
+
+
+        Local thiz = jimple.newLocal("$this", sootClass.getType());
+        body.getLocals().add(thiz);
+
+        NopStmt noClassCreatedAnchor = jimple.newNopStmt();
+        NopStmt classAlreadyCreated = jimple.newNopStmt();
+        Local peer = jimple.newLocal("$peer", this.org_robovm_objc_ObjCObject.getType());
+        body.getLocals().add(peer);
+
+        units.add(jimple.newAssignStmt(peer, jimple.newStaticInvokeExpr(this.org_robovm_objc_ObjCObject_getPeerObject, self)));
+        units.add(jimple.newAssignStmt(thiz, jimple.newCastExpr(peer, thiz.getType())));
+        units.add(jimple.newIfStmt(jimple.newEqExpr(thiz, NullConstant.v()), noClassCreatedAnchor));
+        units.add(classAlreadyCreated);
+        units.add(jimple.newReturnStmt(self));
+
+        // lets create another instance of class
+        units.add(noClassCreatedAnchor);
+        units.add(jimple.newAssignStmt(thiz, jimple.newNewExpr(sootClass.getType())));
+
+        // setting handle before init, this will allow NSObject to not alloc another native part
+        units.add(jimple.newInvokeStmt(jimple.newSpecialInvokeExpr(thiz, this.org_robovm_rt_bro_NativeObject_setHandle, self)));
+
+        // constructor goes
+        units.add(jimple.newInvokeStmt(jimple.newSpecialInvokeExpr(thiz, constructor.makeRef(), args.subList(2, args.size()))));
+
+        // call after marshaled to retain native part
+        SootMethod afterMarshaled = findMethod(sootClass, "afterMarshaled", Arrays.<Type> asList(IntType.v()), VoidType.v(), true);
+        units.add(jimple.newInvokeStmt(jimple.newSpecialInvokeExpr(thiz, afterMarshaled.makeRef(), IntConstant.v(0))));
+
+        // get back handle as it can be mutated as result of init
+        units.add(jimple.newAssignStmt(self, jimple.newSpecialInvokeExpr(thiz, this.org_robovm_rt_bro_NativeObject_getHandle)));
+        units.add(jimple.newReturnStmt(self));
+    }
+
+    private void createParentConstructorCallback(SootClass sootClass, SootMethod defaultConstructor, SootMethod parentConstructor, String selectorName) {
+        // init method is required as it is used initialize native instance
+        SootMethod initMethod = findMethod(sootClass, "init", parentConstructor.getParameterTypes(), LongType.v(), true);
+        if (initMethod == null) {
+            createParentConstructorExceptionCallback(sootClass, parentConstructor, selectorName);
+            return;
+        }
+
+        Jimple jimple = Jimple.v();
+
+        SootMethod callbackMethod = this.getMsgSendInitMethod(selectorName, parentConstructor);
+        sootClass.addMethod(callbackMethod);
+
+        addCallbackAnnotation(callbackMethod);
+        addBindSelectorAnnotation(callbackMethod, selectorName);
+
+        JimpleBody jimpleBody = jimple.newBody(callbackMethod);
+        callbackMethod.setActiveBody(jimpleBody);
+        Body body = callbackMethod.getActiveBody();
+        PatchingChain<Unit> units = body.getUnits();
+
+        // pick parameters first using small hack
+        jimpleBody.insertIdentityStmts();
+        ArrayList<Local> args = new ArrayList<>(jimpleBody.getLocals());
+
+        Local self = jimple.newLocal("$self", LongType.v());
+        body.getLocals().add(self);
+        units.add(jimple.newIdentityStmt(self, jimple.newParameterRef(LongType.v(), 0)));
+        Local thiz = jimple.newLocal("$this", sootClass.getType());
+        body.getLocals().add(thiz);
+
+        NopStmt noClassCreatedAnchor = jimple.newNopStmt();
+        NopStmt classAlreadyCreated = jimple.newNopStmt();
+        Local peer = jimple.newLocal("$peer", this.org_robovm_objc_ObjCObject.getType());
+        body.getLocals().add(peer);
+
+        units.add(jimple.newAssignStmt(peer, jimple.newStaticInvokeExpr(this.org_robovm_objc_ObjCObject_getPeerObject, self)));
+        units.add(jimple.newAssignStmt(thiz, jimple.newCastExpr(peer, thiz.getType())));
+        units.add(jimple.newIfStmt(jimple.newEqExpr(thiz, NullConstant.v()), noClassCreatedAnchor));
+        units.add(classAlreadyCreated);
+        units.add(jimple.newReturnStmt(self));
+
+        // lets create another instance of class
+        units.add(noClassCreatedAnchor);
+        units.add(jimple.newAssignStmt(thiz, jimple.newNewExpr(sootClass.getType())));
+
+        // setting handle before init, this will allow NSObject to not alloc another native part
+        units.add(jimple.newInvokeStmt(jimple.newSpecialInvokeExpr(thiz, this.org_robovm_rt_bro_NativeObject_setHandle, self)));
+
+        // tell default constructor not to call default init
+        if (isNSObject(sootClass.getType()))
+            units.add(jimple.newInvokeStmt(jimple.newSpecialInvokeExpr(thiz, this.org_robovm_apple_foundation_NSObject_forceSkipInit)));
+
+        // calling default constructor
+        units.add(jimple.newInvokeStmt(jimple.newSpecialInvokeExpr(thiz, defaultConstructor.makeRef(), Collections.<Type>emptyList())));
+
+        // now call the init method to initialize native part
+        units.add(jimple.newAssignStmt(self, jimple.newSpecialInvokeExpr(thiz, initMethod.makeRef(), args.subList(2, args.size()))));
+
+        // associate java object with native handle
+        SootMethod initObject = findMethod(sootClass, "initObject", Arrays.<Type> asList(LongType.v()), VoidType.v(), true);
+        units.add(jimple.newInvokeStmt(jimple.newSpecialInvokeExpr(thiz, initObject.makeRef(), self)));
+
+        // call after marshaled to retain native part
+        SootMethod afterMarshaled = findMethod(sootClass, "afterMarshaled", Arrays.<Type> asList(IntType.v()), VoidType.v(), true);
+        units.add(jimple.newInvokeStmt(jimple.newSpecialInvokeExpr(thiz, afterMarshaled.makeRef(), IntConstant.v(0))));
+
+        // now need
+
+        // get back handle as it can be mutated as result of init
+        units.add(jimple.newAssignStmt(self, jimple.newSpecialInvokeExpr(thiz, this.org_robovm_rt_bro_NativeObject_getHandle)));
+        units.add(jimple.newReturnStmt(self));
+    }
+
+    private void createParentConstructorExceptionCallback(SootClass sootClass, SootMethod constructor, String selectorName) {
+        Jimple jimple = Jimple.v();
+
+        SootMethod callbackMethod = this.getMsgSendInitMethod(selectorName, constructor);
+        sootClass.addMethod(callbackMethod);
+
+        addCallbackAnnotation(callbackMethod);
+        addBindSelectorAnnotation(callbackMethod, selectorName);
+
+        callbackMethod.setActiveBody(jimple.newBody(callbackMethod));
+        Body body = callbackMethod.getActiveBody();
+        PatchingChain<Unit> units = body.getUnits();
+
+        // callback defined as following <long self, selector, ...>, pick self there
+        Local self = jimple.newLocal("$self", LongType.v());
+        body.getLocals().add(self);
+        units.add(jimple.newIdentityStmt(self, jimple.newParameterRef(LongType.v(), 0)));
+
+        Local thiz = jimple.newLocal("$this", sootClass.getType());
+        body.getLocals().add(thiz);
+
+        Local peer = jimple.newLocal("$peer", this.org_robovm_objc_ObjCObject.getType());
+        body.getLocals().add(peer);
+        units.add(jimple.newAssignStmt(peer, jimple.newStaticInvokeExpr(this.org_robovm_objc_ObjCObject_getPeerObject, self)));
+        units.add(jimple.newAssignStmt(thiz, jimple.newCastExpr(peer, thiz.getType())));
+
+        // check if pointer already associated with object
+        // this is not expected but possible due mix of java/native classes and receiving call from
+        // native code as super
+        NopStmt noClassCreatedAnchor = jimple.newNopStmt();
+        NopStmt classAlreadyCreatedAnchor = jimple.newNopStmt();
+        units.add(jimple.newIfStmt(jimple.newEqExpr(thiz, NullConstant.v()), noClassCreatedAnchor));
+        units.add(classAlreadyCreatedAnchor);
+        units.add(jimple.newReturnStmt(self));
+
+        // there is no java part, throw exception
+        units.add(noClassCreatedAnchor);
+        String msg = String.format("Objctive-C called -%s which could not be mapped to a constructor in %s. Expected a default constructor or a %s constructor.",
+                selectorName, sootClass.getName(), constructor.getSubSignature());
+
+        Local exc = jimple.newLocal("$exc", java_lang_NoSuchMethodError.getType());
+        body.getLocals().add(exc);
+        units.add(jimple.newAssignStmt(exc, jimple.newNewExpr(java_lang_NoSuchMethodError.getType())));
+        units.add(jimple.newInvokeStmt(jimple.newSpecialInvokeExpr(exc, java_lang_NoSuchMethodError_init, StringConstant.v(msg))));
+        units.add(jimple.newThrowStmt(exc));
+    }
+
+
 
     private void transformMethod(Config config, Clazz clazz, SootClass sootClass,
             SootMethod method, Set<String> selectors, Set<String> overridables, boolean extensions) {
@@ -652,6 +983,26 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
         return false;
     }
 
+    private SootMethod findMethod(SootClass sootClass, String methodName, List<Type> parameterTypes, Type returnType, boolean includeObjC) {
+        boolean done;
+        do {
+            try {
+                SootMethod m = sootClass.getMethod(methodName, parameterTypes, returnType);
+                return m;
+            } catch (RuntimeException e) {
+                // Soot throws RuntimeException if method not found
+            }
+
+            // break if processed ObjC already
+            done = sootClass.getType().equals(org_robovm_objc_ObjCObject.getType());
+            sootClass = sootClass.getSuperclass();
+            // break if now is ObjC and it is not included
+            done |= !includeObjC && sootClass.getType().equals(org_robovm_objc_ObjCObject.getType());
+        } while (!done);
+
+        return null;
+    }
+
     private List<SootMethod> findOverriddenMethods(SootClass sootClass, SootMethod method) {
         SootClass supercls = sootClass.getSuperclass();
         while (!supercls.getType().equals(org_robovm_objc_ObjCObject.getType())) {
@@ -696,6 +1047,24 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
                 && !sootClass.getSuperclass().getType().equals(org_robovm_objc_ObjCObject.getType())) {
             findOverriddenMethodsOnInterfaces(sootClass.getSuperclass(), method, candidates);
         }
+    }
+
+    private SootMethod findOverridenMethodWithAnnotation(SootClass sootClass, SootMethod method, String annotationPath) {
+        SootClass supercls = sootClass.getSuperclass();
+        while (!supercls.getType().equals(org_robovm_objc_ObjCObject.getType())) {
+            try {
+                SootMethod m = supercls.getMethod(method.getName(), method.getParameterTypes(),
+                        method.getReturnType());
+                AnnotationTag annotation = getAnnotation(m, annotationPath);
+                if (annotation != null)
+                    return m;
+            } catch (RuntimeException e) {
+                // Soot throws RuntimeException if method not found
+            }
+            supercls = supercls.getSuperclass();
+        }
+
+        return null;
     }
 
     /**
@@ -1438,4 +1807,5 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
         annotationTag.addElem(new AnnotationStringElem(encoding, 's', "value"));
         addRuntimeVisibleAnnotation(method, annotationTag);
     }
+
 }

--- a/compiler/compiler/src/main/java/org/robovm/compiler/plugin/objc/ObjCMemberPlugin.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/plugin/objc/ObjCMemberPlugin.java
@@ -137,6 +137,7 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
     private SootMethodRef org_robovm_objc_ObjCExtensions_updateStrongRef = null;
     private SootMethodRef org_robovm_objc_Selector_register = null;
     private SootMethodRef org_robovm_objc_ObjCObject_getPeerObject = null;
+    private SootMethodRef org_robovm_objc_ObjCObject_retainCustomObjectFromCb = null;
     private SootMethodRef org_robovm_rt_bro_NativeObject_setHandle = null;
     private SootMethodRef org_robovm_rt_bro_NativeObject_getHandle = null;
     private SootMethodRef org_robovm_apple_foundation_NSObject_forceSkipInit = null;
@@ -452,6 +453,12 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
                         "getPeerObject",
                         Arrays.<Type> asList(LongType.v()),
                         this.org_robovm_objc_ObjCObject.getType(), true);
+        org_robovm_objc_ObjCObject_retainCustomObjectFromCb =
+                Scene.v().makeMethodRef(
+                        org_robovm_objc_ObjCObject,
+                        "retainCustomObjectFromCb",
+                        Arrays.<Type> asList(LongType.v()),
+                        VoidType.v(), true);
         org_robovm_rt_bro_NativeObject_setHandle =
                 Scene.v().makeMethodRef(
                         org_robovm_rt_bro_NativeObject,
@@ -746,6 +753,9 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
         SootMethod afterMarshaled = findMethod(sootClass, "afterMarshaled", Arrays.<Type> asList(IntType.v()), VoidType.v(), true);
         units.add(jimple.newInvokeStmt(jimple.newSpecialInvokeExpr(thiz, afterMarshaled.makeRef(), IntConstant.v(0))));
 
+        // notify objc object to keep reference to this java side
+        units.add(jimple.newInvokeStmt(jimple.newStaticInvokeExpr(this.org_robovm_objc_ObjCObject_retainCustomObjectFromCb, self)));
+
         // get back handle as it can be mutated as result of init
         units.add(jimple.newAssignStmt(self, jimple.newSpecialInvokeExpr(thiz, this.org_robovm_rt_bro_NativeObject_getHandle)));
         units.add(jimple.newReturnStmt(self));
@@ -818,7 +828,8 @@ public class ObjCMemberPlugin extends AbstractCompilerPlugin {
         SootMethod afterMarshaled = findMethod(sootClass, "afterMarshaled", Arrays.<Type> asList(IntType.v()), VoidType.v(), true);
         units.add(jimple.newInvokeStmt(jimple.newSpecialInvokeExpr(thiz, afterMarshaled.makeRef(), IntConstant.v(0))));
 
-        // now need
+        // notify objc object to keep reference to this java side
+        units.add(jimple.newInvokeStmt(jimple.newStaticInvokeExpr(this.org_robovm_objc_ObjCObject_retainCustomObjectFromCb, self)));
 
         // get back handle as it can be mutated as result of init
         units.add(jimple.newAssignStmt(self, jimple.newSpecialInvokeExpr(thiz, this.org_robovm_rt_bro_NativeObject_getHandle)));

--- a/compiler/objc/src/main/java/org/robovm/objc/ObjCObject.java
+++ b/compiler/objc/src/main/java/org/robovm/objc/ObjCObject.java
@@ -169,7 +169,7 @@ public abstract class ObjCObject extends NativeObject {
     }
 
     @SuppressWarnings("unchecked")
-    static <T extends ObjCObject> T getPeerObject(long handle) {
+    protected static <T extends ObjCObject> T getPeerObject(long handle) {
         synchronized (objcBridgeLock) {
             ObjCObjectRef ref = peers.get(handle);
             T o = ref != null ? (T) ref.get() : null;
@@ -254,6 +254,7 @@ public abstract class ObjCObject extends NativeObject {
         if (handle == 0L) {
             return null;
         }
+
         if (cls == ObjCClass.class) {
             return (T) ObjCClass.toObjCClass(handle);
         }
@@ -448,8 +449,11 @@ public abstract class ObjCObject extends NativeObject {
             int count = ObjCRuntime.int_objc_msgSend(self, retainCount);
             if (count <= 1) {
                 synchronized (CUSTOM_OBJECTS) {
-                    ObjCClass cls = ObjCClass.toObjCClass(ObjCRuntime.object_getClass(self));
-                    ObjCObject obj = ObjCObject.toObjCObject(cls.getType(), self, 0);
+                    ObjCObject obj = ObjCObject.getPeerObject(self);
+                    if (obj == null) {
+                        ObjCClass cls = ObjCClass.toObjCClass(ObjCRuntime.object_getClass(self));
+                        obj = ObjCObject.toObjCObject(cls.getType(), self, 0);
+                    }
                     CUSTOM_OBJECTS.put(self, obj);
                 }
             }

--- a/compiler/objc/src/main/java/org/robovm/objc/ObjCObject.java
+++ b/compiler/objc/src/main/java/org/robovm/objc/ObjCObject.java
@@ -48,7 +48,7 @@ import org.robovm.rt.bro.ptr.VoidPtr;
     @Marshaler(ObjCClass.Marshaler.class)
 })
 public abstract class ObjCObject extends NativeObject {
-    
+
     private static volatile boolean logRetainRelease = false;
 
     public static class ObjCObjectPtr extends Ptr<ObjCObject, ObjCObjectPtr> {}
@@ -176,6 +176,18 @@ public abstract class ObjCObject extends NativeObject {
             return o;
         }
     }
+
+    /**
+     * this notification callback from <init> callback for custom object.
+     * It is called to save corresponding java part in ObjectOwnershipHelper
+     * as it is the only place that keeps custom object from GC while native part is
+     * retained
+     * @param handle of native object
+     */
+    protected static void retainCustomObjectFromCb(long handle) {
+        ObjectOwnershipHelper.retainObject(handle);
+    }
+
 
     private static void setPeerObject(long handle, ObjCObject o) {
         synchronized (objcBridgeLock) {
@@ -388,7 +400,7 @@ public abstract class ObjCObject extends NativeObject {
 
     static class ObjectOwnershipHelper {
         private static final LongMap<Object> CUSTOM_OBJECTS = new LongMap<>();
-        
+
         private static final long retainCount = Selector.register("retainCount").getHandle();
         private static final long retain = Selector.register("retain").getHandle();
         private static final long originalRetain = Selector.register("original_retain").getHandle();
@@ -444,19 +456,25 @@ public abstract class ObjCObject extends NativeObject {
             }
         }
 
+        /**
+         * instead of tracking object in retain callback following direct api is used.
+         * as with retain there are known issues that retain could be called inside dealoc cycle
+         * which will cause hard to handle side effects
+         * @param self pointer from native part
+         */
+        public static void retainObject(long self) {
+            synchronized (CUSTOM_OBJECTS) {
+                ObjCObject obj = ObjCObject.getPeerObject(self);
+                CUSTOM_OBJECTS.put(self, obj);
+            }
+        }
+
         @Callback
         private static @Pointer long retain(@Pointer long self, @Pointer long sel) {
+            // TODO: this method is being kept here only for logRetainRelease
+            // but these functionality is not useful anymore due creation of custom
+            // objects in cb<init>
             int count = ObjCRuntime.int_objc_msgSend(self, retainCount);
-            if (count <= 1) {
-                synchronized (CUSTOM_OBJECTS) {
-                    ObjCObject obj = ObjCObject.getPeerObject(self);
-                    if (obj == null) {
-                        ObjCClass cls = ObjCClass.toObjCClass(ObjCRuntime.object_getClass(self));
-                        obj = ObjCObject.toObjCObject(cls.getType(), self, 0);
-                    }
-                    CUSTOM_OBJECTS.put(self, obj);
-                }
-            }
             long cls = ObjCRuntime.object_getClass(self);
             if (logRetainRelease) {
                 logRetainRelease(cls, self, count, true);
@@ -467,9 +485,16 @@ public abstract class ObjCObject extends NativeObject {
 
         @Callback
         private static void release(@Pointer long self, @Pointer long sel) {
+            // this callback is required to remove reference to java counterpart once
+            // native part is being released. dealloc can't be used for purpose
+            // as there is direct retain in afterMarshaled for custom objects
             int count = ObjCRuntime.int_objc_msgSend(self, retainCount);
             if (count <= 2) {
                 synchronized (CUSTOM_OBJECTS) {
+                    // at this moment there is no reference kept for java object
+                    // and it is subject for GC if not being referenced anywhere
+                    // once GC comes it will cause release() to be called in dispose
+                    // which will also release native part
                     CUSTOM_OBJECTS.remove(self);
                 }
             }

--- a/compiler/objc/src/main/java/org/robovm/objc/annotation/Method.java
+++ b/compiler/objc/src/main/java/org/robovm/objc/annotation/Method.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
  * method is a member of a class it must have the <code>native</code> modifier.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 public @interface Method {
     /**
      * The name of the Objective-C selector this method binds to. If not


### PR DESCRIPTION
Hallo, 
short what changed list 
1. issues was fixed as per discussion and changed the way CustomObjects are initiated by NativePart (e.g. when loading from xib/storyboards) 
2. UIKit and Foundation frameworks re-generated to attach @Method annotations to constructors
3. Core* frameworks were processed to support ios10 (as all frameworks were at ios8 level) 

NP: some API was changed due ios10 migration: due conflicts with ios9 API + some old depeicated code (like deprecated in ios6) were removed by bro-script, so I didn't mine for such removals 

all other frameworks are pending for re-generation: need to attach @Method annotations and also to include missing ios10 support (as they stuck on ios8 version) -- but generation/fixing bro script/checking-merging result is quite time consuming and produce huge diff so I will do it as part2 PR

bro-gen with fixes is there, there no PR to @CoderBaron  as it produces @Method annotation for constructors and is not compatible with stable 2.3 version
https://github.com/dkimitsa/robovm-bro-gen