### PR TITLE
Fix issue #140

### DIFF
--- a/compiler/objc/src/main/java/org/robovm/objc/ObjCBlock.java
+++ b/compiler/objc/src/main/java/org/robovm/objc/ObjCBlock.java
@@ -80,6 +80,10 @@ public final class ObjCBlock extends Struct<ObjCBlock> {
     
     @StructMember(6)
     public native ObjCBlock wrapper_addr(@Pointer long wrapper_addr);
+
+    public static void setHandle(ObjCBlock block, long handle) {
+        block.setHandle(handle);
+    }
     
     public Object object() {
         return VM.castAddressToObject(object_addr());

--- a/compiler/objc/src/main/java/org/robovm/objc/RunnableAsObjCBlockMarshaler.java
+++ b/compiler/objc/src/main/java/org/robovm/objc/RunnableAsObjCBlockMarshaler.java
@@ -31,6 +31,9 @@ import org.robovm.rt.bro.annotation.Pointer;
  */
 public class RunnableAsObjCBlockMarshaler implements Runnable {
 
+    private static final Selector COPY_SELECTOR = Selector.register("copy");
+    private static final Selector RELEASE_SELECTOR = Selector.register("release");
+
     private static ObjCBlock.Wrapper WRAPPER = 
             new ObjCBlock.Wrapper(RunnableAsObjCBlockMarshaler.class);
     
@@ -49,6 +52,8 @@ public class RunnableAsObjCBlockMarshaler implements Runnable {
         if (block.hasObject()) {
             return (Runnable) block.object();
         }
+        handle = ObjCRuntime.ptr_objc_msgSend(handle, COPY_SELECTOR.getHandle());
+        ObjCBlock.setHandle(block, handle);
         return new RunnableAsObjCBlockMarshaler(block);
     }
     
@@ -127,5 +132,10 @@ public class RunnableAsObjCBlockMarshaler implements Runnable {
     @Callback
     private static void invoked(ObjCBlock block) {
         ((Runnable) block.object()).run();
+    }
+    
+    @Override
+    protected void finalize() throws Throwable {
+        ObjCRuntime.void_objc_msgSend(this.objCBlock.getHandle(), RELEASE_SELECTOR.getHandle());
     }
 }


### PR DESCRIPTION
Hi,

This PR fixes the issue #140: Application crashes with a bad access error when runnables or void blocks (Swift closures or Obj-c function pointers) are called from a background Java thread (e.g. a libgdx OpenGL thread). This issue was first reported as #1109 in the original RoboVM project and fixed in version 1.11.

Thanks.