### PR TITLE
Add the "framework" compiler target (issue #132)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@
 .idea/
 .DS_Store
 dependency-reduced-pom.xml
-target/
+
+# Commented out because it prevents compiler/compiler/src/main/java/org/robovm/compiler/target/** commits
+#target/

--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -75,6 +75,7 @@ import org.robovm.compiler.plugin.objc.ObjCMemberPlugin;
 import org.robovm.compiler.plugin.objc.ObjCProtocolProxyPlugin;
 import org.robovm.compiler.target.ConsoleTarget;
 import org.robovm.compiler.target.Target;
+import org.robovm.compiler.target.framework.FrameworkTarget;
 import org.robovm.compiler.target.ios.IOSTarget;
 import org.robovm.compiler.target.ios.ProvisioningProfile;
 import org.robovm.compiler.target.ios.SigningIdentity;
@@ -850,6 +851,8 @@ public class Config {
                 target = new ConsoleTarget();
             } else if (IOSTarget.TYPE.equals(targetType)) {
                 target = new IOSTarget();
+            } else if (FrameworkTarget.TYPE.equals(targetType)) {
+                target = new FrameworkTarget();
             } else {
                 for (TargetPlugin plugin : getTargetPlugins()) {
                     if (plugin.getTarget().getType().equals(targetType)) {

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/framework/FrameworkTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/framework/FrameworkTarget.java
@@ -1,0 +1,217 @@
+package org.robovm.compiler.target.framework;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.robovm.compiler.clazz.Path;
+import org.robovm.compiler.config.Arch;
+import org.robovm.compiler.config.Config;
+import org.robovm.compiler.config.OS;
+import org.robovm.compiler.log.Logger;
+import org.robovm.compiler.log.LoggerProxy;
+import org.robovm.compiler.target.AbstractTarget;
+import org.robovm.compiler.target.ios.SDK;
+import org.robovm.compiler.util.Executor;
+
+import com.dd.plist.NSDictionary;
+import com.dd.plist.NSObject;
+import com.dd.plist.PropertyListParser;
+
+public class FrameworkTarget extends AbstractTarget {
+
+	public static final String TYPE = "framework";
+
+    private OS os;
+    private Arch arch;
+    private SDK sdk;
+
+    public FrameworkTarget() {
+	}
+
+	@Override
+	public String getType() {
+		return TYPE;
+	}
+
+	@Override
+	public OS getOs() {
+		return os;
+	}
+
+	@Override
+	public Arch getArch() {
+		return arch;
+	}
+
+    @Override
+	public boolean canLaunch() {
+		return false;
+	}
+
+	public static boolean isSimulatorArch(Arch arch) {
+        return arch == Arch.x86 || arch == Arch.x86_64;
+    }
+
+    public static boolean isDeviceArch(Arch arch) {
+        return arch == Arch.thumbv7 || arch == Arch.arm64;
+    }
+
+
+    public List<SDK> getSDKs() {
+        if (isSimulatorArch(arch)) {
+            return SDK.listSimulatorSDKs();
+        } else {
+            return SDK.listDeviceSDKs();
+        }
+    }
+
+	public void init(Config paramConfig) {
+		super.init(paramConfig);
+
+		os = config.getOs();
+        if (os == null)
+            os = OS.getDefaultOS();
+
+        arch = config.getArch();
+        if (arch == null)
+            arch = Arch.getDefaultArch();
+
+		if (os.getFamily() != OS.Family.darwin)
+			throw new IllegalArgumentException("Frameworks can only be built for Darwin platforms");
+		
+		if (paramConfig.getInfoPList() == null)
+			throw new IllegalArgumentException("Frameworks must have a Info.plist file");
+		paramConfig.getIosInfoPList().parse(paramConfig.getProperties());
+		
+		String sdkVersion = config.getIosSdkVersion();
+        
+		List<SDK> sdks = getSDKs();
+        if (sdkVersion == null) {
+            if (sdks.isEmpty()) {
+                throw new IllegalArgumentException("No " + (isDeviceArch(arch) ? "device" : "simulator")
+                        + " SDKs installed");
+            }
+            Collections.sort(sdks);
+            this.sdk = sdks.get(sdks.size() - 1);
+        }
+        else {
+            for (SDK sdk : sdks) {
+                if (sdk.getVersion().equals(sdkVersion)) {
+                    this.sdk = sdk;
+                    break;
+                }
+            }
+            if (sdk == null) {
+                throw new IllegalArgumentException("No SDK found matching version string " + sdkVersion);
+            }
+        }		
+	}
+
+	@Override
+	public String getInstallRelativeArchivePath(Path path) {
+		return config.getImageName() + ".bundle/Resources/" + super.getInstallRelativeArchivePath(path);
+	}
+
+	@Override
+	protected List<String> getTargetExportedSymbols() {
+		return Arrays.asList(new String[] { "JNI_*" });
+	}
+	
+	private String getMinimumOSVersion() {
+		NSObject minimumOSVersion = config.getInfoPList().getDictionary().objectForKey("MinimumOSVersion");
+		if (minimumOSVersion != null)
+			return minimumOSVersion.toString();
+		return "8.0";
+	}
+
+	@Override
+	protected List<String> getTargetCcArgs() {
+		List<String> ccArgs = new ArrayList<String>();
+		
+		ccArgs.add("-stdlib=libc++");
+		
+		if (isDeviceArch(arch))
+			ccArgs.add("-miphoneos-version-min=" + getMinimumOSVersion());
+		else
+			ccArgs.add("-mios-simulator-version-min=" + getMinimumOSVersion());
+		
+		ccArgs.add("-isysroot");
+		ccArgs.add(sdk.getRoot().getAbsolutePath());
+		
+		ccArgs.add("-dynamiclib");
+		ccArgs.add("-single_module");
+		ccArgs.add("-compatibility_version");
+		ccArgs.add("1");
+		ccArgs.add("-current_version");
+		ccArgs.add("1");
+		
+		if (this.config.getArch() == Arch.x86) {
+			ccArgs.add("-read_only_relocs");
+			ccArgs.add("suppress");
+		}
+		
+		ccArgs.add("-install_name");
+		ccArgs.add(String.format("@rpath/%s.framework/%s", config.getImageName(), config.getImageName()));
+
+		return ccArgs;
+	}
+
+	@Override
+	protected void doInstall(File installDir, String image, File resourcesDir) throws IOException {
+		File frameworkDir = new File(installDir, image + ".framework");
+		
+		config.getLogger().info("Creating framework: %s", frameworkDir);
+		
+		if (frameworkDir.exists())
+			FileUtils.deleteDirectory(frameworkDir);
+		frameworkDir.mkdirs();
+		
+		File bundleDir = new File(frameworkDir, image + ".bundle");
+		bundleDir.mkdirs();
+		
+		File bundleResourcesDir = new File(bundleDir, "Resources");
+		bundleResourcesDir.mkdirs();
+				
+		super.doInstall(frameworkDir, image, bundleResourcesDir);
+		
+		File frameworkBinaryFile = new File(frameworkDir, image);
+		File dsymDir = new File(installDir, image + ".dSYM");
+		
+		config.getLogger().info("Creating framework symbol directory: %s", dsymDir);
+		if (dsymDir.exists())
+			FileUtils.deleteDirectory(dsymDir);
+		dsymDir.mkdirs();
+		new Executor(new FilterDSYMWarningsLogger(config.getLogger()), "xcrun").args("dsymutil", "-o", dsymDir, frameworkBinaryFile).exec();
+		
+		if (!config.isDebug()) {
+			config.getLogger().info("Striping framework binary: %s", frameworkBinaryFile);
+			new Executor(config.getLogger(), "xcrun").args("strip", "-x", frameworkBinaryFile).exec();
+		}
+		
+		NSDictionary infoPlist = config.getInfoPList().getDictionary();
+		if (infoPlist.objectForKey("MinimumOSVersion") == null)
+			infoPlist.put("MinimumOSVersion", "8.0");
+		
+		File infoPlistBin = new File(frameworkDir, "Info.plist");
+		config.getLogger().info("Installing Info.plist to: %s", infoPlistBin);
+		PropertyListParser.saveAsBinary(infoPlist, infoPlistBin);
+	}
+	
+	private static class FilterDSYMWarningsLogger extends LoggerProxy {
+
+		public FilterDSYMWarningsLogger(Logger target) {
+			super(target);
+		}
+
+		@Override
+		public void warn(String format, Object... args) {
+			if (!(format.startsWith("warning:") && format.contains("could not find object file symbol for symbol"))) 
+				super.warn(format, args);
+		}
+	}
+}


### PR DESCRIPTION
Hello,

Here is a pull request for the "framework" compiler target (i.e. `<target>framework</target >` in robovm.xml). It replicates the original commercial RoboVM feature, with the following differences:

- It uses libc++ instead of the deprecated libstdc++.
- The structure of the framework doesn't have a root Resources directory anymore: the Resources directory is now under a MyFrameworkName.bundle directory, as it should be according to the new Apple policy.
- Only the iOS OS is supported (i.e. `<os>ios</ios>` in robovm.xml).
- It is not a plugin but a core feature of the compiler (see Config.java).

Known issues (**help wanted!**):

- The Java VM created in init.m (see sample initialization code in [init.m](https://github.com/robovm/robovm-samples/blob/master/AnswerMe/sdk/src/main/native/init.m)) starts with a wrong classpath because it looks for jars in `MyFrameworkName.framework/Resources/MyFrameworkName.bundle/Resources` instead of `MyFrameworkName.framework/MyFrameworkName.bundle/Resources`. As a workaround, one can use this JNI option:
`[NSString stringWithFormat: @"-rvm:ResourcesPath=%@/Frameworks/MyFrameworkName.framework", [[NSBundle mainBundle] resourcePath]]`
Where is initialized the VM classpath and how can I fix this faulty default classpath in the case of frameworks?
- The AnswerMe sample doesn't work anymore as is because of the above Resources path issue and because, for some strange reason, `Retrofit.Builder().baseUrl("http://api.duckduckgo.com")` throws an exception ([HttpUrl](https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/HttpUrl.java).Builder.host(String) throws an IllegalArgumentException whatever host you pass, unless it is an IPV6 address, as it was already reported [here](https://gitter.im/MobiDevelop/robovm/archives/2016/07/19) by @omainegra).
- My framework makes intensive use of Runnable/VoidBlock(n) as callbacks (closures in my Swift code). It works fine unless the blocks are called asynchronously, which ends up with a bad access error. This issue was first reported as [#1109](https://github.com/robovm/robovm/issues/1109) in the original RoboVM project and fixed in 1.11. I can use the workaround found by @alexitelman, but using blocks would be much more convenient... Can any of you fix this issue in this fork?

Note: this PR fixes the previous one (136) which was conflicting with another commit...

Thanks,
Franck.