### PR TITLE
implemented @IBOutlet/@IBOutletCollection on class fields

### DIFF
--- a/compiler/objc/src/main/java/org/robovm/objc/annotation/IBOutlet.java
+++ b/compiler/objc/src/main/java/org/robovm/objc/annotation/IBOutlet.java
@@ -38,7 +38,7 @@ import org.robovm.objc.ObjCObject;
  * "set".
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.METHOD })
+@Target({ ElementType.METHOD, ElementType.FIELD})
 public @interface IBOutlet {
     /**
      * The name of the Objective-C selector this outlet binds to. If not


### PR DESCRIPTION
functionality was in original 1.14 and useful for UIKit app. Allow to attach annotation to field instead of implementing a setter. 
Actually proposed change will generate setter for fields tagged with @IBOutlet/@IBOutletCollection