### PR TITLE
IDEA -- fixed extra rebuild of all classes after idea restart

### DIFF
--- a/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/RoboVmPlugin.java
@@ -422,8 +422,14 @@ public class RoboVmPlugin {
                     try {
                         out = new FileOutputStream(f);
                         IOUtils.copy(in, out);
-                    } finally {
                         IOUtils.closeQuietly(out);
+                        out = null;
+                        // set last modification time stamp as it was inside tar otherwise
+                        // robovm will see new time stamp and will rebuild all classes that were inside jar
+                        f.setLastModified(entry.getLastModifiedDate().getTime());
+                    } finally {
+                        if (out != null)
+                            IOUtils.closeQuietly(out);
                     }
                 }
             }


### PR DESCRIPTION
in case of snapshot build idea unpacks all jars every time. and they were receiving new time stamp which caused every class in project to be rebuild. 
changes done to save time stamp of file as it was in tar file. 