### PR TITLE
Added the ability to select one of several USB-connected physical dev…

### DIFF
--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -69,6 +69,7 @@ The simulator launcher properties can be set by project properties via `gradle.p
  * iPad-Pro
  * iPad-Retina
  * Apple-TV-1080p
+* `robovm.device.udid`: Select one of several USB-connected physical devices by UDID to run your app on.
 * `robovm.sdk.version`: Set the sdk version property.
 
 The arch can be specified using the `gradle.properties` or `-P` command line parameter. To launch on the simulator in 64-bit mode use:
@@ -83,6 +84,12 @@ To launch on device in 64-bit mode:
 
 ```
 gradle -Probovm.arch=arm64 launchIOSDevice
+```
+
+To launch on a device with a given UDID in 64-bit mode:
+
+```
+gradle -Probovm.arch=arm64 -Probovm.device.udid=eecfc85775e44c5b3061dc3571c848e4cfc3221a launchIOSDevice
 ```
 
 The `robovmArchive` task will by default include the archs listed in the `robovm.xml` file in the archive. Use the `robovm.archs` property to specify the archs to include in the archive:

--- a/plugins/gradle/src/main/java/org/robovm/gradle/tasks/IOSDeviceTask.java
+++ b/plugins/gradle/src/main/java/org/robovm/gradle/tasks/IOSDeviceTask.java
@@ -22,6 +22,7 @@ import org.robovm.compiler.config.Config;
 import org.robovm.compiler.config.OS;
 import org.robovm.compiler.target.LaunchParameters;
 import org.robovm.compiler.target.ios.IOSTarget;
+import org.robovm.compiler.target.ios.IOSDeviceLaunchParameters;
 
 /**
  *
@@ -42,7 +43,11 @@ public class IOSDeviceTask extends AbstractRoboVMTask {
                 return;
             }
             Config config = compiler.getConfig();
-            LaunchParameters launchParameters = config.getTarget().createLaunchParameters();
+            IOSDeviceLaunchParameters launchParameters = (IOSDeviceLaunchParameters) config.getTarget().createLaunchParameters();
+			String udid = (String) project.getProperties().get("robovm.device.udid");	
+			if(udid != null && !udid.isEmpty()){
+				launchParameters.setDeviceId(udid);
+			}
             compiler.launch(launchParameters);
         } catch (Throwable t) {
             throw new GradleException("Failed to launch IOS Device", t);


### PR DESCRIPTION
When working with several devices being connected via USB, the gradle plugin did not offer a possibility to select one of them. I have added the robovm.device.udid project property which enables selecting a device by its UDID.