### PR TITLE
Exposing dump-intermediates builder option to gradle plugin config

### DIFF
--- a/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMPluginExtension.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/RoboVMPluginExtension.java
@@ -45,6 +45,7 @@ public class RoboVMPluginExtension {
     private String cacheDir;
     private String keychainPassword;
     private String keychainPasswordFile;
+    private boolean dumpIntermediates = false;
 
     public RoboVMPluginExtension(Project project) {
         this.project = project;
@@ -242,4 +243,12 @@ public class RoboVMPluginExtension {
     public void setKeychainPasswordFile(String keychainPasswordFile) {
         this.keychainPasswordFile = keychainPasswordFile;
     }
+
+	public boolean isDumpIntermediates() {
+		return dumpIntermediates;
+	}
+
+	public void setDumpIntermediates(boolean dumpIntermediates) {
+		this.dumpIntermediates = dumpIntermediates;
+	}
 }

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMBuildTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/AbstractRoboVMBuildTask.java
@@ -44,6 +44,8 @@ public abstract class AbstractRoboVMBuildTask extends AbstractRoboVMTask {
                 }
                 builder.archs(archs);
             }
+            
+            builder.dumpIntermediates(extension.isDumpIntermediates());
 
             AppCompiler compiler = new AppCompiler(builder.build());
             compiler.build();


### PR DESCRIPTION
Looking into an issue with our robovm build, thought the -dump-intermediates command line option would be useful in the gradle plugin configuration.

This commit adds the ability to configure that existing flag in the gradle robovm configuration like so:

```
robovm {
   dumpIntermediates = true
}
```

This defaults to false like the existing default in the config builder.