### PR TITLE
removed resource rules 

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -419,7 +419,7 @@ public class IOSTarget extends AbstractTarget {
             args.add(entitlementsPList);
         }
         if (preserveMetadata) {
-            args.add("--preserve-metadata=identifier,entitlements,resource-rules");
+            args.add("--preserve-metadata=identifier,entitlements");
         }
         if (verbose) {
             args.add("--verbose");


### PR DESCRIPTION
as it causes “invalid resource directory (directory or signature have been modified)” error on frameworks with resources signed

More over it is deprecated since Xcode7 and should not be used
https://developer.apple.com/library/content/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG206