### PR TITLE
Fixing #127 <stripArchives> config ignored

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -905,7 +905,15 @@ public class Config {
         osArchCacheDir.mkdirs();
 
         this.clazzes = new Clazzes(this, realBootclasspath, classpath);
-		  this.stripArchivesConfig = stripArchivesBuilder == null ? StripArchivesConfig.DEFAULT : stripArchivesBuilder.build();
+        
+        if(this.stripArchivesConfig == null) {
+            if(stripArchivesBuilder == null) {
+                this.stripArchivesConfig = StripArchivesConfig.DEFAULT;
+            }
+            else {
+                this.stripArchivesConfig = stripArchivesBuilder.build();
+            }
+        }
 
         mergeConfigsFromClasspath();
 


### PR DESCRIPTION
`stripArchivesConfig` should not be overwritten by the default config if it is configured via robovm.xml.